### PR TITLE
fix: reduce llama-vision target flapping alerts

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/llama-vision/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/llama-vision/helmrelease.yaml
@@ -150,6 +150,8 @@ spec:
                   initialDelaySeconds: 30
                   periodSeconds: 30
                   failureThreshold: 6
+                  timeoutSeconds: 10
+                  timeoutSeconds: 10
               readiness:
                 enabled: true
                 custom: true
@@ -159,6 +161,7 @@ spec:
                     port: 8080
                   initialDelaySeconds: 20
                   periodSeconds: 10
+                  timeoutSeconds: 10
                   failureThreshold: 6
               startup:
                 enabled: true

--- a/kubernetes/apps/base/llm/openclaw/llama-vision/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/llama-vision/helmrelease.yaml
@@ -151,7 +151,6 @@ spec:
                   periodSeconds: 30
                   failureThreshold: 6
                   timeoutSeconds: 10
-                  timeoutSeconds: 10
               readiness:
                 enabled: true
                 custom: true
@@ -161,8 +160,8 @@ spec:
                     port: 8080
                   initialDelaySeconds: 20
                   periodSeconds: 10
-                  timeoutSeconds: 10
                   failureThreshold: 6
+                  timeoutSeconds: 10
               startup:
                 enabled: true
                 custom: true
@@ -172,6 +171,7 @@ spec:
                     port: 8080
                   failureThreshold: 360
                   periodSeconds: 10
+                  timeoutSeconds: 10
     persistence:
       models:
         existingClaim: llm-models

--- a/kubernetes/apps/base/llm/openclaw/llama-vision/servicemonitor.yaml
+++ b/kubernetes/apps/base/llm/openclaw/llama-vision/servicemonitor.yaml
@@ -16,4 +16,5 @@ spec:
   endpoints:
     - port: http
       path: /metrics
+      scrapeTimeout: 30s
   fallbackScrapeProtocol: PrometheusText0.0.4


### PR DESCRIPTION
$## Summary\n- increase the `llama-vision` ServiceMonitor scrape timeout to 30s\n- increase `llama-vision` health probe timeouts to 10s\n\n## Why\nPrometheus was scraping `llama-vision` with a 10s timeout and repeatedly hitting that ceiling during heavy vision inference. The `TargetDown` rule also has `for: 10m`, which made the alerts feel sticky even after recovery.\n\nObserved during investigation:\n- target scrape timeout was 10s\n- max scrape duration over the last 6h was ~10.00s\n- `avg_over_time(up{job="llama-vision",namespace="llm"}[6h])` was ~0.714\n- pod itself was healthy when checked, so this looked like timeouts and false negatives rather than a persistent crash\n\n## Risk\nLow. This only makes scrapes and health checks less trigger-happy for a heavy inference workload.