### PR TITLE
Update OpenClaw to 2026.5.3-1

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -16,7 +16,7 @@ data:
           model: {
             primary: "minimax/MiniMax-M2.7",
             fallbacks: [
-              "openai-codex/gpt-5.4-mini",
+              "openai/gpt-5.4-mini",
               "litellm/self-hosted",
             ]
           },
@@ -24,7 +24,7 @@ data:
             primary: "litellm/vision",
             fallbacks: [
               "litellm/self-hosted",
-              "openai-codex/gpt-5.4-mini",
+              "openai/gpt-5.4-mini",
             ]
           },
           imageGenerationModel: {
@@ -34,9 +34,9 @@ data:
             "moonshot/kimi-k2.5": { alias: "moonshot" },
             "minimax/MiniMax-M2.7": { alias: "minimax" },
             "litellm/self-hosted": { alias: "skirk", params: { cache_prompt: true } },
-            "openai-codex/gpt-5.5": { alias: "gpt" },
-            "openai-codex/gpt-5.4-mini": { alias: "gpt-mini" },
-            "openai-codex/gpt-5.4-nano": { alias: "gpt-lite" },
+            "openai/gpt-5.5": { alias: "gpt" },
+            "openai/gpt-5.4-mini": { alias: "gpt-mini" },
+            "openai/gpt-5.4-nano": { alias: "gpt-lite" },
             "openai-codex/gpt-5.3-codex": { alias: "gpt-coder" },
             "litellm/vision": { alias: "vision" },
           },
@@ -93,9 +93,9 @@ data:
     
             model: {
               primary: "minimax/MiniMax-M2.7",
-            fallbacks: [
+              fallbacks: [
                 "litellm/self-hosted",
-                "openai-codex/gpt-5.4-mini",
+                "openai/gpt-5.4-mini",
               ]
             },
             identity: {
@@ -115,7 +115,7 @@ data:
               primary: "litellm/self-hosted",
               fallbacks: [
                 "minimax/MiniMax-M2.7",
-                "openai-codex/gpt-5.5",
+                "openai/gpt-5.5",
               ]
             },
             identity: {
@@ -228,21 +228,6 @@ data:
         },
       },
       plugins: {
-        allow: [
-          "comfy",
-          "composio",
-          "discord",
-          "lossless-claw",
-          "memory-core",
-          "openclaw-better-gateway",
-          "openclaw-mcp-bridge",
-          "searxng",
-          "memory-wiki",
-          "minimax",
-          "openai",
-          "moonshot",
-          "browser",
-        ],
         entries: {
           discord: { enabled: true },
           comfy: {

--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -79,7 +79,7 @@ spec:
           app:
             image:
               repository: ghcr.io/openclaw/openclaw
-              tag: 2026.4.24@sha256:7c4370ff8777555d4c9fe5ab821aaaad7c87188d389a6cf761270725d96ec3e9
+              tag: 2026.5.3-1@sha256:142f70fa2751bdedf03648ae427372fff3f92ac0e96ab91abb3824b088c38b7b
             command:
             - /bin/sh
             - -c


### PR DESCRIPTION
## Summary
- Update OpenClaw to the 2026.5.3-1 stable hotfix image.
- Move current OpenAI/Codex model routes to the canonical OpenAI provider prefix while preserving the legacy GPT coder alias for runtime validation.
- Remove the restrictive plugin allowlist so bundled/plugin-migrated functionality can continue to resolve during OpenClaw's plugin split.

## Validation
- flux-local test --enable-helm --path ./kubernetes/clusters/main

## Notes
- No rendered secrets or secret values are included in this PR description.
- After deploy, run OpenClaw doctor/plugin validation inside the pod before deciding whether to mirror any runtime migrations back to Git.