### PR TITLE
fix(llm): set llama-vision KV cache K and V to q8_0

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/llama-vision/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/llama-vision/helmrelease.yaml
@@ -89,6 +89,10 @@ spec:
               - --no-context-shift
               - --cache-prompt
               - --kv-unified
+              - --cache-type-k
+              - q8_0
+              - --cache-type-v
+              - q8_0
               - --ctx-checkpoints
               - "4"
               - --checkpoint-every-n-tokens


### PR DESCRIPTION
Sets --cache-type-k q8_0 and --cache-type-v q8_0 to quantize both key and value caches.