### PR TITLE
feat(openclaw): add memory-wiki plugin in bridge mode

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
@@ -443,6 +443,7 @@ spec:
                 "composio",
                 "openclaw-mcp-bridge",
                 "searxng",
+                "memory-wiki",
               ],
               entries: {
                 discord: { enabled: true },
@@ -563,6 +564,33 @@ spec:
                       language: "en"
                     }
                   }
+                },
+                "memory-wiki": {
+                  enabled: true,
+                  config: {
+                    vaultMode: "bridge",
+                    vault: {
+                      path: "~/.openclaw/wiki/main",
+                      renderMode: "native",
+                    },
+                    bridge: {
+                      enabled: true,
+                      readMemoryArtifacts: true,
+                      indexDreamReports: true,
+                      indexDailyNotes: true,
+                      indexMemoryRoot: true,
+                      followMemoryEvents: true,
+                    },
+                    search: {
+                      backend: "shared",
+                      corpus: "all",
+                    },
+                    render: {
+                      preserveHumanBlocks: true,
+                      createBacklinks: true,
+                      createDashboards: true,
+                    },
+                  },
                 },
               },
               slots: {


### PR DESCRIPTION
Adds bundled memory-wiki plugin as a durable wiki compiler alongside memory-lancedb-pro. Uses bridge mode to import memory artifacts from the active memory plugin for provenance-rich syntheses and dashboards.

**Changes:**
- Adds memory-wiki to plugins.allow list
- Adds memory-wiki plugin entry with bridge mode config
- search.backend: shared, corpus: all
- render.createBacklinks and createDashboards enabled

Plugin docs: https://docs.openclaw.ai/plugins/memory-wiki