### PR TITLE
hermes: fix vision model name to vision (not llama-vision)

### DIFF
--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -45,3 +45,9 @@ data:
     mcp_servers:
       toolhive:
         url: http://vmcp-mcp-gateway-internal.llm:4483/mcp
+    auxiliary:
+      vision:
+        provider: openai
+        model: vision
+        base_url: http://litellm.llm:4000/v1
+        api_key: ${LITELLM_API_KEY}


### PR DESCRIPTION
Fix auxiliary.vision model name from `llama-vision` to `vision` to match litellm model alias.

Without this fix, litellm returns 'No connected db' error because `llama-vision` is not a recognized model name.