### PR TITLE
feat(database): install CloudNativePG operator

### DIFF
--- a/kubernetes/apps/base/database/cloudnative-pg/helmrelease.yaml
+++ b/kubernetes/apps/base/database/cloudnative-pg/helmrelease.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cloudnative-pg
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.28.2
+  url: oci://ghcr.io/cloudnative-pg/charts/cloudnative-pg
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app cloudnative-pg
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 15m
+  dependsOn: []
+  values:
+    crds:
+      create: true
+    monitoring:
+      podMonitorEnabled: true
+      grafanaDashboard:
+        create: true
+        labels:
+          grafana_dashboard: "1"

--- a/kubernetes/apps/base/database/cloudnative-pg/kustomization.yaml
+++ b/kubernetes/apps/base/database/cloudnative-pg/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/main/database/cloudnative-pg.yaml
+++ b/kubernetes/apps/main/database/cloudnative-pg.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloudnative-pg
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/database/cloudnative-pg
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/kubernetes/apps/main/database/kustomization.yaml
+++ b/kubernetes/apps/main/database/kustomization.yaml
@@ -8,5 +8,6 @@ components:
 replacements:
   - path: ../../../components/replacements/ks.yaml
 resources:
+  - ./cloudnative-pg.yaml
   - ./crunchy-postgres.yaml
   - ./dragonfly.yaml


### PR DESCRIPTION
## Summary
- Installs the cloudnative-pg operator (chart `0.28.2`) into the `database` namespace alongside the existing crunchy-postgres-operator
- Phase 0 of the CPGO → CNPG migration; no-op on running workloads
- The two operators watch different CRD groups (`postgres-operator.crunchydata.com` vs `postgresql.cnpg.io`) so they coexist without conflict

## Test plan
- [ ] Flux reconciles `cloudnative-pg` Kustomization
- [ ] Operator pod becomes `Running` in `database` namespace
- [ ] `kubectl get crd | grep cnpg.io` shows the new CRDs
- [ ] Existing CPGO operator + PostgresClusters remain healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)