### PR TITLE
saffron: switch memory-lancedb-pro to BGE-M3 + reranker

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
@@ -445,9 +445,11 @@ spec:
                     embedding: {
                       provider: "openai-compatible",
                       apiKey: "ollama",
-                      model: "nomic-embed-text",
+                      model: "bge-m3",
                       baseURL: "http://ollama.llm:11434/v1",
                       chunking: true,
+                      dimensions: 1024,
+                      normalized: true,
                     },
                     llm: {
                       model: "memory",
@@ -474,6 +476,12 @@ spec:
                       filterNoise: true,
                       minScore: 0.25,
                       hardMinScore: 0.28,
+                      rerank: true,
+                      rerankApiKey: "ollama",
+                      rerankModel: "kopens/bge-reranker-v2-m3",
+                      rerankEndpoint: "http://ollama.llm:11434",
+                      rerankProvider: "tei",
+                      rerankTimeoutMs: 30000,
                     },
                     scopes: {
                       definitions: {
@@ -481,12 +489,15 @@ spec:
                         "sage": { description: "Sage's private memories" },
                         "maple": { description: "Maple's private memories" },
                         "saffron": { description: "Saffron's private memories" },
-                        "matcha": { description: "Matcha's private memories" }
+                        "matcha": { description: "Matcha's private memories" },
+                        "rag:saffron": { description: "Saffron RAG corpus - code, infra, docs" },
+                        "rag:miso": { description: "Miso RAG corpus - chat, preferences" },
+                        "rag:shared": { description: "Shared team docs and conventions" }
                       },
                       agentAccess: {
                         "sage": ["global", "sage"],
                         "maple": ["global", "maple"],
-                        "saffron": ["global", "saffron"],
+                        "saffron": ["global", "saffron", "rag:saffron", "rag:shared"],
                         "matcha": ["global", "matcha"]
                       },
                     },


### PR DESCRIPTION
## Summary

Switch memory-lancedb-pro embedding model from nomic-embed-text to BGE-M3 and enable reranking with bge-reranker-v2-m3.

## Changes

- **Embedding model**:  → 
  - Added  and  for BGE-M3 compatibility
- **Reranker**: Enabled bge-reranker-v2-m3 via TEI provider pointing to Ollama
  - Timeout: 30s (CPU-based reranker needs more time)
- **New RAG scopes** (Phase 2 preparation):
  -  — Saffron RAG corpus (code, infra, docs)
  -  — Miso RAG corpus (chat, preferences)
  -  — Shared team docs and conventions
- **Access**: Saffron granted access to  and  scopes

## Phase 1 Complete

This is Phase 1 of the RAG enrichment plan for Saffron + Miso:
1. ✅ BGE-M3 and reranker models confirmed available in Ollama
2. ✅ Config updated to use BGE-M3 as embedder
3. ✅ Reranking enabled
4. ✅ RAG scopes added

## Validation

After merge, monitor:
-  for embedding errors
- Memory recall quality on next heartbeat
- Reranking latency (target: <30s for top-20 rerank)

## Testing

Test queries after deploy:
- Saffron: "home-ops HelmRelease versioning conventions"
- Memory recall: "what did we discuss about windowstead PRs"

---

Closes #TBD