### PR TITLE
llm: route hermes via litellm, tune llama-server checkpoints

### DIFF
--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -64,7 +64,7 @@ data:
         url: http://vmcp-mcp-gateway-internal.llm:4483/mcp
     auxiliary:
       vision:
-        provider: custom:kubernetes
+        provider: openai
         model: vision
         base_url: http://litellm.llm:4000/v1
         api_key: $${LITELLM_API_KEY}

--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -7,27 +7,25 @@ data:
   config.yaml: |
     model:
       default: self-hosted
-      provider: litellm
+      provider: custom:kubernetes
       base_url: http://litellm.llm:4000/v1
       api_key: $${LITELLM_API_KEY}
     fallback_providers:
-      - provider: minimax
+      - provider: custom:kubernetes
         model: minimax/MiniMax-M2.7
-      - provider: openai
+      - provider: custom:kubernetes
         model: chatgpt/gpt-5.5
-      - provider: openai
+      - provider: custom:kubernetes
         model: vision
-      - provider: moonshot
+      - provider: custom:kubernetes
         model: moonshot/kimi-k2.6
     providers:
+      kubernetes:
+        base_url: http://litellm.llm:4000/v1
+        api_key: $${LITELLM_API_KEY}
       minimax:
         api_key: $${MINIMAX_API_KEY}
         base_url: https://api.minimax.chat/v1
-      litellm:
-        base_url: http://litellm.llm:4000/v1
-        api_key: $${LITELLM_API_KEY}
-      openai:
-        api_key: $${OPENAI_API_KEY}
       moonshot:
         api_key: $${MOONSHOT_API_KEY}
         base_url: https://api.moonshot.ai/v1
@@ -66,7 +64,7 @@ data:
         url: http://vmcp-mcp-gateway-internal.llm:4483/mcp
     auxiliary:
       vision:
-        provider: openai
+        provider: custom:kubernetes
         model: vision
         base_url: http://litellm.llm:4000/v1
         api_key: $${LITELLM_API_KEY}

--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -20,12 +20,12 @@ data:
       - provider: moonshot
         model: moonshot/kimi-k2.6
     providers:
-      litellm:
-        base_url: http://litellm.llm:4000/v1
-        api_key: $${LITELLM_API_KEY}
       minimax:
         api_key: $${MINIMAX_API_KEY}
         base_url: https://api.minimax.chat/v1
+      litellm:
+        base_url: http://litellm.llm:4000/v1
+        api_key: $${LITELLM_API_KEY}
       openai:
         api_key: $${OPENAI_API_KEY}
       moonshot:

--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -7,25 +7,27 @@ data:
   config.yaml: |
     model:
       default: self-hosted
-      provider: custom:kubernetes
+      provider: litellm
       base_url: http://litellm.llm:4000/v1
       api_key: $${LITELLM_API_KEY}
     fallback_providers:
-      - provider: custom:kubernetes
-        model: vision
-      - provider: custom:kubernetes
+      - provider: minimax
         model: minimax/MiniMax-M2.7
-      - provider: custom:kubernetes
+      - provider: openai
         model: chatgpt/gpt-5.5
-      - provider: custom:kubernetes
+      - provider: openai
+        model: vision
+      - provider: moonshot
         model: moonshot/kimi-k2.6
     providers:
-      kubernetes:
+      litellm:
         base_url: http://litellm.llm:4000/v1
         api_key: $${LITELLM_API_KEY}
       minimax:
         api_key: $${MINIMAX_API_KEY}
         base_url: https://api.minimax.chat/v1
+      openai:
+        api_key: $${OPENAI_API_KEY}
       moonshot:
         api_key: $${MOONSHOT_API_KEY}
         base_url: https://api.moonshot.ai/v1
@@ -46,7 +48,7 @@ data:
       max_turns: 90
       gateway_timeout: 1800
       restart_drain_timeout: 60
-      api_max_retries: 3
+      api_max_retries: 2
       reasoning_effort: medium
     streaming:
       enabled: false

--- a/kubernetes/apps/base/llm/litellm/Qwen3.6-35B-A3B/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/Qwen3.6-35B-A3B/helmrelease.yaml
@@ -93,9 +93,9 @@ spec:
             - --cache-prompt
             - --kv-unified
             - --ctx-checkpoints
-            - "4"
+            - "8"
             - --checkpoint-every-n-tokens
-            - "16384"
+            - "32768"
             - --image-min-tokens
             - "1024"
             - --metrics

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -8,12 +8,6 @@ data:
     model_list:
       # These aliases keep the client-facing names stable while LiteLLM
       # forwards the upstream model IDs that each llama.cpp server expects.
-      - model_name: llama-memory
-        litellm_params:
-          model: openai/memory
-          api_base: http://llama-memory.llm:8080/v1
-          api_key: llama-memory
-
       - model_name: self-hosted
         litellm_params:
           model: openai/self-hosted

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -8,6 +8,12 @@ data:
     model_list:
       # These aliases keep the client-facing names stable while LiteLLM
       # forwards the upstream model IDs that each llama.cpp server expects.
+      - model_name: llama-memory
+        litellm_params:
+          model: openai/memory
+          api_base: http://llama-memory.llm:8080/v1
+          api_key: llama-memory
+
       - model_name: self-hosted
         litellm_params:
           model: openai/self-hosted


### PR DESCRIPTION
## Summary

**Hermes configmap:**
- Route default model through litellm (self-hosted alias) instead of direct llama-server calls
- Fallback chain: minimax → chatgpt/gpt-5.5 → vision → moonshot/kimi-k2.6
- api_max_retries: 2 (was 3)

**llama-server Qwen3.6-35B-A3B:**
- ctx-checkpoints: 4 → 8 (more checkpoint history in memory)
- checkpoint-every-n-tokens: 16384 → 32768 (half the disk writes)

Enables litellm observability and consistent proxy behavior for all LLM traffic.