### PR TITLE
feat(llm): expand llama-vision for PR review

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/llama-vision/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/llama-vision/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
               - --mmproj
               - /models/qwen-vision/mmproj-F16.gguf
               - --ctx-size
-              - "30000"
+              - "100000"
               - --n-gpu-layers
               - "99"
               - --fit
@@ -82,7 +82,7 @@ spec:
               - --flash-attn
               - "on"
               - --parallel
-              - "3"
+              - "4"
               - --cont-batching
               - -sps
               - "0.90"


### PR DESCRIPTION
Expands llama-vision to handle PR review workload alongside existing vision tasks.

Changes:
- ctx-size: 30K → 100K (handle larger PR diffs without truncation)
- parallel: 3 → 4 (modest concurrency increase, watch for stability)

Model stays Qwen3.5-9B-heretic (Q5_K_M). Vision support preserved via --mmproj.