### PR TITLE
fix(hermes): route default model through litellm

### DIFF
--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
 data:
   config.yaml: |
     model:
-      default: selfhosted
-      provider: custom
-      base_url: http://llama-server.llm:8080/v1
-      api_key: ""
+      default: llama-server
+      provider: litellm
+      base_url: http://litellm.llm:4000/v1
+      api_key: $${LITELLM_API_KEY}
     providers:
       litellm:
         base_url: http://litellm.llm:4000/v1


### PR DESCRIPTION
## Summary

Changes hermes-agent config to route the default model through LiteLLM instead of calling llama-server directly.

### Changes

- `model.default`: `selfhosted` → `llama-server` (litellm model alias)
- `model.provider`: `custom` → `litellm` (use providers.litellm config)
- `model.base_url`: added (http://litellm.llm:4000/v1)
- `model.api_key`: added with `$${LITELLM_API_KEY}` flux escaping

### Why

Routing through LiteLLM enables observability (tokens, latency, spend) and consistent proxy behavior across all LLM traffic.

### Testing

- Verified litellm `/v1/models` returns `llama-server` in model list
- API key format confirmed working

### Wiki

Created `concepts/hermes-agent.md` with full config documentation.