### PR TITLE
hermes: fix vision model name to 'vision' (not 'llama-vision')

### DIFF
--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -48,6 +48,6 @@ data:
     auxiliary:
       vision:
         provider: openai
-        model: vision
+        model: openai/vision
         base_url: http://litellm.llm:4000/v1
         api_key: ${LITELLM_API_KEY}


### PR DESCRIPTION
Fix the auxiliary.vision model name from `llama-vision` to `vision` to match the litellm model alias.

Without this fix, litellm returns 'No connected db' error because `llama-vision` is not a recognized model name in the litellm config.