### PR TITLE
litellm: add chatgpt/ prefix to gpt-5.5 models and add Moonshot API key

### DIFF
--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -50,25 +50,25 @@ data:
           api_base: https://api.moonshot.ai/v1
           api_key: os.environ/MOONSHOT_API_KEY
 
-      - model_name: gpt-5.5
+      - model_name: chatgpt/gpt-5.5
         model_info:
           mode: responses
         litellm_params:
           model: chatgpt/gpt-5.5
 
-      - model_name: gpt-5.5-mini
+      - model_name: chatgpt/gpt-5.5-mini
         model_info:
           mode: responses
         litellm_params:
           model: chatgpt/gpt-5.5-mini
 
-      - model_name: gpt-5.5-nano
+      - model_name: chatgpt/gpt-5.5-nano
         model_info:
           mode: responses
         litellm_params:
           model: chatgpt/gpt-5.5-nano
 
-      - model_name: gpt-5.3-codex
+      - model_name: chatgpt/gpt-5.3-codex
         model_info:
           mode: responses
         litellm_params:

--- a/kubernetes/apps/base/llm/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/externalsecret.yaml
@@ -14,6 +14,7 @@ spec:
       data:
         LITELLM_MASTER_KEY: "{{ .password }}"
         MINIMAX_API_KEY: "{{ .MINIMAX_API_KEY }}"
+        MOONSHOT_API_KEY: "{{ .MOONSHOT_API_KEY }}"
   dataFrom:
     - extract:
         key: litellm


### PR DESCRIPTION
## Summary

Adds `chatgpt/` prefix to gpt-5.5 model names and adds `MOONSHOT_API_KEY` to the litellm externalsecret.

### Changes

- **configmap.yaml**: Added `chatgpt/` prefix to gpt-5.5, gpt-5.5-mini, gpt-5.5-nano, and gpt-5.3-codex model names
- **externalsecret.yaml**: Added `MOONSHOT_API_KEY` secret reference

### Files changed

- `kubernetes/apps/base/llm/litellm/app/configmap.yaml`
- `kubernetes/apps/base/llm/litellm/app/externalsecret.yaml`