### PR TITLE
litellm: replace gpt-5.5-mini/nano with gpt-5.3-instant

### DIFF
--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -56,17 +56,12 @@ data:
         litellm_params:
           model: chatgpt/gpt-5.5
 
-      - model_name: chatgpt/gpt-5.5-mini
+      - model_name: chatgpt/gpt-5.3-instant
         model_info:
           mode: responses
         litellm_params:
-          model: chatgpt/gpt-5.5-mini
+          model: chatgpt/gpt-5.3-instant
 
-      - model_name: chatgpt/gpt-5.5-nano
-        model_info:
-          mode: responses
-        litellm_params:
-          model: chatgpt/gpt-5.5-nano
 
       - model_name: chatgpt/gpt-5.3-codex
         model_info:


### PR DESCRIPTION
## Summary

Replaces `chatgpt/gpt-5.5-mini` and `chatgpt/gpt-5.5-nano` models with `chatgpt/gpt-5.3-instant`.

### Changes

- **configmap.yaml**:
  - Renamed `chatgpt/gpt-5.5-mini` → `chatgpt/gpt-5.3-instant`
  - Removed `chatgpt/gpt-5.5-nano` model

### Files changed

- `kubernetes/apps/base/llm/litellm/app/configmap.yaml`