### PR TITLE
feat: add Promxy as cross-cluster Prometheus query fanout

### DIFF
--- a/kubernetes/apps/base/observability/grafana/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/base/observability/grafana/instance/grafanadatasource.yaml
@@ -62,3 +62,18 @@ spec:
     jsonData:
       implementation: prometheus
     url: https://alertmanager-utility.jory.dev
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/grafana.integreatly.org/grafanadatasource_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: &name promxy
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasource:
+    type: prometheus
+    name: *name
+    access: proxy
+    url: http://promxy.observability.svc.cluster.local:8082

--- a/kubernetes/apps/base/observability/promxy/config/config.yaml
+++ b/kubernetes/apps/base/observability/promxy/config/config.yaml
@@ -1,0 +1,23 @@
+promxy:
+  server_groups:
+    # Main cluster Prometheus — the primary data source.
+    # Queries succeed even if this group is the only one available.
+    - static_configs:
+        - targets:
+            - prometheus-operated.observability.svc.cluster.local:9090
+      labels:
+        cluster: main
+      scheme: http
+
+    # Utility cluster Prometheus — queried for cross-cluster dashboards.
+    # ignore_error: true ensures that if the utility cluster is unreachable,
+    # Promxy still returns results from the main cluster instead of failing
+    # the entire query. This is essential for best-effort cross-cluster
+    # Prometheus access without requiring both clusters to be online.
+    - static_configs:
+        - targets:
+            - prometheus-utility.jory.dev
+      labels:
+        cluster: utility
+      scheme: https
+      ignore_error: true

--- a/kubernetes/apps/base/observability/promxy/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/promxy/helmrelease.yaml
@@ -28,10 +28,6 @@ spec:
               tag: "v0.0.93@sha256:9fe586d910f43a00de6044a56e1cc9878aaeb420adb59076f8e6731e2508da3f"
             args:
             - --config.file=/etc/promxy/config.yaml
-            ports:
-              http:
-                enabled: true
-                containerPort: 8082
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/base/observability/promxy/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/promxy/helmrelease.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: promxy
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 15m
+  dependsOn:
+  - name: kube-prometheus-stack
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+    controllers:
+      promxy:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/joryirving/promxy
+              tag: "v0.0.93@sha256:9fe586d910f43a00de6044a56e1cc9878aaeb420adb59076f8e6731e2508da3f"
+            args:
+            - --config.file=/etc/promxy/config.yaml
+            ports:
+              http:
+                enabled: true
+                containerPort: 8082
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+    persistence:
+      config:
+        type: configMap
+        name: "{{ .Release.Name }}-configmap"
+        globalMounts:
+        - path: /etc/promxy/config.yaml
+          subPath: config.yaml
+          readOnly: true
+    service:
+      app:
+        ports:
+          http:
+            port: 8082

--- a/kubernetes/apps/base/observability/promxy/kustomization.yaml
+++ b/kubernetes/apps/base/observability/promxy/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: promxy-configmap
+    files:
+      - config.yaml=./config/config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/main/observability/kustomization.yaml
+++ b/kubernetes/apps/main/observability/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ./kube-prometheus-stack.yaml
   - ./kube-prometheus-stack-scrapeconfig.yaml
   - ./prometheus-adapter.yaml
+  - ./promxy.yaml
   - ./silence-operator.yaml
   - ./silences.yaml
   - ./victoria-logs.yaml

--- a/kubernetes/apps/main/observability/promxy.yaml
+++ b/kubernetes/apps/main/observability/promxy.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: promxy
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/observability/promxy
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
## Summary

Add **Promxy** in the main cluster as a lightweight query fanout layer so Grafana can use a single Prometheus-compatible datasource across both clusters.

## What this does

- Deploys Promxy in the `observability` namespace on the **main** cluster
- Configures two server groups:
  - **main** — `prometheus-operated.observability.svc.cluster.local:9090` (HTTP, primary)
  - **utility** — `prometheus-utility.jory.dev` (HTTPS, best-effort with `ignore_error: true`)
- Adds a `promxy` GrafanaDatasource pointing to the Promxy ClusterIP service

## What this does NOT do

- No `remote_write`, Thanos, Mimir, or VictoriaMetrics
- Main Prometheus does not scrape the utility cluster
- Existing per-cluster datasources are untouched

## Grafana Datasource

| Property | Value |
|---|---|
| Name | promxy |
| URL | http://promxy.observability.svc.cluster.local:8082 |
| Type | prometheus |

## Files changed

- `kubernetes/apps/base/observability/promxy/` — new app (HelmRelease, Kustomization, config)
- `kubernetes/apps/main/observability/promxy.yaml` — Flux Kustomization
- `kubernetes/apps/main/observability/kustomization.yaml` — added promxy resource
- `kubernetes/apps/base/observability/grafana/instance/grafanadatasource.yaml` — added promxy datasource
