### PR TITLE
feat(ci): use llama-vision for AI PR reviewer

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -30,7 +30,7 @@ jobs:
       REPO: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      AI_BASE_URL: ${{ vars.AI_BASE_URL || 'http://llama-server.llm:8080/v1' }}
+      AI_BASE_URL: ${{ vars.AI_BASE_URL || 'http://10.69.10.23:8080/v1' }}
       AI_MODEL: ${{ vars.AI_MODEL || 'self-hosted' }}
       AI_PRIMARY_RETRIES: ${{ vars.AI_PRIMARY_RETRIES || '8' }}
       AI_PRIMARY_RETRY_DELAY_SEC: ${{ vars.AI_PRIMARY_RETRY_DELAY_SEC || '15' }}

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -30,7 +30,7 @@ jobs:
       REPO: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      AI_BASE_URL: ${{ vars.AI_BASE_URL || 'http://10.69.10.23:8080/v1' }}
+      AI_BASE_URL: ${{ vars.AI_BASE_URL || 'http://llama-vision.llm:8080/v1' }}
       AI_MODEL: ${{ vars.AI_MODEL || 'self-hosted' }}
       AI_PRIMARY_RETRIES: ${{ vars.AI_PRIMARY_RETRIES || '8' }}
       AI_PRIMARY_RETRY_DELAY_SEC: ${{ vars.AI_PRIMARY_RETRY_DELAY_SEC || '15' }}


### PR DESCRIPTION
Updates ai-review.yaml to point to llama-vision (10.69.10.23) instead of llama-server for PR review workload.

Llama-vision runs Qwen3.5-9B-heretic with expanded ctx-size (100K) and parallel 4, better suited for PR review tasks.