### PR TITLE
feat(hermes): add read-only ClusterRole RBAC (secrets excluded)

### DIFF
--- a/kubernetes/apps/base/llm/hermes/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/hermes/helmrelease.yaml
@@ -149,3 +149,78 @@ spec:
         path: /mnt/daena/comfyui/output
         globalMounts:
         - path: /mnt/gallery
+    serviceAccount:
+      hermes: {}
+    rbac:
+      roles:
+        # Broad read-only access across cluster resources. Secrets intentionally excluded.
+        hermes-read-all:
+          type: ClusterRole
+          rules:
+          - apiGroups: [""]
+            resources: ["pods", "pods/log", "nodes", "services", "namespaces", "configmaps",
+              "persistentvolumes", "persistentvolumeclaims", "endpoints", "resourcequotas",
+              "limitranges", "serviceaccounts", "events"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["apps"]
+            resources: ["deployments", "daemonsets", "statefulsets", "replicasets",
+              "controllerrevisions"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["batch"]
+            resources: ["jobs", "cronjobs"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["networking.k8s.io"]
+            resources: ["ingresses", "ingressclasses", "networkpolicies"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["storage.k8s.io"]
+            resources: ["storageclasses", "csinodes", "csidrivers", "volumeattachments"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["autoscaling"]
+            resources: ["horizontalpodautoscalers"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["policy"]
+            resources: ["poddisruptionbudgets"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["coordination.k8s.io"]
+            resources: ["leases"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["rbac.authorization.k8s.io"]
+            resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["apiextensions.k8s.io"]
+            resources: ["customresourcedefinitions"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["apiregistration.k8s.io"]
+            resources: ["apiservices"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["metrics.k8s.io"]
+            resources: ["nodes", "pods"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["helm.toolkit.fluxcd.io"]
+            resources: ["helmreleases"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+            resources: ["kustomizations"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["source.toolkit.fluxcd.io"]
+            resources: ["gitrepositories", "helmrepositories", "ocirepositories",
+              "buckets", "helmcharts"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["external-secrets.io"]
+            resources: ["externalsecrets", "secretstores", "clustersecretstores"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["monitoring.coreos.com"]
+            resources: ["prometheuses", "alertmanagers", "servicemonitors", "podmonitors",
+              "prometheusrules", "thanosrulers", "probes"]
+            verbs: ["get", "list", "watch"]
+          - apiGroups: ["snapshot.storage.k8s.io"]
+            resources: ["volumesnapshots", "volumesnapshotcontents", "volumesnapshotclasses"]
+            verbs: ["get", "list", "watch"]
+      bindings:
+        hermes-read-all:
+          type: ClusterRoleBinding
+          roleRef:
+            identifier: hermes-read-all
+          subjects:
+          - identifier: hermes
+            serviceAccount: hermes


### PR DESCRIPTION
## Summary

- Adds `hermes-read-all` ClusterRole with broad read-only access across cluster resources
- Binds the role to the `hermes` ServiceAccount via ClusterRoleBinding
- Secrets intentionally excluded from read access — mirrors the openclaw RBAC pattern

## Changes

- `kubernetes/apps/base/llm/hermes/helmrelease.yaml` — added `serviceAccount` and `rbac` block