### PR TITLE
feat(llm): enable speculative decoding with Gemma 4 E2B draft model

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/Gemma4-26B-A4B/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/Gemma4-26B-A4B/helmrelease.yaml
@@ -26,19 +26,30 @@ spec:
               - |
                 set -euo pipefail
 
-                if [ ! -s /models/gemma4-26b/gemma-4-26B-A4B-it-UD-Q5_K_XL.gguf ] || [ ! -s /models/gemma4-26b/mmproj-F16.gguf ]; then
+                # Download main model if missing
+                if [ ! -s /models/gemma4-26b/gemma-4-26B-A4B-it-UD-Q5_K_XL.gguf ]; then
                   pip install --no-cache-dir huggingface_hub
                   mkdir -p /models/gemma4-26b
                   rm -rf /models/gemma4-26b/.cache/huggingface/download/gemma-4-26B-A4B-UD-Q5_K_XL.gguf.lock
                   hf download \
                     unsloth/gemma-4-26B-A4B-it-GGUF \
                     gemma-4-26B-A4B-it-UD-Q5_K_XL.gguf \
-                    mmproj-F16.gguf \
                     --local-dir /models/gemma4-26b
-
                   echo "Gemma-4-26B-A4B-Q5_K_XL download complete"
                 else
                   echo "Gemma-4-26B-A4B-Q5_K_XL already downloaded, skipping"
+                fi
+
+                # Download E2B draft model for speculative decoding
+                if [ ! -s /models/gemma4-26b/gemma-4-E2B-it-UD-Q4_K_XL.gguf ]; then
+                  pip install --no-cache-dir huggingface_hub
+                  hf download \
+                    unsloth/gemma-4-E2B-it-GGUF \
+                    gemma-4-E2B-it-UD-Q4_K_XL.gguf \
+                    --local-dir /models/gemma4-26b
+                  echo "Gemma-4-E2B-Q4_K_XL draft model download complete"
+                else
+                  echo "Gemma-4-E2B-Q4_K_XL draft model already downloaded, skipping"
                 fi
             env:
               HF_HUB_ENABLE_HF_TRANSFER: "1"
@@ -69,16 +80,14 @@ spec:
               - self-hosted
               - --model
               - /models/gemma4-26b/gemma-4-26B-A4B-it-UD-Q5_K_XL.gguf
-              - --mmproj
-              - /models/gemma4-26b/mmproj-F16.gguf
               - --ctx-size
-              - "150000"
+              - "262144"
               - --n-gpu-layers
               - "29"
               - --flash-attn
               - "on"
               - --parallel
-              - "5"
+              - "1"
               - --cont-batching
               - -sps
               - "0.90"
@@ -89,10 +98,6 @@ spec:
               - "4"
               - --checkpoint-every-n-tokens
               - "16384"
-              - --image-min-tokens
-              - "1120"
-              - --image-max-tokens
-              - "1120"
               - --temp
               - "1.0"
               - --top-p
@@ -111,6 +116,15 @@ spec:
               - "16"
               - --no-mmap
               - --jinja
+              # Speculative decoding - Gemma 4 E2B draft model
+              - --model-draft
+              - /models/gemma4-26b/gemma-4-E2B-it-UD-Q4_K_XL.gguf
+              - --n-gpu-layers-draft
+              - "99"
+              - --draft-max
+              - "8"
+              - --draft-min
+              - "1"
             resources:
               requests:
                 cpu: 1


### PR DESCRIPTION
## Summary

Enable speculative decoding on the Gemma 4 26B llama-server to improve inference throughput, based on [Reddit benchmarks](https://www.reddit.com/r/LocalLLaMA/comments/1sjct6a/speculative_decoding_works_great_for_gemma_4_31b/) showing +29% average speedup and +50% on code generation with 52.2% average acceptance rate.

## Changes

### Removed (vision)
- `--mmproj /models/gemma4-26b/mmproj-F16.gguf`
- `--image-min-tokens 1120`
- `--image-max-tokens 1120`

Note: Vision is handled separately by `llama-vision` deployment.

### Modified
| Flag | Before | After | Reason |
|------|--------|-------|--------|
| `--ctx-size` | 150000 | 262144 | Model max context |
| `--parallel` | 5 | 1 | Mandatory for speculative decoding draft KV cache |

### Added (speculative decoding)
| Flag | Value | Notes |
|------|-------|-------|
| `--model-draft` | `/models/gemma4-26b/gemma-4-E2B-it-UD-Q4_K_XL.gguf` | Draft model |
| `--n-gpu-layers-draft` | 99 | Full GPU offload for draft |
| `--draft-max` | 8 | Max draft tokens |
| `--draft-min` | 1 | Min draft tokens |

### Init container update
Added E2B draft model download:
```bash
hf download unsloth/gemma-4-E2B-it-GGUF gemma-4-E2B-it-UD-Q4_K_XL.gguf --local-dir /models/gemma4-26b
```

## Verification

After deployment, watch for:
- `/health` endpoint responding
- Log message confirming E2B draft model loaded
- Token throughput improvement on actual queries

Check for token vocab compatibility warning in logs - if present, re-download the 26B GGUF from unsloth.

## Notes

- `--parallel 1` is mandatory per upstream llama.cpp - with auto (=4), draft KV cache is allocated 4x and tanks performance to 7 t/s
- Q4 draft is fine - Q8 (4.8GB) doesn't improve speed over Q4 (3.0GB)
- Extra VRAM ~2.3GB with Q4 draft + 128K context