### PR TITLE
feat(database): init CNPG clusters for the remaining 10 CPGO apps

### DIFF
--- a/kubernetes/apps/main/downloads/prowlarr.yaml
+++ b/kubernetes/apps/main/downloads/prowlarr.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/postgres
+    - ../../../../components/postgres-cnpg
   dependsOn:
     - name: crunchy-postgres-operator
       namespace: database
@@ -15,6 +16,10 @@ spec:
       kind: PostgresCluster
       failed: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'True')
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/downloads/prowlarr
   postBuild:

--- a/kubernetes/apps/main/downloads/radarr.yaml
+++ b/kubernetes/apps/main/downloads/radarr.yaml
@@ -8,6 +8,7 @@ spec:
   components:
     - ../../../../components/zeroscaler
     - ../../../../components/postgres
+    - ../../../../components/postgres-cnpg
   dependsOn:
     - name: crunchy-postgres-operator
       namespace: database
@@ -16,6 +17,10 @@ spec:
       kind: PostgresCluster
       failed: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'True')
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/downloads/radarr
   postBuild:

--- a/kubernetes/apps/main/downloads/sonarr.yaml
+++ b/kubernetes/apps/main/downloads/sonarr.yaml
@@ -8,6 +8,7 @@ spec:
   components:
     - ../../../../components/zeroscaler
     - ../../../../components/postgres
+    - ../../../../components/postgres-cnpg
   dependsOn:
     - name: crunchy-postgres-operator
       namespace: database
@@ -16,6 +17,10 @@ spec:
       kind: PostgresCluster
       failed: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'True')
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/downloads/sonarr
   postBuild:

--- a/kubernetes/apps/main/games/romm.yaml
+++ b/kubernetes/apps/main/games/romm.yaml
@@ -8,7 +8,17 @@ spec:
   components:
   - ../../../../components/dragonfly
   - ../../../../components/postgres
+  - ../../../../components/postgres-cnpg
   - ../../../../components/volsync
+  healthCheckExprs:
+  - apiVersion: postgres-operator.crunchydata.com/v1beta1
+    kind: PostgresCluster
+    failed: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'False')
+    current: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'True')
+  - apiVersion: postgresql.cnpg.io/v1
+    kind: Cluster
+    failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+    current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/games/romm
   postBuild:

--- a/kubernetes/apps/main/llm/openclaw.yaml
+++ b/kubernetes/apps/main/llm/openclaw.yaml
@@ -76,11 +76,16 @@ metadata:
 spec:
   components:
     - ../../../../../components/postgres
+    - ../../../../../components/postgres-cnpg
   healthCheckExprs:
     - apiVersion: postgres-operator.crunchydata.com/v1beta1
       kind: PostgresCluster
       failed: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'True')
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/llm/openclaw/dispatch
   postBuild:

--- a/kubernetes/apps/main/media/kyoo.yaml
+++ b/kubernetes/apps/main/media/kyoo.yaml
@@ -8,12 +8,17 @@ spec:
   components:
     - ../../../../components/gpu
     - ../../../../components/postgres
+    - ../../../../components/postgres-cnpg
     - ../../../../components/volsync
   healthCheckExprs:
     - apiVersion: postgres-operator.crunchydata.com/v1beta1
       kind: PostgresCluster
       failed: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'True')
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/media/kyoo
   postBuild:

--- a/kubernetes/apps/main/media/seerr.yaml
+++ b/kubernetes/apps/main/media/seerr.yaml
@@ -7,12 +7,17 @@ metadata:
 spec:
   components:
     - ../../../../components/postgres
+    - ../../../../components/postgres-cnpg
     - ../../../../components/volsync
   healthCheckExprs:
     - apiVersion: postgres-operator.crunchydata.com/v1beta1
       kind: PostgresCluster
       failed: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'True')
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/media/seerr
   postBuild:

--- a/kubernetes/apps/main/security/authentik.yaml
+++ b/kubernetes/apps/main/security/authentik.yaml
@@ -7,11 +7,16 @@ metadata:
 spec:
   components:
     - ../../../../components/postgres
+    - ../../../../components/postgres-cnpg
   healthCheckExprs:
     - apiVersion: postgres-operator.crunchydata.com/v1beta1
       kind: PostgresCluster
       failed: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'True')
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/security/authentik
   postBuild:

--- a/kubernetes/apps/main/self-hosted/paperless.yaml
+++ b/kubernetes/apps/main/self-hosted/paperless.yaml
@@ -9,6 +9,7 @@ spec:
     - ../../../../components/dragonfly
     - ../../../../components/zeroscaler
     - ../../../../components/postgres
+    - ../../../../components/postgres-cnpg
     - ../../../../components/volsync
   healthCheckExprs:
     - apiVersion: dragonflydb.io/v1alpha1
@@ -19,6 +20,10 @@ spec:
       kind: PostgresCluster
       failed: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'True')
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/paperless
   postBuild:

--- a/kubernetes/apps/main/workadventure/synapse.yaml
+++ b/kubernetes/apps/main/workadventure/synapse.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/postgres
+    - ../../../../components/postgres-cnpg
     - ../../../../components/volsync
   dependsOn:
     - name: crunchy-postgres-operator
@@ -16,6 +17,10 @@ spec:
       kind: PostgresCluster
       failed: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'False')
       current: status.conditions.filter(e, e.type == 'ProxyAvailable').all(e, e.status == 'True')
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/workadventure/synapse
   postBuild:


### PR DESCRIPTION
## Summary

Additive sweep — adds `components/postgres-cnpg` alongside `components/postgres` for the ten remaining CPGO apps. Each app now declares both Components; CPGO stays load-bearing while CNPG comes up empty and imports data from CPGO via the component's `bootstrap.initdb.import` default. Pure additive: **no `DATABASE_URL` changes in this PR**.

Apps touched:

- `authentik`
- `dispatch` (in `openclaw.yaml`)
- `kyoo`
- `paperless`
- `prowlarr`
- `radarr`
- `romm` (also gained a `healthCheckExprs` block it was missing)
- `seerr`
- `sonarr`
- `synapse`

## How the import works

The `components/postgres-cnpg` Component already on `main` (PR #7111 + follow-up fixes) defaults to `bootstrap.initdb.import` from `${APP}-primary` (CPGO's headless primary svc, same namespace short-DNS), using CPGO's own `${APP}-pguser-postgres` secret for creds. CNPG runs `pg_dump | pg_restore` natively during initdb. `pgDumpExtraOptions` skips the `pg_stat_statements`/`pgaudit` extensions and `pgbouncer` schema (proven on open-webui).

## Expected reconcile behavior

For each of the 10 apps, on merge:

1. Flux applies the updated `kustomization.yaml`, which now references both Components.
2. CNPG creates a fresh 3-instance Cluster (`${APP}`) in the app's namespace.
3. `initdb` runs against the live CPGO primary, importing the `${APP}` database.
4. CNPG starts archiving WAL + base backups to `s3://postgresql/${APP}/${APP}/`.
5. App pod continues talking to CPGO — `DATABASE_URL` is unchanged.

`Cluster in healthy state` (3/3 ready) is the gate before we open the cutover PR.

## Known follow-ups (not in this PR)

- **Cutover PR**: flip each app's `DATABASE_URL` secret ref from `${APP}-pguser-${APP}/pgbouncer-uri` → `${APP}-app/uri`.
- **Pooler/PgBouncer parity**: authentik uses `POOL_MODE: transaction`. Direct connection works for the import, but cutover for authentik specifically may want a Pooler — TBD when we draft the cutover PR.
- **CPGO decommission**: after spot-checking a few cut-over apps stay healthy for a soak window, drop `components/postgres` references + Barman path cleanup.

## Test plan

- [ ] `flux-local test --enable-helm --path kubernetes/clusters/main` passes (verified locally)
- [ ] Flux reconciles each app's Kustomization without error
- [ ] CNPG Cluster reaches `Ready` for all 10 apps
- [ ] Spot-check rowcounts on at least 3 apps (e.g. authentik, paperless, synapse) match CPGO source
- [ ] CPGO clusters remain healthy throughout
- [ ] No app pod is restarted (DATABASE_URL unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)