### PR TITLE
feat(localai): split models across dedicated pods

### DIFF
--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -23,19 +23,19 @@ data:
       - model_name: localai/gemma4-e4b
         litellm_params:
           model: openai/gemma4_e4b
-          api_base: http://localai.llm:8080/v1
+          api_base: http://localai-gemma4-e4b.llm:8080/v1
           api_key: localai
 
       - model_name: localai/qwen3.5-9b
         litellm_params:
           model: openai/qwen3_5_9b
-          api_base: http://localai.llm:8080/v1
+          api_base: http://localai-qwen3-5-9b.llm:8080/v1
           api_key: localai
 
       - model_name: localai/qwen2.5-coder-7b
         litellm_params:
           model: openai/qwen2_5_coder_7b
-          api_base: http://localai.llm:8080/v1
+          api_base: http://localai-qwen2-5-coder-7b.llm:8080/v1
           api_key: localai
 
       - model_name: minimax/MiniMax-M2.7

--- a/kubernetes/apps/base/llm/localai/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/localai/helmrelease.yaml
@@ -3,7 +3,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: localai
+  name: localai-gemma4-e4b
 spec:
   chartRef:
     kind: OCIRepository
@@ -16,8 +16,75 @@ spec:
         - name: gpu
           resourceClaimTemplateName: localai-gpu
     controllers:
-      localai:
-        replicas: 3
+      localai-gemma4-e4b:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image: &image
+              repository: quay.io/go-skynet/local-ai
+              tag: v4.1.3-gpu-intel@sha256:8fb1248c11ee7379521c7531a42dff696affe010c2b98d8dc55b03e12841a16c
+            env: &env
+              TZ: America/Edmonton
+              DEBUG: "false"
+              LOCALAI_FORCE_META_BACKEND_CAPABILITY: intel
+              LOCALAI_BACKEND_GALLERIES: >-
+                [{"name":"localai","url":"https://raw.githubusercontent.com/mudler/LocalAI/master/backend/index.yaml"}]
+              LOCALAI_EXTERNAL_BACKENDS: llama-cpp
+              LOCALAI_MAX_ACTIVE_BACKENDS: "1"
+              LOCALAI_WATCHDOG_IDLE: "false"
+              MODELS_PATH: /models
+              THREADS: "6"
+              ZES_ENABLE_SYSMAN: "1"
+            resources: &resources
+              claims:
+                - name: gpu
+              requests:
+                cpu: 500m
+                memory: 8Gi
+              limits:
+                memory: 16Gi
+    persistence:
+      model-config:
+        type: configMap
+        name: localai-model-gemma4-e4b
+        globalMounts:
+          - path: /models
+            readOnly: true
+      model-data: &modelData
+        existingClaim: localai-models
+        globalMounts:
+          - path: /models-data
+      dev-dri: &devDri
+        type: hostPath
+        hostPath: /dev/dri
+        globalMounts:
+          - path: /dev/dri
+            readOnly: true
+    service:
+      app: &service
+        ports:
+          http:
+            port: 8080
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: localai-qwen3-5-9b
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  dependsOn: []
+  interval: 15m
+  values:
+    defaultPodOptions:
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: localai-gpu
+    controllers:
+      localai-qwen3-5-9b:
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
@@ -32,9 +99,9 @@ spec:
               LOCALAI_BACKEND_GALLERIES: >-
                 [{"name":"localai","url":"https://raw.githubusercontent.com/mudler/LocalAI/master/backend/index.yaml"}]
               LOCALAI_EXTERNAL_BACKENDS: llama-cpp
-              LOCALAI_MAX_ACTIVE_BACKENDS: "3"
+              LOCALAI_MAX_ACTIVE_BACKENDS: "1"
               LOCALAI_WATCHDOG_IDLE: "false"
-              MODELS_PATH: &modelPath /models
+              MODELS_PATH: /models
               THREADS: "6"
               ZES_ENABLE_SYSMAN: "1"
             resources:
@@ -46,10 +113,84 @@ spec:
               limits:
                 memory: 16Gi
     persistence:
-      models:
+      model-config:
+        type: configMap
+        name: localai-model-qwen3-5-9b
+        globalMounts:
+          - path: /models
+            readOnly: true
+      model-data:
         existingClaim: localai-models
         globalMounts:
-          - path: *modelPath
+          - path: /models-data
+      dev-dri:
+        type: hostPath
+        hostPath: /dev/dri
+        globalMounts:
+          - path: /dev/dri
+            readOnly: true
+    service:
+      app:
+        ports:
+          http:
+            port: 8080
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: localai-qwen2-5-coder-7b
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  dependsOn: []
+  interval: 15m
+  values:
+    defaultPodOptions:
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: localai-gpu
+    controllers:
+      localai-qwen2-5-coder-7b:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: quay.io/go-skynet/local-ai
+              tag: v4.1.3-gpu-intel@sha256:8fb1248c11ee7379521c7531a42dff696affe010c2b98d8dc55b03e12841a16c
+            env:
+              TZ: America/Edmonton
+              DEBUG: "false"
+              LOCALAI_FORCE_META_BACKEND_CAPABILITY: intel
+              LOCALAI_BACKEND_GALLERIES: >-
+                [{"name":"localai","url":"https://raw.githubusercontent.com/mudler/LocalAI/master/backend/index.yaml"}]
+              LOCALAI_EXTERNAL_BACKENDS: llama-cpp
+              LOCALAI_MAX_ACTIVE_BACKENDS: "1"
+              LOCALAI_WATCHDOG_IDLE: "false"
+              MODELS_PATH: /models
+              THREADS: "6"
+              ZES_ENABLE_SYSMAN: "1"
+            resources:
+              claims:
+                - name: gpu
+              requests:
+                cpu: 500m
+                memory: 8Gi
+              limits:
+                memory: 16Gi
+    persistence:
+      model-config:
+        type: configMap
+        name: localai-model-qwen2-5-coder-7b
+        globalMounts:
+          - path: /models
+            readOnly: true
+      model-data:
+        existingClaim: localai-models
+        globalMounts:
+          - path: /models-data
       dev-dri:
         type: hostPath
         hostPath: /dev/dri

--- a/kubernetes/apps/base/llm/localai/models/README.md
+++ b/kubernetes/apps/base/llm/localai/models/README.md
@@ -9,15 +9,15 @@ This directory manages LocalAI model definitions and artifact sync jobs with Flu
 
 ## Managed Models
 
-- `qwen3_5_9b`: downloads `Qwen3.5-9B-heretic.Q4_K_M.gguf` and `mmproj-F16.gguf` into `/models/qwen-vision`.
-- `gemma4_e4b`: downloads `gemma-4-E4B-it-UD-Q4_K_XL.gguf` into `/models/memory`.
-- `qwen2_5_coder_7b`: downloads `Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf` into `/models/qwen2-5-coder-7b`.
+- `qwen3_5_9b`: downloads `Qwen3.5-9B-heretic.Q4_K_M.gguf` and `mmproj-F16.gguf` into `/models-data/qwen-vision`.
+- `gemma4_e4b`: downloads `gemma-4-E4B-it-UD-Q4_K_XL.gguf` into `/models-data/memory`.
+- `qwen2_5_coder_7b`: downloads `Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf` into `/models-data/qwen2-5-coder-7b`.
 
 ## How To Add A Model
 
 1. Add a new `<model>.yaml` file containing a model ConfigMap and sync Job.
-2. Configure the sync Job to download artifacts into `/models` on the `localai-models` PVC.
-3. Copy the model config file from `/config` to `/models` after download.
+2. Configure the sync Job to download artifacts into `/models-data` on the `localai-models` PVC.
+3. Mount the model ConfigMap into the matching LocalAI HelmRelease at `/models`.
 4. Add the new file to `kustomization.yaml`.
 
 ## Notes For Intel iGPU

--- a/kubernetes/apps/base/llm/localai/models/gemma4-e4b.yaml
+++ b/kubernetes/apps/base/llm/localai/models/gemma4-e4b.yaml
@@ -20,7 +20,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: localai-model-sync-gemma4-e4b-v3
+  name: localai-model-sync-gemma4-e4b
 spec:
   ttlSecondsAfterFinished: 86400
   backoffLimit: 2

--- a/kubernetes/apps/base/llm/localai/models/gemma4-e4b.yaml
+++ b/kubernetes/apps/base/llm/localai/models/gemma4-e4b.yaml
@@ -9,8 +9,8 @@ data:
     name: gemma4_e4b
     backend: llama-cpp
     parameters:
-      model: memory/gemma-4-E4B-it-UD-Q4_K_XL.gguf
-    mmproj: memory/mmproj-F16.gguf
+      model: /models-data/memory/gemma-4-E4B-it-UD-Q4_K_XL.gguf
+    mmproj: /models-data/memory/mmproj-F16.gguf
     context_size: 131072
     threads: 12
     mmap: false
@@ -20,7 +20,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: localai-model-sync-gemma4-e4b-v2
+  name: localai-model-sync-gemma4-e4b-v3
 spec:
   ttlSecondsAfterFinished: 86400
   backoffLimit: 2
@@ -37,10 +37,9 @@ spec:
             - |
               set -euo pipefail
 
-              target_dir=/models/memory
+              target_dir=/models-data/memory
               model_file="$target_dir/gemma-4-E4B-it-UD-Q4_K_XL.gguf"
               mmproj_file="$target_dir/mmproj-F16.gguf"
-              config_file=gemma4_e4b.yaml
 
               if [ ! -s "$model_file" ] || [ ! -s "$mmproj_file" ]; then
                 pip install --no-cache-dir huggingface_hub
@@ -56,7 +55,6 @@ spec:
                   --local-dir "$target_dir"
               fi
 
-              cp "/config/$config_file" "/models/$config_file"
           env:
             - name: HF_HUB_ENABLE_HF_TRANSFER
               value: "1"
@@ -64,14 +62,9 @@ spec:
             - secretRef:
                 name: huggingface
           volumeMounts:
-            - name: config
-              mountPath: /config
             - name: models
-              mountPath: /models
+              mountPath: /models-data
       volumes:
-        - name: config
-          configMap:
-            name: localai-model-gemma4-e4b
         - name: models
           persistentVolumeClaim:
             claimName: localai-models

--- a/kubernetes/apps/base/llm/localai/models/qwen2-5-coder-7b.yaml
+++ b/kubernetes/apps/base/llm/localai/models/qwen2-5-coder-7b.yaml
@@ -9,7 +9,7 @@ data:
     name: qwen2_5_coder_7b
     backend: llama-cpp
     parameters:
-      model: qwen2-5-coder-7b/Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf
+      model: /models-data/qwen2-5-coder-7b/Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf
     context_size: 32768
     threads: 12
     mmap: false
@@ -36,9 +36,8 @@ spec:
             - |
               set -euo pipefail
 
-              target_dir=/models/qwen2-5-coder-7b
+              target_dir=/models-data/qwen2-5-coder-7b
               model_file="$target_dir/Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf"
-              config_file=qwen2_5_coder_7b.yaml
 
               if [ ! -s "$model_file" ]; then
                 pip install --no-cache-dir huggingface_hub
@@ -50,7 +49,6 @@ spec:
                   --local-dir "$target_dir"
               fi
 
-              cp "/config/$config_file" "/models/$config_file"
           env:
             - name: HF_HUB_ENABLE_HF_TRANSFER
               value: "1"
@@ -58,14 +56,9 @@ spec:
             - secretRef:
                 name: huggingface
           volumeMounts:
-            - name: config
-              mountPath: /config
             - name: models
-              mountPath: /models
+              mountPath: /models-data
       volumes:
-        - name: config
-          configMap:
-            name: localai-model-qwen2-5-coder-7b
         - name: models
           persistentVolumeClaim:
             claimName: localai-models

--- a/kubernetes/apps/base/llm/localai/models/qwen2-5-coder-7b.yaml
+++ b/kubernetes/apps/base/llm/localai/models/qwen2-5-coder-7b.yaml
@@ -19,7 +19,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: localai-model-sync-qwen2-5-coder-7b-v1
+  name: localai-model-sync-qwen2-5-coder-7b
 spec:
   ttlSecondsAfterFinished: 86400
   backoffLimit: 2

--- a/kubernetes/apps/base/llm/localai/models/qwen3-5-9b.yaml
+++ b/kubernetes/apps/base/llm/localai/models/qwen3-5-9b.yaml
@@ -22,7 +22,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: localai-model-sync-qwen3-5-9b-v3
+  name: localai-model-sync-qwen3-5-9b
 spec:
   ttlSecondsAfterFinished: 86400
   backoffLimit: 2

--- a/kubernetes/apps/base/llm/localai/models/qwen3-5-9b.yaml
+++ b/kubernetes/apps/base/llm/localai/models/qwen3-5-9b.yaml
@@ -9,8 +9,8 @@ data:
     name: qwen3_5_9b
     backend: llama-cpp
     parameters:
-      model: qwen-vision/Qwen3.5-9B-heretic.Q4_K_M.gguf
-    mmproj: qwen-vision/mmproj-F16.gguf
+      model: /models-data/qwen-vision/Qwen3.5-9B-heretic.Q4_K_M.gguf
+    mmproj: /models-data/qwen-vision/mmproj-F16.gguf
     context_size: 131072
     threads: 12
     mmap: false
@@ -22,7 +22,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: localai-model-sync-qwen3-5-9b-v2
+  name: localai-model-sync-qwen3-5-9b-v3
 spec:
   ttlSecondsAfterFinished: 86400
   backoffLimit: 2
@@ -39,10 +39,9 @@ spec:
             - |
               set -euo pipefail
 
-              target_dir=/models/qwen-vision
+              target_dir=/models-data/qwen-vision
               model_file="$target_dir/Qwen3.5-9B-heretic.Q4_K_M.gguf"
               mmproj_file="$target_dir/mmproj-F16.gguf"
-              config_file=qwen3_5_9b.yaml
 
               if [ ! -s "$model_file" ] || [ ! -s "$mmproj_file" ]; then
                 pip install --no-cache-dir huggingface_hub
@@ -58,7 +57,6 @@ spec:
                   --local-dir "$target_dir"
               fi
 
-              cp "/config/$config_file" "/models/$config_file"
           env:
             - name: HF_HUB_ENABLE_HF_TRANSFER
               value: "1"
@@ -66,14 +64,9 @@ spec:
             - secretRef:
                 name: huggingface
           volumeMounts:
-            - name: config
-              mountPath: /config
             - name: models
-              mountPath: /models
+              mountPath: /models-data
       volumes:
-        - name: config
-          configMap:
-            name: localai-model-qwen3-5-9b
         - name: models
           persistentVolumeClaim:
             claimName: localai-models


### PR DESCRIPTION
## Summary
- Splits LocalAI into one HelmRelease per model so each pod only loads a single model config.
- Keeps shared GGUF artifacts on the RWX `localai-models` PVC mounted at `/models-data`.
- Updates LiteLLM localai aliases to target the per-model LocalAI services directly.

## Notes
- I checked the existing Crunchy Postgres overlay and Authentik Terraform patterns. Full LocalAI distributed/router mode would require adding per-app PostgreSQL state, NATS, and auth, so this PR uses the lighter deterministic split-pod topology instead.

## Validation
- `/Users/joryirving/.local/share/mise/installs/pipx-flux-local/8.1.0/bin/flux-local test --enable-helm --path ./kubernetes/clusters/main`