### PR TITLE
fix(litellm): add MiniMax provider prefix

### DIFF
--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -28,13 +28,13 @@ data:
 
       - model_name: minimax/MiniMax-M2.7
         litellm_params:
-          model: MiniMax-M2.7
+          model: minimax/MiniMax-M2.7
           api_base: https://api.minimax.io/v1
           api_key: $${MINIMAX_API_KEY}
 
       - model_name: minimax/MiniMax-M2.7-highspeed
         litellm_params:
-          model: MiniMax-M2.7-highspeed
+          model: minimax/MiniMax-M2.7-highspeed
           api_base: https://api.minimax.io/v1
           api_key: $${MINIMAX_API_KEY}
 


### PR DESCRIPTION
## Summary

Repurpose this PR to fix the MiniMax LiteLLM routing config.

Per the LiteLLM MiniMax provider docs, MiniMax calls must use the provider-prefixed model string in `litellm_params.model`:

- `minimax/MiniMax-M2.7`
- `minimax/MiniMax-M2.7-highspeed`

This keeps the client-facing `model_name` entries unchanged while fixing the backend model strings LiteLLM passes into `litellm.completion()`.

Also removed the earlier 2-replica change from this PR so the HA/metrics work can be handled separately.

## Testing

- Parsed `kubernetes/apps/base/llm/litellm/app/configmap.yaml` as YAML.
- Confirmed MiniMax entries resolve to provider-prefixed LiteLLM models:
  - `minimax/MiniMax-M2.7 -> minimax/MiniMax-M2.7 @ https://api.minimax.io/v1`
  - `minimax/MiniMax-M2.7-highspeed -> minimax/MiniMax-M2.7-highspeed @ https://api.minimax.io/v1`
