### PR TITLE
feat(llm): restore comfyui on skirk

### DIFF
--- a/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: comfyui
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  dependsOn: []
+  interval: 15m
+  values:
+    controllers:
+      comfyui:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: yanwk/comfyui-boot
+              tag: rocm7@sha256:dd435f0b8b5abc49c64e37557e04ff25662d853fc6baa25ca2d8f2e6e6503726
+            securityContext:
+              privileged: true
+            env:
+              HSA_OVERRIDE_GFX_VERSION: "11.5.1"
+              HSA_ENABLE_SDMA: "0"
+              HIP_VISIBLE_DEVICES: "0"
+              ROCR_VISIBLE_DEVICES: "0"
+              PYTORCH_HIP_ALLOC_CONF: "max_split_size_mb:256,garbage_collection_threshold:0.6"
+              CLI_ARGS: "--listen 0.0.0.0 --port 8188 --use-pytorch-cross-attention --disable-mmap --lowvram --reserve-vram 118"
+            resources:
+              requests:
+                cpu: 1
+                memory: 8Gi
+              limits:
+                memory: 16Gi
+    defaultPodOptions:
+      hostIPC: true
+      nodeSelector:
+        topology.kubernetes.io/gpus: amd
+      tolerations:
+        - key: llm-workload
+          operator: Exists
+          effect: NoSchedule
+    service:
+      app:
+        ports:
+          http:
+            port: 8188
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.jory.dev"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      comfyui:
+        existingClaim: "comfyui"
+        globalMounts:
+          - path: /root/ComfyUI/
+      data:
+        type: nfs
+        server: voyager.internal
+        path: /mnt/daena/comfyui/
+        globalMounts:
+          - path: /root/ComfyUI/output
+            subPath: output
+          - path: /root/ComfyUI/input
+            subPath: input
+      dev-dri:
+        type: hostPath
+        hostPath: /dev/dri
+        globalMounts:
+          - path: /dev/dri
+      dev-kfd:
+        type: hostPath
+        hostPath: /dev/kfd
+        globalMounts:
+          - path: /dev/kfd

--- a/kubernetes/apps/base/llm/comfyui/app/kustomization.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/main/llm/comfyui.yaml
+++ b/kubernetes/apps/main/llm/comfyui.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app comfyui
+spec:
+  components:
+    - ../../../../../components/gpu
+    - ../../../../../components/volsync
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/comfyui/app
+  postBuild:
+    substitute:
+      APP: *app
+      CLUSTER: ${CLUSTER}
+      VOLSYNC_CAPACITY: 100Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/main/llm/kustomization.yaml
+++ b/kubernetes/apps/main/llm/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - ./searxng.yaml
   - ./toolhive.yaml
   - ./ai-gateway.yaml
+  - ./comfyui.yaml


### PR DESCRIPTION
## Summary
- Recreate the ComfyUI base manifests under `kubernetes/apps/base/llm/comfyui/app` with the prior working HelmRelease profile (ROCm image, low-VRAM args, GPU node targeting, and existing NFS mounts).
- Restore the main-cluster Flux Kustomization at `kubernetes/apps/main/llm/comfyui.yaml` with `gpu` and `volsync` components and re-add it to `kubernetes/apps/main/llm/kustomization.yaml`.
- This re-enables ComfyUI in GitOps now that current skirk UMA headroom is acceptable for the workload.

## Validation
- `/Users/joryirving/.local/share/mise/installs/pipx-flux-local/8.1.0/bin/flux-local test --enable-helm --path ./kubernetes/clusters/main`