### PR TITLE
fix(openclaw): add missing native commands to plugins.allow

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
@@ -442,6 +442,7 @@ spec:
                 "composio",
                 "openclaw-mcp-bridge",
                 "searxng",
+                "config.schema.lookup",
               ],
               entries: {
                 discord: { enabled: true },


### PR DESCRIPTION
## Summary

The `openclaw config.schema.lookup` command was blocked by `plugins.allow` after a recent OpenClaw update tightened defaults. This PR adds `config.schema.lookup` to the allowlist.

## Change

Added only `config.schema.lookup` to `plugins.allow` in the `openclaw-config` ExternalSecret.

## Validation

The error message explicitly instructs to add `"config.schema.lookup"` to `plugins.allow`:

> The `openclaw config.schema.lookup` command is unavailable because `plugins.allow` excludes "config.schema.lookup". Add "config.schema.lookup" to `plugins.allow` if you want that bundled plugin CLI surface.

## Note

Other command names (`help`, `commands.list`) were NOT included because they could not be explicitly confirmed as blocked in `plugins.allow`. Only `config.schema.lookup` is validated.