### PR TITLE
feat(openclaw): switch memory slot to memory-core

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
@@ -192,7 +192,7 @@ spec:
                   name: "Matcha",
                   workspace: "/home/node/.openclaw/workspace-matcha",
                   agentDir: "/home/node/.openclaw/agents/matcha/agent",
-                  tools: { allow: ["exec", "message", "read", "web_fetch", "image", "memory_recall", "memory_store"] },
+                  tools: { allow: ["exec", "message", "read", "web_fetch", "image", "memory_search", "memory_get"] },
 
                   model: {
                     primary: "minimax/MiniMax-M2.7",
@@ -212,7 +212,7 @@ spec:
                   heartbeat: { every: "60m", model: "llama-server/self-hosted", activeHours: { start: "06:00", end: "23:00" }, },
                   workspace: "/home/node/.openclaw/workspace-saffron",
                   agentDir: "/home/node/.openclaw/agents/saffron/agent",
-                  tools: { allow: ["exec", "read", "write", "kubectl", "web_fetch", "browser", "sessions_spawn", "memory_recall", "memory_store", "mcp"] },
+                  tools: { allow: ["exec", "read", "write", "kubectl", "web_fetch", "browser", "sessions_spawn", "memory_search", "memory_get", "mcp"] },
 
                   model: {
                     primary: "llama-server/self-hosted",
@@ -381,6 +381,7 @@ spec:
                 "discord",
                 "lossless-claw",
                 "memory-lancedb-pro",
+                "memory-core",
                 "openclaw-better-gateway",
                 "openclaw-mcp-bridge",
                 "searxng",
@@ -551,9 +552,13 @@ spec:
                 browser: {
                   enabled: true,
                 },
+
+                "memory-core": {
+                  enabled: true,
+                },
               },
               slots: {
-                memory: "memory-lancedb-pro",
+                memory: "memory-core",
                 contextEngine: "lossless-claw"
               },
             },


### PR DESCRIPTION
## Summary
- switch OpenClaw `plugins.slots.memory` from `memory-lancedb-pro` to bundled `memory-core`
- allow and enable `memory-core` in plugin config
- update Matcha/Saffron memory tool allow-lists from `memory_recall`/`memory_store` to `memory_search`/`memory_get`

## Notes
- leaves `memory-lancedb-pro` in `plugins.allow` for rollback while the QMD migration is validated
- leaves `lossless-claw` as the active `contextEngine`
- keeps `memory-core` config minimal (`enabled: true`) because its schema only supports optional `dreaming` config

## Validation
- `git diff --check`
- parsed `externalsecret.yaml` with PyYAML (`yaml_docs=5`)
- extracted embedded `openclaw.json` object and verified:
  - `plugins.slots.memory === "memory-core"`
  - `plugins.entries["memory-core"].enabled === true`
  - Saffron/Matcha memory tools are `memory_search`, `memory_get`
