### PR TITLE
feat(observability): add rocm smi exporter

### DIFF
--- a/kubernetes/apps/base/llm/litellm/Qwen3.6-35B-A3B/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/Qwen3.6-35B-A3B/helmrelease.yaml
@@ -86,7 +86,7 @@ spec:
             - --flash-attn
             - "on"
             - --parallel
-            - "3"
+            - "4"
             - --cont-batching
             - -sps
             - "0.90"

--- a/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
@@ -163,7 +163,7 @@ spec:
                   },
                   archiveAfterMinutes: 120,
                   maxConcurrent: 3,
-                  thinking: "low",
+                  thinking: "adaptive",
                 },
                 heartbeat: {
                   directPolicy: "allow",
@@ -171,6 +171,7 @@ spec:
                   isolatedSession: true,
                   includeReasoning: true,
                 },
+                thinkingDefault: "adaptive",
                 timeoutSeconds: 600
               },
               list: [

--- a/kubernetes/apps/base/observability/exporters/rocm-smi-exporter/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/rocm-smi-exporter/helmrelease.yaml
@@ -1,0 +1,73 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app rocm-smi-exporter
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 15m
+  dependsOn: []
+  values:
+    defaultPodOptions:
+      nodeSelector:
+        node-role.kubernetes.io/rocm-worker: "true"
+        topology.kubernetes.io/gpus: amd
+      securityContext:
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      tolerations:
+        - key: llm-workload
+          operator: Exists
+          effect: NoSchedule
+    controllers:
+      rocm-smi-exporter:
+        type: daemonset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/joryirving/rocm-smi-exporter
+              tag: 0.1.0@sha256:25c4f94a60bdf3d17a88f1039936f9d5425c0f53b67806e621c16f1d46fc9747
+            env:
+              SYSFS_ROOT: /host/sys
+              TZ: America/Edmonton
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /metrics
+                    port: &port 9494
+                  initialDelaySeconds: 0
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+              readOnlyRootFilesystem: true
+    persistence:
+      sys:
+        type: hostPath
+        hostPath: /sys
+        globalMounts:
+          - path: /host/sys
+            readOnly: true
+    service:
+      app:
+        ports:
+          metrics:
+            enabled: true
+            protocol: TCP
+            port: *port

--- a/kubernetes/apps/base/observability/exporters/rocm-smi-exporter/kustomization.yaml
+++ b/kubernetes/apps/base/observability/exporters/rocm-smi-exporter/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/base/observability/exporters/rocm-smi-exporter/servicemonitor.yaml
+++ b/kubernetes/apps/base/observability/exporters/rocm-smi-exporter/servicemonitor.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: &app rocm-smi-exporter
+  labels: &labels
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+spec:
+  selector:
+    matchLabels:
+      <<: *labels
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      metricRelabelings:
+        - action: labeldrop
+          regex: (pod)

--- a/kubernetes/apps/main/observability/exporters/kustomization.yaml
+++ b/kubernetes/apps/main/observability/exporters/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./blackbox-exporter-probes.yaml
   - ./hoymiles-exporter.yaml
   - ./nut-exporter.yaml
+  - ./rocm-smi-exporter.yaml
   - ./smartctl-exporter.yaml
   - ./speedtest-exporter.yaml
   - ./unpoller.yaml

--- a/kubernetes/apps/main/observability/exporters/rocm-smi-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/rocm-smi-exporter.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: rocm-smi-exporter
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/observability/exporters/rocm-smi-exporter
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
## Summary
- add rocm-smi-exporter to the main observability exporters using the 0.1.0 image digest
- run it as a DaemonSet pinned to the ROCm worker via `node-role.kubernetes.io/rocm-worker=true` and `topology.kubernetes.io/gpus=amd`
- include the local LLM tuning changes for Qwen3.6 parallelism and OpenClaw adaptive thinking defaults

## GPU / DRA note
- did not add `components/gpu` because the existing component is Intel DRA-specific (`gpu.intel.com`) and depends on `intel-gpu-resource-driver`
- the exporter currently scrapes host `/sys` read-only and does not need GPU device allocation through DRA

## Testing
- `kustomize build kubernetes/apps/base/observability/exporters/rocm-smi-exporter`
- `kustomize build kubernetes/apps/main/observability/exporters`
- `/Users/joryirving/.local/share/mise/installs/pipx-flux-local/8.1.0/bin/flux-local test --enable-helm --path ./kubernetes/clusters/main`