### PR TITLE
feat(llm): revert speculative decoding to parallel 1

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/Gemma4-26B-A4B/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/Gemma4-26B-A4B/helmrelease.yaml
@@ -87,7 +87,7 @@ spec:
               - --flash-attn
               - "on"
               - --parallel
-              - "2"
+              - "1"
               - --cont-batching
               - -sps
               - "0.90"


### PR DESCRIPTION
Reverts --parallel from 2 back to 1.

Benchmark confirmed parallel 2 significantly degrades performance:
- Parallel 2: 6.99 t/s, 55.86s latency, 5.59s TTFT
- Parallel 1: 27.72 t/s, 11.81s latency, 1.18s TTFT

E2B draft model with parallel 1 remains the optimal configuration.