### PR TITLE
feat(database): cutover the remaining 10 apps from CPGO to CNPG

### DIFF
--- a/kubernetes/apps/base/downloads/prowlarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/prowlarr/helmrelease.yaml
@@ -36,12 +36,12 @@ spec:
               PROWLARR__AUTH__REQUIRED: DisabledForLocalAddresses
               PROWLARR__LOG__DBENABLED: "False"
               PROWLARR__LOG__LEVEL: info
-              PROWLARR__POSTGRES__HOST: "{{ .Release.Name }}-pgbouncer.downloads.svc"
+              PROWLARR__POSTGRES__HOST: "{{ .Release.Name }}-rw.downloads.svc"
               PROWLARR__POSTGRES__MAINDB: "{{ .Release.Name }}"
               PROWLARR__POSTGRES__PASSWORD:
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-pguser-{{ .Release.Name }}"
+                    name: "{{ .Release.Name }}-app"
                     key: password
               PROWLARR__POSTGRES__PORT: "5432"
               PROWLARR__POSTGRES__USER: "{{ .Release.Name }}"

--- a/kubernetes/apps/base/downloads/radarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/radarr/helmrelease.yaml
@@ -35,12 +35,12 @@ spec:
               RADARR__AUTH__REQUIRED: DisabledForLocalAddresses
               RADARR__LOG__DBENABLED: "False"
               RADARR__LOG__LEVEL: info
-              RADARR__POSTGRES__HOST: "{{ .Release.Name }}-pgbouncer.downloads.svc"
+              RADARR__POSTGRES__HOST: "{{ .Release.Name }}-rw.downloads.svc"
               RADARR__POSTGRES__MAINDB: "{{ .Release.Name }}"
               RADARR__POSTGRES__PASSWORD:
                 valueFrom:
                   secretKeyRef:
-                    name: radarr-pguser-radarr
+                    name: radarr-app
                     key: password
               RADARR__POSTGRES__PORT: "5432"
               RADARR__POSTGRES__USER: "{{ .Release.Name }}"

--- a/kubernetes/apps/base/downloads/sonarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/sonarr/helmrelease.yaml
@@ -35,12 +35,12 @@ spec:
               SONARR__AUTH__REQUIRED: DisabledForLocalAddresses
               SONARR__LOG__DBENABLED: "False"
               SONARR__LOG__LEVEL: info
-              SONARR__POSTGRES__HOST: "{{ .Release.Name }}-pgbouncer.downloads.svc"
+              SONARR__POSTGRES__HOST: "{{ .Release.Name }}-rw.downloads.svc"
               SONARR__POSTGRES__MAINDB: "{{ .Release.Name }}"
               SONARR__POSTGRES__PASSWORD:
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-pguser-{{ .Release.Name }}"
+                    name: "{{ .Release.Name }}-app"
                     key: password
               SONARR__POSTGRES__PORT: "5432"
               SONARR__POSTGRES__USER: "{{ .Release.Name }}"

--- a/kubernetes/apps/base/games/romm/helmrelease.yaml
+++ b/kubernetes/apps/base/games/romm/helmrelease.yaml
@@ -32,27 +32,27 @@ spec:
               DB_HOST:
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-pguser-{{ .Release.Name }}"
-                    key: pgbouncer-host
+                    name: "{{ .Release.Name }}-app"
+                    key: host
               DB_PORT:
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-pguser-{{ .Release.Name }}"
-                    key: pgbouncer-port
+                    name: "{{ .Release.Name }}-app"
+                    key: port
               DB_USER:
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-pguser-{{ .Release.Name }}"
-                    key: user
+                    name: "{{ .Release.Name }}-app"
+                    key: username
               DB_PASSWD:
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-pguser-{{ .Release.Name }}"
+                    name: "{{ .Release.Name }}-app"
                     key: password
               DB_NAME:
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-pguser-{{ .Release.Name }}"
+                    name: "{{ .Release.Name }}-app"
                     key: dbname
               DISABLE_DOWNLOAD_ENDPOINT_AUTH: true
               DISABLE_USERPASS_LOGIN: false

--- a/kubernetes/apps/base/llm/openclaw/dispatch/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/dispatch/helmrelease.yaml
@@ -24,8 +24,8 @@ spec:
               DATABASE_URL:
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-pguser-{{ .Release.Name }}"
-                    key: pgbouncer-uri
+                    name: "{{ .Release.Name }}-app"
+                    key: uri
             envFrom:
               - secretRef:
                   name: dispatch

--- a/kubernetes/apps/base/media/kyoo/helmrelease.yaml
+++ b/kubernetes/apps/base/media/kyoo/helmrelease.yaml
@@ -161,11 +161,11 @@ spec:
         reloader.stakater.com/auto: "true"
       postgres:
         shared:
-          host: kyoo-pgbouncer.media.svc
+          host: kyoo-rw.media.svc
           port: 5432
           databaseOverride: *app
-          existingSecret: kyoo-pguser-kyoo
-          userKey: user
+          existingSecret: kyoo-app
+          userKey: username
           passwordKey: password
         kyoo_api:
           sslmode: ${SSLMODE}

--- a/kubernetes/apps/base/media/seerr/helmrelease.yaml
+++ b/kubernetes/apps/base/media/seerr/helmrelease.yaml
@@ -30,13 +30,13 @@ spec:
                 v3.2.0@sha256:c4cbd5121236ac2f70a843a0b920b68a27976be57917555f1c45b08a1e6b2aad
             env:
               DB_TYPE: "postgres"
-              DB_HOST: "{{ .Release.Name }}-pgbouncer.media.svc"
+              DB_HOST: "{{ .Release.Name }}-rw.media.svc"
               DB_PORT: "5432"
               DB_USER: "{{ .Release.Name }}"
               DB_PASS:
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-pguser-{{ .Release.Name }}"
+                    name: "{{ .Release.Name }}-app"
                     key: password
               DB_NAME: "{{ .Release.Name }}"
               LOG_LEVEL: "info"

--- a/kubernetes/apps/base/security/authentik/helmrelease.yaml
+++ b/kubernetes/apps/base/security/authentik/helmrelease.yaml
@@ -34,13 +34,13 @@ spec:
       - name: AUTHENTIK_POSTGRESQL__NAME
         value: *app
       - name: AUTHENTIK_POSTGRESQL__HOST
-        value: authentik-pgbouncer.security.svc   #Authentik requires transaction for pgBouncer
+        value: authentik-rw.security.svc
       - name: AUTHENTIK_POSTGRESQL__USER
         value: *app
       - name: AUTHENTIK_POSTGRESQL__PASSWORD
         valueFrom:
           secretKeyRef:
-            name: authentik-pguser-authentik
+            name: authentik-app
             key: password
       - name: AUTHENTIK_POSTGRESQL__USE_PGBOUNCER
         value: "true"

--- a/kubernetes/apps/base/self-hosted/paperless/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/paperless/helmrelease.yaml
@@ -36,12 +36,12 @@ spec:
               PAPERLESS_DBENGINE: postgresql
               PAPERLESS_DBPORT: "5432"
               PAPERLESS_DBNAME: "{{ .Release.Name }}"
-              PAPERLESS_DBHOST: "{{ .Release.Name }}-pgbouncer.self-hosted.svc"
+              PAPERLESS_DBHOST: "{{ .Release.Name }}-rw.self-hosted.svc"
               PAPERLESS_DBUSER: "{{ .Release.Name }}"
               PAPERLESS_DBPASS:
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-pguser-{{ .Release.Name }}"
+                    name: "{{ .Release.Name }}-app"
                     key: password
               # Remote User Auth
               PAPERLESS_ACCOUNT_ALLOW_SIGNUPS: "false"

--- a/kubernetes/apps/base/workadventure/synapse/externalsecret.yaml
+++ b/kubernetes/apps/base/workadventure/synapse/externalsecret.yaml
@@ -54,7 +54,7 @@ spec:
             name: psycopg2
             allow_unsafe_locale: true
             args:
-              host: synapse-pgbouncer.workadventure.svc.cluster.local
+              host: synapse-rw.workadventure.svc.cluster.local
               port: 5432
               user: synapse
               database: synapse

--- a/kubernetes/apps/base/workadventure/synapse/helmrelease.yaml
+++ b/kubernetes/apps/base/workadventure/synapse/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
               PGPASSWORD:
                 valueFrom:
                   secretKeyRef:
-                    name: "{{ .Release.Name }}-pguser-{{ .Release.Name }}"
+                    name: "{{ .Release.Name }}-app"
                     key: password
             ports:
               - name: http


### PR DESCRIPTION
## Summary

Cutover PR — flips connection params on all remaining apps from CPGO's `${APP}-pguser-${APP}` (via the `${APP}-pgbouncer` service) to CNPG's `${APP}-app` (via the `${APP}-rw` primary service). After PR #7113 brought up 10 CNPG clusters with imported data and a soak, this PR is what actually moves traffic. open-webui was already cut over in 157e992a; this PR completes the sweep.

Apps cut over:

- `authentik`
- `dispatch`
- `kyoo`
- `paperless`
- `prowlarr`
- `radarr`
- `romm`
- `seerr`
- `sonarr`
- `synapse`

## Changes per pattern

**Simple HOST + password secret** (authentik, paperless, prowlarr, radarr, sonarr, seerr):
- `${APP}-pgbouncer.${NS}.svc` → `${APP}-rw.${NS}.svc`
- `${APP}-pguser-${APP}` → `${APP}-app`

**Multi-key secret references** (romm — 5 env vars):
- Secret name retargets to `${APP}-app`
- Key renames where CNPG uses different schema:
  - `pgbouncer-host` → `host`
  - `pgbouncer-port` → `port`
  - `user` → `username` ← CNPG's key
  - `password` / `dbname` unchanged

**DATABASE_URL** (dispatch):
- `pgbouncer-uri` → `uri`

**Chart `existingSecret` pattern** (kyoo):
- Host + secret name swap
- `userKey: user` → `userKey: username`

**Inline config in ExternalSecret** (synapse):
- `homeserver.yaml`'s `host:` line updated alongside the regular `PGPASSWORD` env

## Notable

- **No Pooler.** Everything connects direct to `${APP}-rw`. authentik still has `AUTHENTIK_POSTGRESQL__USE_PGBOUNCER: "true"` — harmless with direct CNPG (just disables prepared statements). Revisit when/if a Pooler ships.
- **CPGO still in place.** Each app's Flux Kustomization still references `components/postgres` AND `components/postgres-cnpg`. CPGO PostgresClusters keep running, idle. Per-app rollback is a one-line revert of the secret/host change. CPGO decommission ships in a follow-up PR after a soak.
- **Reloader** annotations are already set on each app's HelmRelease/deploy — secret-ref changes trigger pod rolls automatically, no manual intervention needed.

## Test plan

- [ ] `flux-local test --enable-helm --path kubernetes/clusters/main` passes (verified locally)
- [ ] Flux reconciles each HelmRelease and rolls each app's deploy
- [ ] All 10 apps come back to Ready
- [ ] Spot-check on critical paths:
  - [ ] authentik can serve OIDC logins (this one's the biggest blast radius)
  - [ ] sonarr/radarr show their library counts
  - [ ] paperless can list docs
  - [ ] synapse responds to homeserver requests
- [ ] CPGO PostgresClusters remain `Healthy` but idle (no connections)

## Rollback

Per-app: `git revert` just the relevant file. App's Reloader re-rolls the pod back onto CPGO. CPGO cluster is untouched throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)