### PR TITLE
fix(toolhive): remove telemetryConfigRef from VirtualMCPServer; add PodMonitor

### DIFF
--- a/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
@@ -15,5 +15,3 @@ spec:
     type: anonymous
   outgoingAuth:
     source: discovered
-  telemetryConfigRef:
-    name: prometheus


### PR DESCRIPTION
## Summary

Fix the toolhive-config kustomization which fails because `VirtualMCPServer.spec.telemetryConfigRef` is not recognized by the deployed toolhive-operator-crds v0.18.0 schema.

Also includes PodMonitor for the toolhive MCP gateway service.

## Changes

- **virtualmcpserver.yaml**: Remove `telemetryConfigRef` field (CRD doesn't support it)
- **podmonitor.yaml**: Add PodMonitor to scrape `--metrics` endpoint from toolhive MCP gateway pods

## Testing

`kustomize build` passes. Flux reconciliation of toolhive-config should go green after merge.