### PR TITLE
Remove custom archive-timeout

### DIFF
--- a/kubernetes/main/apps/database/crunchy-postgres/cluster/cluster.yaml
+++ b/kubernetes/main/apps/database/crunchy-postgres/cluster/cluster.yaml
@@ -104,7 +104,6 @@ spec:
             name: crunchy-pgo-secret
       global: &backupFlag
         # Minio
-        archive-timeout: "60"
         compress-type: bz2
         compress-level: "9"
         repo1-block: y


### PR DESCRIPTION
Allows archiving to happen at the default interval of 5 minutes