### PR TITLE
feat(llm): expose /metrics endpoint in litellm via success_callback

### DIFF
--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -44,6 +44,7 @@ data:
       health_check_endpoint: /v1/health
 
     litellm_settings:
+      success_callback: ["prometheus"]
       prometheus_adapter: true
       drop_params: true
       set_verbose: false


### PR DESCRIPTION
## Summary

Adds `success_callback: ["prometheus"]` to litellm's `litellm_settings`.

**Root cause:** litellm's `/metrics` endpoint is only mounted when a `prometheus` success callback is registered (via `PrometheusLogger._mount_metrics_endpoint()`). The existing `prometheus_adapter: true` config does NOT enable the endpoint — it only configures a Prometheus adapter that writes to a pushgateway (which also requires configuration).

With `success_callback: ["prometheus"]` added, litellm mounts `/metrics` and Prometheus can scrape it directly without needing a pushgateway.

## Testing

- `/metrics` on litellm.llm:4000 should return prometheus metrics text format
- Prometheus scrape config in `kube-prometheus-stack-scrapeconfig.yaml` already targets `litellm.llm:4000/metrics`

## Files changed

- `kubernetes/apps/base/llm/litellm/app/configmap.yaml`: +1 line

Closes #6566