### PR TITLE
litellm: add moonshot upstream provider

### DIFF
--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -14,12 +14,6 @@ data:
       litellm:
         base_url: http://litellm.llm:4000/v1
         api_key: $${LITELLM_API_KEY}
-      minimax:
-        api_key: $${MINIMAX_API_KEY}
-        base_url: https://api.minimax.chat/v1
-      moonshot:
-        api_key: $${MOONSHOT_API_KEY}
-        base_url: https://api.moonshot.ai/v1
     toolsets:
       - hermes-cli
     terminal:

--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -14,6 +14,12 @@ data:
       litellm:
         base_url: http://litellm.llm:4000/v1
         api_key: $${LITELLM_API_KEY}
+      minimax:
+        api_key: $${MINIMAX_API_KEY}
+        base_url: https://api.minimax.chat/v1
+      moonshot:
+        api_key: $${MOONSHOT_API_KEY}
+        base_url: https://api.moonshot.ai/v1
     toolsets:
       - hermes-cli
     terminal:

--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
 data:
   config.yaml: |
     model:
-      default: selfhosted
-      provider: custom
-      base_url: http://llama-server.llm:8080/v1
-      api_key: ""
+      default: llama-server
+      provider: litellm
+      base_url: http://litellm.llm:4000/v1
+      api_key: $${LITELLM_API_KEY}
     providers:
       litellm:
         base_url: http://litellm.llm:4000/v1

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -28,13 +28,13 @@ data:
 
       - model_name: minimax
         litellm_params:
-          model: openai/*minimax*
-          api_base: https://api.minimax.chat/v1
+          model: minimax/*
+          api_base: https://api.minimax.io/v1
           api_key: ${MINIMAX_API_KEY}
 
       - model_name: moonshot
         litellm_params:
-          model: openai/moonshot*
+          model: moonshot/*
           api_base: https://api.moonshot.ai/v1
           api_key: ${MOONSHOT_API_KEY}
 

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -50,13 +50,29 @@ data:
           api_base: https://api.moonshot.ai/v1
           api_key: $${{MOONSHOT_API_KEY}}
 
-      - model_name: gpt-5.3-codex
-        litellm_params:
-          model: chatgpt/gpt-5.3-codex
-
       - model_name: gpt-5.5
+        model_info:
+          mode: responses
         litellm_params:
           model: chatgpt/gpt-5.5
+
+      - model_name: gpt-5.5-mini
+        model_info:
+          mode: responses
+        litellm_params:
+          model: chatgpt/gpt-5.5-mini
+
+      - model_name: gpt-5.5-nano
+        model_info:
+          mode: responses
+        litellm_params:
+          model: chatgpt/gpt-5.5-nano
+
+      - model_name: gpt-5.3-codex
+        model_info:
+          mode: responses
+        litellm_params:
+          model: chatgpt/gpt-5.3-codex
 
     general_settings:
       health_check_endpoint: /v1/health

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -32,6 +32,12 @@ data:
           api_base: https://api.minimax.chat/v1
           api_key: ${MINIMAX_API_KEY}
 
+      - model_name: moonshot
+        litellm_params:
+          model: openai/moonshot*
+          api_base: https://api.moonshot.ai/v1
+          api_key: ${MOONSHOT_API_KEY}
+
       - model_name: gpt-5.3-codex
         litellm_params:
           model: chatgpt/gpt-5.3-codex
@@ -51,3 +57,4 @@ data:
 
     environment:
       - MINIMAX_API_KEY
+      - MOONSHOT_API_KEY

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -10,19 +10,19 @@ data:
       # forwards the upstream model IDs that each llama.cpp server expects.
       - model_name: llama-memory
         litellm_params:
-          model: openai/memory
+          model: memory
           api_base: http://llama-memory.llm:8080/v1
           api_key: llama-memory
 
       - model_name: llama-server
         litellm_params:
-          model: openai/self-hosted
+          model: self-hosted
           api_base: http://llama-server.llm:8080/v1
           api_key: llama-server
 
       - model_name: llama-vision
         litellm_params:
-          model: openai/vision
+          model: vision
           api_base: http://llama-vision.llm:8080/v1
           api_key: llama-vision
 

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -22,13 +22,13 @@ data:
 
       - model_name: minimax/minimax-m2.7
         litellm_params:
-          model: minimax/minimax-m2.7
+          model: minimax/*
           api_base: https://api.minimax.io/v1
           api_key: ${MINIMAX_API_KEY}
 
       - model_name: moonshot/kimi-2.6
         litellm_params:
-          model: moonshot/kimi-2.6
+          model: moonshot/*
           api_base: https://api.moonshot.ai/v1
           api_key: ${MOONSHOT_API_KEY}
 

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -20,15 +20,15 @@ data:
           api_base: http://llama-vision.llm:8080/v1
           api_key: llama-vision
 
-      - model_name: minimax
+      - model_name: minimax/minimax-m2.7
         litellm_params:
-          model: minimax/*
+          model: minimax/minimax-m2.7
           api_base: https://api.minimax.io/v1
           api_key: ${MINIMAX_API_KEY}
 
-      - model_name: moonshot
+      - model_name: moonshot/kimi-2.6
         litellm_params:
-          model: moonshot/*
+          model: moonshot/kimi-2.6
           api_base: https://api.moonshot.ai/v1
           api_key: ${MOONSHOT_API_KEY}
 

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -30,25 +30,25 @@ data:
         litellm_params:
           model: MiniMax-M2.7
           api_base: https://api.minimax.io/v1
-          api_key: $$MINIMAX_API_KEY
+          api_key: $${{MINIMAX_API_KEY}}
 
       - model_name: minimax/MiniMax-M2.7-highspeed
         litellm_params:
           model: MiniMax-M2.7-highspeed
           api_base: https://api.minimax.io/v1
-          api_key: $$MINIMAX_API_KEY
+          api_key: $${{MINIMAX_API_KEY}}
 
       - model_name: moonshot/kimi-k2.5
         litellm_params:
           model: kimi-k2.5
           api_base: https://api.moonshot.ai/v1
-          api_key: $$MOONSHOT_API_KEY
+          api_key: $${{MOONSHOT_API_KEY}}
 
       - model_name: moonshot/kimi-k2.6
         litellm_params:
           model: kimi-k2.6
           api_base: https://api.moonshot.ai/v1
-          api_key: $$MOONSHOT_API_KEY
+          api_key: $${{MOONSHOT_API_KEY}}
 
       - model_name: gpt-5.3-codex
         litellm_params:

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -8,27 +8,39 @@ data:
     model_list:
       # These aliases keep the client-facing names stable while LiteLLM
       # forwards the upstream model IDs that each llama.cpp server expects.
-      - model_name: self-hosted
+      - model_name: llama-memory
         litellm_params:
-          model: self-hosted
+          model: openai/memory
+          api_base: http://llama-memory.llm:8080/v1
+          api_key: llama-memory
+
+      - model_name: llama-server
+        litellm_params:
+          model: openai/self-hosted
           api_base: http://llama-server.llm:8080/v1
           api_key: llama-server
 
-      - model_name: vision
+      - model_name: llama-vision
         litellm_params:
-          model: vision
+          model: openai/vision
           api_base: http://llama-vision.llm:8080/v1
           api_key: llama-vision
 
-      - model_name: minimax/minimax-m2.7
+      - model_name: minimax/MiniMax-M2.7
         litellm_params:
-          model: minimax/*
+          model: MiniMax-M2.7
           api_base: https://api.minimax.io/v1
           api_key: ${MINIMAX_API_KEY}
 
-      - model_name: moonshot/kimi-2.6
+      - model_name: minimax/MiniMax-M2.7-highspeed
         litellm_params:
-          model: moonshot/*
+          model: MiniMax-M2.7-highspeed
+          api_base: https://api.minimax.io/v1
+          api_key: ${MINIMAX_API_KEY}
+
+      - model_name: moonshot
+        litellm_params:
+          model: openai/moonshot*
           api_base: https://api.moonshot.ai/v1
           api_key: ${MOONSHOT_API_KEY}
 

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -30,25 +30,25 @@ data:
         litellm_params:
           model: MiniMax-M2.7
           api_base: https://api.minimax.io/v1
-          api_key: ${MINIMAX_API_KEY}
+          api_key: $$MINIMAX_API_KEY
 
       - model_name: minimax/MiniMax-M2.7-highspeed
         litellm_params:
           model: MiniMax-M2.7-highspeed
           api_base: https://api.minimax.io/v1
-          api_key: ${MINIMAX_API_KEY}
+          api_key: $$MINIMAX_API_KEY
 
       - model_name: moonshot/kimi-k2.5
         litellm_params:
           model: kimi-k2.5
           api_base: https://api.moonshot.ai/v1
-          api_key: ${MOONSHOT_API_KEY}
+          api_key: $$MOONSHOT_API_KEY
 
       - model_name: moonshot/kimi-k2.6
         litellm_params:
           model: kimi-k2.6
           api_base: https://api.moonshot.ai/v1
-          api_key: ${MOONSHOT_API_KEY}
+          api_key: $$MOONSHOT_API_KEY
 
       - model_name: gpt-5.3-codex
         litellm_params:

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -38,9 +38,15 @@ data:
           api_base: https://api.minimax.io/v1
           api_key: ${MINIMAX_API_KEY}
 
-      - model_name: moonshot
+      - model_name: moonshot/kimi-k2.5
         litellm_params:
-          model: openai/moonshot*
+          model: kimi-k2.5
+          api_base: https://api.moonshot.ai/v1
+          api_key: ${MOONSHOT_API_KEY}
+
+      - model_name: moonshot/kimi-k2.6
+        litellm_params:
+          model: kimi-k2.6
           api_base: https://api.moonshot.ai/v1
           api_key: ${MOONSHOT_API_KEY}
 

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -8,19 +8,13 @@ data:
     model_list:
       # These aliases keep the client-facing names stable while LiteLLM
       # forwards the upstream model IDs that each llama.cpp server expects.
-      - model_name: llama-memory
-        litellm_params:
-          model: memory
-          api_base: http://llama-memory.llm:8080/v1
-          api_key: llama-memory
-
-      - model_name: llama-server
+      - model_name: self-hosted
         litellm_params:
           model: self-hosted
           api_base: http://llama-server.llm:8080/v1
           api_key: llama-server
 
-      - model_name: llama-vision
+      - model_name: vision
         litellm_params:
           model: vision
           api_base: http://llama-vision.llm:8080/v1


### PR DESCRIPTION
## Summary

Add moonshot as a routed upstream model in litellm, alongside existing minimax and chatgpt providers.

### Changes
- Added  model entry with  compatibility mode
- Routes to 
- API key from  (already added to litellm secret)
- Added  to litellm environment variables list

### Why
- Provides another upstream option for hermes/openclaw to route through litellm
- Enables spend/usage tracking via litellm metrics