### PR TITLE
feat(database): postgres-cnpg component + open-webui pilot (additive)

### DIFF
--- a/kubernetes/apps/main/llm/open-webui.yaml
+++ b/kubernetes/apps/main/llm/open-webui.yaml
@@ -4,10 +4,13 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &app open-webui
+  labels:
+    components.postgres/cnpg: init
 spec:
   components:
     - ../../../../components/dragonfly
     - ../../../../components/postgres
+    - ../../../../components/postgres-cnpg
     - ../../../../components/volsync
   dependsOn:
     - name: searxng
@@ -20,6 +23,10 @@ spec:
       kind: PostgresCluster
       failed: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'True')
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/llm/open-webui
   postBuild:

--- a/kubernetes/clusters/main/apps.yaml
+++ b/kubernetes/clusters/main/apps.yaml
@@ -174,3 +174,29 @@ spec:
       target:
         kind: Kustomization
         labelSelector: "components.postgres/cpgo=init"
+    - # Bootstrap CNPG cluster (initdb instead of recovery from Barman)
+      # $${...} escape preserves the variable through outer (cluster-apps) substitution
+      # so the inner (app) Kustomization's postBuild can resolve APP/USERNAME.
+      patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: not-used
+        spec:
+          patches:
+            - target:
+                group: postgresql.cnpg.io
+                version: v1
+                kind: Cluster
+              patch: |-
+                - op: replace
+                  path: /spec/bootstrap
+                  value:
+                    initdb:
+                      database: $${APP}
+                      owner: $${USERNAME:=$${APP}}
+                - op: remove
+                  path: /spec/externalClusters
+      target:
+        kind: Kustomization
+        labelSelector: "components.postgres/cnpg=init"

--- a/kubernetes/components/postgres-cnpg/README.md
+++ b/kubernetes/components/postgres-cnpg/README.md
@@ -1,0 +1,49 @@
+# postgres-cnpg
+
+CloudNativePG-backed Postgres component. Migration target for the existing `components/postgres` (CrunchyData PGO), which is being phased out due to the Snowflake acquisition.
+
+## Substitution variables
+
+| Variable    | Default                  | Notes                                                                 |
+|-------------|--------------------------|-----------------------------------------------------------------------|
+| `APP`       | _(required)_             | Name of the consuming app — used for cluster, secret, backup paths.   |
+| `USERNAME`  | `${APP}`                 | App-level role (only honored on initial `initdb` bootstrap).          |
+| `DATABASES` | `["${APP}"]`             | Reserved for future use (single-DB initdb today).                     |
+
+## Bootstrap behavior
+
+Default: the cluster bootstraps via `recovery` from the Barman archive at `s3://postgresql/${APP}` (Garage). This means a torn-down cluster will rebuild itself from the last backup.
+
+For a brand-new app (no backup yet exists), add the `components.postgres/cnpg: init` label to the consuming Flux Kustomization. A patch in `clusters/main/apps.yaml` swaps `bootstrap.recovery` for `bootstrap.initdb` so the cluster comes up empty. Remove the label once the app is live and the first backup has completed.
+
+## Connecting from an app
+
+CNPG generates a `${APP}-app` Secret with these keys: `uri`, `jdbc-uri`, `username`, `password`, `host`, `port`, `dbname`, `pgpass`.
+
+The standard pattern in an app-template HelmRelease:
+
+```yaml
+DATABASE_URL:
+  valueFrom:
+    secretKeyRef:
+      name: "{{ .Release.Name }}-app"
+      key: uri
+```
+
+This points directly at the cluster's read-write primary service `${APP}-rw`. There is no PgBouncer/Pooler in this first cut — see _Future work_.
+
+## Health check expression
+
+```yaml
+healthCheckExprs:
+  - apiVersion: postgresql.cnpg.io/v1
+    kind: Cluster
+    failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+    current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+```
+
+## Future work
+
+- **PgBouncer/Pooler** — CNPG's `Pooler` CRD exists but doesn't generate its own connection secret, so adoption needs a wrapper to template `<cluster>-app` creds into a pooler-targeted URI. Re-add once that pattern is settled. Apps that rely on `transaction` pool mode (authentik) will need this before migrating.
+- **Encryption at rest** — Barman supports server-side encryption (`wal.encryption: AES256`); enable once we've verified Garage's SSE behavior.
+- **Promote back to `components/postgres/`** — once every app is migrated and CPGO is decommissioned, rename this folder to `components/postgres/` and update import paths.

--- a/kubernetes/components/postgres-cnpg/cluster.yaml
+++ b/kubernetes/components/postgres-cnpg/cluster.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: ${APP}
+spec:
+  instances: 3
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.4
+  primaryUpdateStrategy: unsupervised
+  enableSuperuserAccess: true
+  minSyncReplicas: 1
+  maxSyncReplicas: 1
+  storage:
+    storageClass: local-hostpath
+    size: 5Gi
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: topology.kubernetes.io/gpus
+                operator: DoesNotExist
+    topologyKey: kubernetes.io/hostname
+    podAntiAffinityType: required
+  postgresql:
+    parameters:
+      max_connections: "500"
+      max_wal_size: "5GB"
+      synchronous_commit: "on"
+  bootstrap:
+    recovery:
+      source: &archive ${APP}-backup-archive
+  externalClusters:
+    - name: *archive
+      barmanObjectStore: &barman
+        destinationPath: s3://postgresql/${APP}
+        endpointURL: https://s3.jory.dev
+        s3Credentials:
+          accessKeyId:
+            name: ${APP}-postgres
+            key: AWS_ACCESS_KEY_ID
+          secretAccessKey:
+            name: ${APP}-postgres
+            key: AWS_SECRET_ACCESS_KEY
+        wal:
+          compression: bzip2
+        data:
+          compression: bzip2
+  backup:
+    barmanObjectStore: *barman
+    retentionPolicy: 7d
+  monitoring:
+    enablePodMonitor: true

--- a/kubernetes/components/postgres-cnpg/externalsecret.yaml
+++ b/kubernetes/components/postgres-cnpg/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name ${APP}-postgres
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: postgresql-bucket

--- a/kubernetes/components/postgres-cnpg/kustomization.yaml
+++ b/kubernetes/components/postgres-cnpg/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./cluster.yaml
+  - ./externalsecret.yaml
+  - ./scheduledbackup.yaml
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+    patch: |-
+      - op: add
+        path: /spec/dependsOn/-
+        value:
+          name: cloudnative-pg
+          namespace: database

--- a/kubernetes/components/postgres-cnpg/scheduledbackup.yaml
+++ b/kubernetes/components/postgres-cnpg/scheduledbackup.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: ${APP}-weekly
+spec:
+  schedule: "0 30 1 * * 0"
+  backupOwnerReference: self
+  cluster:
+    name: ${APP}


### PR DESCRIPTION
## Summary
- Phase 1: adds a reusable `components/postgres-cnpg` Kustomize Component that mirrors the shape of the existing CPGO `components/postgres` against the cnpg.io API group, plus the `components.postgres/cnpg=init` label patch in `clusters/main/apps.yaml` to swap Barman recovery for empty `initdb` on first bootstrap
- Phase 2a: open-webui adopts the new component **alongside** CPGO — both clusters run simultaneously, the new CNPG cluster comes up empty, and `DATABASE_URL` is unchanged so traffic stays on CPGO

This is the safe pre-cutover state. CPGO remains load-bearing for open-webui; nothing else changes for any other app. No data is at risk on merge.

## Why additive
A flag-day swap would prune the CPGO `PostgresCluster` the moment Flux reconciled, taking the data with it. This PR keeps both components active so we can `pg_dump` from CPGO and `pg_restore` into the new CNPG cluster out of band, then flip `DATABASE_URL` in a separate PR.

## After this merges (out-of-band, gated on validation)
1. `pg_dump` from `open-webui-postgres-*` (CPGO primary) → `pg_restore` into the new `open-webui-*` (CNPG)
2. **Validate the same-name rebuild story**: delete `Cluster open-webui`, recreate with same name + `bootstrap.recovery` from the same Barman path. Must come back clean without bumping `serverName` / destination path. This is the gate for migrating any further app.
3. Only if (2) succeeds: follow-up PR flips `DATABASE_URL` secret ref `${APP}-pguser-${APP}` → `${APP}-app`
4. Follow-up PR removes the `components/postgres` line + `cnpg=init` label

## Known trade-offs (documented in `components/postgres-cnpg/README.md`)
- No PgBouncer/Pooler in this first cut. open-webui will connect directly to the cluster's `${APP}-rw` Service. Pooler parity is a tracked follow-up before authentik (which uses `POOL_MODE: transaction`) can migrate.
- No backup encryption-at-rest configured yet — Garage bucket-level encryption still applies. Server-side `AES256` via Barman is a future enable once verified against Garage.

## Test plan
- [ ] `flux-local test --enable-helm --path kubernetes/clusters/main` passes
- [ ] After merge, Flux reconciles the open-webui Kustomization with both Components
- [ ] CPGO `PostgresCluster open-webui` remains `Healthy`
- [ ] CNPG `Cluster open-webui` reaches `Ready` (empty, bootstrapped via `initdb`)
- [ ] open-webui app stays up and continues serving from CPGO
- [ ] (out of band) Same-name rebuild test on the CNPG cluster succeeds — proving the migration's rebuild premise

🤖 Generated with [Claude Code](https://claude.com/claude-code)