### PR TITLE
chore: add self-hosted runners for windowstead CI

### DIFF
--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners/kustomization.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./windowstead-helmrelease.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners/windowstead-helmrelease.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners/windowstead-helmrelease.yaml
@@ -1,0 +1,55 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name windowstead-runner-${CLUSTER}
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gha-runner-scale-set
+  dependsOn: []
+  interval: 15m
+  values:
+    githubConfigUrl: https://github.com/joryirving/windowstead
+    githubConfigSecret: home-ops-runner-secret
+    runnerScaleSetName: windowstead-${CLUSTER}
+    scaleSetLabels:
+      - windowstead
+      - linux
+      - x64
+    minRunners: 0
+    maxRunners: 2
+    containerMode:
+      type: kubernetes
+      kubernetesModeWorkVolumeClaim:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-hostpath
+        resources:
+          requests:
+            storage: 50Gi
+    controllerServiceAccount:
+      name: actions-runner-controller
+      namespace: actions-runner-system
+    template:
+      spec:
+        containers:
+          - name: runner
+            image: ghcr.io/joryirving/actions-runner:2.333.1@sha256:6ff67813438d14e443284b7ec13c41afa25d0dbba0926f6f13c9eafe0bb1ce41
+            command: ["/home/runner/run.sh"]
+            env:
+              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                value: "false"
+              - name: NODE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.hostIP
+            volumeMounts:
+              - mountPath: /var/run/secrets/talos.dev
+                name: talos
+                readOnly: true
+        serviceAccountName: home-ops-runner-${CLUSTER}
+        volumes:
+          - name: talos
+            secret:
+              secretName: home-ops-runner-${CLUSTER}


### PR DESCRIPTION
## Summary
- add a dedicated ARC runner scale set for `joryirving/windowstead` on the `main` cluster
- label the runner set for repo-specific Linux release jobs (`windowstead`, `linux`, `x64`)
- increase the work PVC size to `50Gi` for Godot export artifacts

## Notes
- this is intended for release-only CI/CD builds, not blanket PR/commit workloads
- `joryirving/windowstead` is currently private, so this uses self-hosted runners instead of GitHub-hosted runners
- the current `main` cluster setup is Talos/Linux only, so this PR only adds the Linux runner path in-cluster
- Windows and macOS labels/runners are **not** added here because there are no Windows or macOS cluster nodes/patterns in `home-ops` today
- if native Windows/macOS release builds are required later, they will need separate non-cluster runner hosts or another provisioning pattern outside the current ARC-on-Talos setup
