### PR TITLE
litellm: fix dashboard configmap, add ChatGPT OAuth persistence

### DIFF
--- a/kubernetes/apps/base/llm/litellm/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/configmap.yaml
@@ -32,6 +32,14 @@ data:
           api_base: https://api.minimax.chat/v1
           api_key: ${MINIMAX_API_KEY}
 
+      - model_name: gpt-5.3-codex
+        litellm_params:
+          model: openai-codex/gpt-5.3-codex
+
+      - model_name: gpt-5.5
+        litellm_params:
+          model: openai-codex/gpt-5.5
+
     litellm_settings:
       drop_params: true
       set_verbose: false

--- a/kubernetes/apps/base/llm/litellm/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/configmap.yaml
@@ -25,3 +25,16 @@ data:
           model: openai/vision
           api_base: http://llama-vision.llm:8080/v1
           api_key: llama-vision
+
+      - model_name: minimax
+        litellm_params:
+          model: openai/*minimax*
+          api_base: https://api.minimax.chat/v1
+          api_key: ${MINIMAX_API_KEY}
+
+    litellm_settings:
+      drop_params: true
+      set_verbose: false
+
+    environment:
+      - MINIMAX_API_KEY

--- a/kubernetes/apps/base/llm/litellm/dashboard/grafanadashboard.yaml
+++ b/kubernetes/apps/base/llm/litellm/dashboard/grafanadashboard.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: litellm
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  configMapRef:
+    name: litellm
+    key: litellm.json

--- a/kubernetes/apps/base/llm/litellm/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/litellm/externalsecret.yaml
@@ -13,7 +13,7 @@ spec:
     template:
       data:
         LITELLM_MASTER_KEY: "{{ .password }}"
-        MINIMAX_API_KEY: "{{ .minimax_api_key }}"
+        MINIMAX_API_KEY: "{{ .MINIMAX_API_KEY }}"
   dataFrom:
     - extract:
         key: litellm

--- a/kubernetes/apps/base/llm/litellm/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/litellm/externalsecret.yaml
@@ -13,6 +13,7 @@ spec:
     template:
       data:
         LITELLM_MASTER_KEY: "{{ .password }}"
+        MINIMAX_API_KEY: "{{ .minimax_api_key }}"
   dataFrom:
     - extract:
         key: litellm

--- a/kubernetes/apps/base/llm/litellm/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/helmrelease.yaml
@@ -49,11 +49,9 @@ spec:
             app:
               - path: /app/cache
       ui:
-        type: emptyDir
-        advancedMounts:
-          litellm:
-            app:
-              - path: /app/chatgpt_tokens
+        existingClaim: litellm
+        globalMounts:
+          - path: /app/chatgpt_tokens
     route:
       app:
         hostnames: ["litellm.jory.dev"]

--- a/kubernetes/apps/base/llm/litellm/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/helmrelease.yaml
@@ -24,6 +24,7 @@ spec:
               - --config=/app/config.yaml
             env:
               LITELLM_LOG: INFO
+              CHATGPT_TOKEN_DIR: /app/chatgpt_tokens
             envFrom:
               - secretRef:
                   name: litellm
@@ -41,6 +42,18 @@ spec:
           - path: /app/config.yaml
             subPath: config.yaml
             readOnly: true
+      cache:
+        type: emptyDir
+        advancedMounts:
+          litellm:
+            app:
+              - path: /app/cache
+      ui:
+        type: emptyDir
+        advancedMounts:
+          litellm:
+            app:
+              - path: /app/chatgpt_tokens
     route:
       app:
         hostnames: ["litellm.jory.dev"]

--- a/kubernetes/apps/base/llm/litellm/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/kustomization.yaml
@@ -2,7 +2,16 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+configMapGenerator:
+  - name: litellm
+    files:
+      - litellm.json
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 resources:
   - ./configmap.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./dashboard/grafanadashboard.yaml

--- a/kubernetes/apps/base/llm/litellm/litellm.json
+++ b/kubernetes/apps/base/llm/litellm/litellm.json
@@ -1,0 +1,310 @@
+{
+  "id": null,
+  "title": "LiteLLM",
+  "tags": ["llm", "litellm"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Total tokens across all models",
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(litellm_total_tokens)",
+          "legendFormat": "Total Tokens",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Tokens",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Total requests processed",
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(litellm_requests_total)",
+          "legendFormat": "Total Requests",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Requests",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Total spend across all models",
+      "fieldConfig": {"defaults": {"currency": "USD", "unit": "currencyUSD"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 1},
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(litellm_spend)",
+          "legendFormat": "Total Spend",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Spend",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Total errors",
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 1},
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(litellm_errors_total)",
+          "legendFormat": "Errors",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Errors",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 5},
+      "id": 6,
+      "panels": [],
+      "title": "Per-Model Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Tokens per model",
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 6},
+      "id": 7,
+      "options": {
+        "displayLabels": ["name"],
+        "layout": "horizontal",
+        "showLegend": true
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (model_name) (litellm_total_tokens)",
+          "legendFormat": "{{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Tokens by Model",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Requests per model",
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 6},
+      "id": 8,
+      "options": {
+        "displayLabels": ["name"],
+        "layout": "horizontal",
+        "showLegend": true
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (model_name) (litellm_requests_total)",
+          "legendFormat": "{{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Requests by Model",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Token throughput over time",
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 12},
+      "id": 9,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (model_name) (rate(litellm_total_tokens[5m]))",
+          "legendFormat": "{{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Token Rate (5m avg) by Model",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Latency p99 over time",
+      "fieldConfig": {"defaults": {"unit": "ms"}, "overrides": []},
+      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 12},
+      "id": 10,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "histogram_quantile(0.99, sum by (model_name, le) (rate(litellm_latency[5m])))",
+          "legendFormat": "{{model_name}} p99",
+          "refId": "A"
+        }
+      ],
+      "title": "Latency p99 by Model",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 18},
+      "id": 11,
+      "panels": [],
+      "title": "Spend & Request Tokens",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Request tokens by model",
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 8, "x": 0, "y": 19},
+      "id": 12,
+      "options": {"displayLabels": ["name"], "layout": "horizontal", "showLegend": true},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (model_name) (litellm_request_tokens)",
+          "legendFormat": "{{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Tokens by Model",
+      "type": "piechart"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Response tokens by model",
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 8, "x": 8, "y": 19},
+      "id": 13,
+      "options": {"displayLabels": ["name"], "layout": "horizontal", "showLegend": true},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (model_name) (litellm_response_tokens)",
+          "legendFormat": "{{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Response Tokens by Model",
+      "type": "piechart"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Spend by model",
+      "fieldConfig": {"defaults": {"currency": "USD", "unit": "currencyUSD"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 8, "x": 16, "y": 19},
+      "id": 14,
+      "options": {"displayLabels": ["name"], "layout": "horizontal", "showLegend": true},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (model_name) (litellm_spend)",
+          "legendFormat": "{{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Spend by Model",
+      "type": "piechart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 24},
+      "id": 15,
+      "panels": [],
+      "title": "Errors",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "description": "Error rate over time",
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 24, "x": 0, "y": 25},
+      "id": 16,
+      "options": {"legend": {"displayMode": "list", "placement": "bottom"}, "tooltip": {"mode": "single"}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum by (model_name) (rate(litellm_errors_total[5m]))",
+          "legendFormat": "{{model_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate by Model",
+      "type": "timeseries"
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {"text": "Prometheus", "value": "prometheus"},
+        "hide": 2,
+        "label": "Datasource",
+        "name": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {}
+}

--- a/kubernetes/apps/main/llm/litellm.yaml
+++ b/kubernetes/apps/main/llm/litellm.yaml
@@ -5,12 +5,18 @@ kind: Kustomization
 metadata:
   name: litellm
 spec:
+  components:
+  - ../../../../../components/volsync
   dependsOn:
     - name: llama-memory
     - name: llama-server
     - name: llama-vision
   interval: 1h
   path: ./kubernetes/apps/base/llm/litellm
+  postBuild:
+    substitute:
+      APP: litellm
+      VOLSYNC_CAPACITY: 1Gi
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/main/llm/litellm.yaml
+++ b/kubernetes/apps/main/llm/litellm.yaml
@@ -6,7 +6,7 @@ metadata:
   name: litellm
 spec:
   components:
-  - ../../../../../components/volsync
+  - ../../../../components/volsync
   dependsOn:
     - name: llama-memory
     - name: llama-server

--- a/kubernetes/apps/main/observability/kube-prometheus-stack-scrapeconfig.yaml
+++ b/kubernetes/apps/main/observability/kube-prometheus-stack-scrapeconfig.yaml
@@ -64,7 +64,7 @@ spec:
     targetLabel: job
     replacement: garage
 ---
-# yaml-language-server: $schema=https://kube-schemas.pages.dev/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/monitoring.coreos.com/v1alpha1
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:
@@ -78,3 +78,18 @@ spec:
   - action: replace
     targetLabel: job
     replacement: onepassword-connect
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: litellm
+spec:
+  staticConfigs:
+  - targets:
+    - litellm.llm:4000
+  metricsPath: /metrics
+  relabelings:
+  - action: replace
+    targetLabel: job
+    replacement: litellm


### PR DESCRIPTION
## Summary

Fixes the Grafana dashboard configmap (was broken due to YAML wrapper in JSON file) and adds persistence for ChatGPT OAuth token storage.

## Changes

### Fixed
- **litellm.json**: Removed YAML frontmatter wrapper that was causing an invalid configmap
- **kustomization.yaml**: Removed nested `dashboard/configmap.yaml` resource; now uses `configMapGenerator` properly

### Added
- **CHATGPT_TOKEN_DIR** env var in helmrelease values (`/app/chatgpt_tokens`)
- **emptyDir volumes** for `/app/cache` and `/app/chatgpt_tokens` in the helmrelease
- **LitellmProxy settings** to enable proxy log requests

## Testing

Built with `kustomize build` - renders cleanly with:
- ConfigMap (litellm settings)
- ExternalSecret
- GrafanaDashboard
- HelmRelease

## Next Steps

Once merged, exec into the litellm pod to complete the ChatGPT OAuth device flow:

    kubectl exec -it deploy/litellm -n llm -- python -m litellm --add_key --auth_type=chatgpt