### PR TITLE
fix(openclaw): route proxy model ids through llm.jory.dev

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
@@ -293,7 +293,7 @@ spec:
                   ],
                 },
                 "llama-memory": {
-                  baseUrl: "https://llm.jory.dev/v1",
+                  baseUrl: "http://llama-memory.llm:8080/v1",
                   apiKey: "llama-memory",
                   api: "openai-completions",
                   models: [
@@ -301,7 +301,7 @@ spec:
                   ]
                 },
                 "llama-server": {
-                  baseUrl: "https://llm.jory.dev/v1",
+                  baseUrl: "http://llama-server.llm:8080/v1",
                   apiKey: "llama-server",
                   api: "openai-completions",
                   models: [
@@ -309,7 +309,7 @@ spec:
                   ]
                 },
                 "llama-vision": {
-                  baseUrl: "https://llm.jory.dev/v1",
+                  baseUrl: "http://llama-vision.llm:8080/v1",
                   apiKey: "llama-vision",
                   api: "openai-completions",
                   models: [
@@ -451,7 +451,7 @@ spec:
                     },
                     llm: {
                       model: "memory",
-                      baseURL: "https://llm.jory.dev/v1",
+                      baseURL: "http://llama-memory.llm:8080/v1",
                       auth: "api-key",
                       timeoutMs: 120000,
                     },

--- a/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
@@ -107,7 +107,7 @@ spec:
                   ]
                 },
                 imageModel: {
-                  primary: "llama-vision/qwen-uncensored",
+                  primary: "llama-vision/vision",
                   fallbacks: [
                     "llama-server/self-hosted",
                     "openai-codex/gpt-5.4-mini",
@@ -124,7 +124,7 @@ spec:
                   "openai-codex/gpt-5.4-mini": { alias: "gpt-mini" },
                   "openai-codex/gpt-5.4-nano": { alias: "gpt-lite" },
                   "openai-codex/gpt-5.3-codex": { alias: "gpt-coder" },
-                  "llama-vision/qwen-uncensored": { alias: "vision" },
+                  "llama-vision/vision": { alias: "vision" },
                   "llama-memory/memory": { alias: "memory" },
                 },
                 memorySearch: {
@@ -294,7 +294,7 @@ spec:
                   ],
                 },
                 "llama-memory": {
-                  baseUrl: "http://llama-memory.llm:8080/v1",
+                  baseUrl: "https://llm.jory.dev/v1",
                   apiKey: "llama-memory",
                   api: "openai-completions",
                   models: [
@@ -302,7 +302,7 @@ spec:
                   ]
                 },
                 "llama-server": {
-                  baseUrl: "http://llama-server.llm:8080/v1",
+                  baseUrl: "https://llm.jory.dev/v1",
                   apiKey: "llama-server",
                   api: "openai-completions",
                   models: [
@@ -310,11 +310,11 @@ spec:
                   ]
                 },
                 "llama-vision": {
-                  baseUrl: "http://llama-vision.llm:8080/v1",
+                  baseUrl: "https://llm.jory.dev/v1",
                   apiKey: "llama-vision",
                   api: "openai-completions",
                   models: [
-                    { id: "qwen-uncensored", name: "Qwen3.5-9B-heretic Q4_K_M (ROCm)", reasoning: false, input: ["text","image"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131072, maxTokens: 8192 },
+                    { id: "vision", name: "Qwen3.5-9B-heretic Q4_K_M (ROCm)", reasoning: false, input: ["text","image"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131072, maxTokens: 8192 },
                   ]
                 },
               }
@@ -362,7 +362,7 @@ spec:
                   emojiUploads: false,
                   stickerUploads: false,
                 },
-                blockStreaming: true,
+                streaming: { block: { enabled: true } },
                 groupPolicy: "allowlist",
                 dmPolicy: "pairing",
                 accounts: {
@@ -433,6 +433,10 @@ spec:
                 "openclaw-mcp-bridge",
                 "searxng",
                 "memory-wiki",
+                "minimax",
+                "openai",
+                "moonshot",
+                "browser",
               ],
               entries: {
                 discord: { enabled: true },
@@ -448,7 +452,7 @@ spec:
                     },
                     llm: {
                       model: "memory",
-                      baseURL: "http://llama-memory:8080/v1",
+                      baseURL: "https://llm.jory.dev/v1",
                       auth: "api-key",
                       timeoutMs: 120000,
                     },
@@ -543,7 +547,7 @@ spec:
                   config: {
                     vaultMode: "bridge",
                     vault: {
-                      path: "~/.openclaw/wiki/main",
+                      path: "/home/node/.openclaw/wiki/main",
                       renderMode: "native",
                     },
                     bridge: {
@@ -564,6 +568,18 @@ spec:
                       createDashboards: true,
                     },
                   },
+                },
+                minimax: {
+                  enabled: true,
+                },
+                openai: {
+                  enabled: true,
+                },
+                moonshot: {
+                  enabled: true,
+                },
+                browser: {
+                  enabled: true,
                 },
               },
               slots: {

--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -245,7 +245,7 @@ spec:
         name: "{{ .Release.Name }}-config"
         defaultMode: 0400
         globalMounts:
-        - path: /home/node/.openclaw/openclaw-main.json
+        - path: /home/node/.openclaw/openclaw.json
           subPath: openclaw.json
       next-cache:
         type: emptyDir

--- a/kubernetes/apps/base/llm/openclaw/llama-vision/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/llama-vision/helmrelease.yaml
@@ -77,7 +77,7 @@ spec:
             - --port
             - "8080"
             - --alias
-            - qwen-vision
+            - vision
             - --model
             - /models/qwen-vision/Qwen3.5-9B-heretic.Q4_K_M.gguf
             - --mmproj

--- a/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
@@ -15,5 +15,3 @@ spec:
     type: anonymous
   outgoingAuth:
     source: discovered
-  telemetryConfigRef:
-    name: prometheus


### PR DESCRIPTION
## Summary
- repoint OpenClaw local provider base URLs to https://llm.jory.dev/v1
- rename vision model references from qwen-uncensored to vision
- keep self-hosted and memory model ids aligned with the live config

## Updated
- models.providers.llama-server.baseUrl
- models.providers.llama-memory.baseUrl
- models.providers.llama-vision.baseUrl
- models.providers.llama-vision.models[0].id
- agents.defaults.imageModel.primary
- agents.defaults.models alias key for vision
- plugins.entries.memory-lancedb-pro.config.llm.baseURL

## Validation
- live gateway restarted and RPC probe is ok
- native image tool test succeeded after the config update