### PR TITLE
feat(llm): swap speculative draft model to Gemma 4 E4B

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/Gemma4-26B-A4B/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/Gemma4-26B-A4B/helmrelease.yaml
@@ -40,16 +40,16 @@ spec:
                   echo "Gemma-4-26B-A4B-Q5_K_XL already downloaded, skipping"
                 fi
 
-                # Download E2B draft model for speculative decoding
-                if [ ! -s /models/gemma4-26b/gemma-4-E2B-it-UD-Q4_K_XL.gguf ]; then
+                # Download E4B draft model for speculative decoding
+                if [ ! -s /models/gemma4-26b/gemma-4-E4B-it-UD-Q4_K_XL.gguf ]; then
                   pip install --no-cache-dir huggingface_hub
                   hf download \
-                    unsloth/gemma-4-E2B-it-GGUF \
-                    gemma-4-E2B-it-UD-Q4_K_XL.gguf \
+                    unsloth/gemma-4-E4B-it-GGUF \
+                    gemma-4-E4B-it-UD-Q4_K_XL.gguf \
                     --local-dir /models/gemma4-26b
-                  echo "Gemma-4-E2B-Q4_K_XL draft model download complete"
+                  echo "Gemma-4-E4B-Q4_K_XL draft model download complete"
                 else
-                  echo "Gemma-4-E2B-Q4_K_XL draft model already downloaded, skipping"
+                  echo "Gemma-4-E4B-Q4_K_XL draft model already downloaded, skipping"
                 fi
             env:
               HF_HUB_ENABLE_HF_TRANSFER: "1"
@@ -116,9 +116,9 @@ spec:
               - "16"
               - --no-mmap
               - --jinja
-              # Speculative decoding - Gemma 4 E2B draft model
+              # Speculative decoding - Gemma 4 E4B draft model
               - --model-draft
-              - /models/gemma4-26b/gemma-4-E2B-it-UD-Q4_K_XL.gguf
+              - /models/gemma4-26b/gemma-4-E4B-it-UD-Q4_K_XL.gguf
               - --n-gpu-layers-draft
               - "99"
               - --draft-max


### PR DESCRIPTION
## Summary
- swap the speculative draft model from Gemma 4 E2B to Gemma 4 E4B
- update the init container to download the E4B Q4_K_XL GGUF artifact
- keep the existing speculative decoding settings unchanged for an apples-to-apples draft model test

## Why
- benchmark artifacts are saved locally for the E2B rollout comparison
- this PR isolates the draft model swap so we can measure TTFT and throughput impact cleanly

## Notes
- benchmark artifacts verified locally:
  - /home/node/.openclaw/workspace-saffron/benchmarks/baseline-before.tokens.jsonl
  - /home/node/.openclaw/workspace-saffron/benchmarks/baseline-after.tokens.jsonl
- exact Hugging Face artifact used here: unsloth/gemma-4-E4B-it-GGUF -> gemma-4-E4B-it-UD-Q4_K_XL.gguf
