### PR TITLE
chore: centralize Kustomization defaults

### DIFF
--- a/kubernetes/apps/base/flux-system/flux-operator/kustomization.yaml
+++ b/kubernetes/apps/base/flux-system/flux-operator/kustomization.yaml
@@ -1,30 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: flux-system
-patches:
-- patch: |-
-    apiVersion: helm.toolkit.fluxcd.io/v2
-    kind: HelmRelease
-    metadata:
-      name: not-used
-    spec:
-      install:
-        crds: CreateReplace
-      rollback:
-        cleanupOnFail: true
-        recreate: true
-      timeout: 10m
-      upgrade:
-        cleanupOnFail: true
-        crds: CreateReplace
-        strategy:
-          name: RemediateOnFailure
-        remediation:
-          remediateLastFailure: true
-          retries: 2
-  target:
-    group: helm.toolkit.fluxcd.io
-    kind: HelmRelease
 resources:
 - ./grafanadashboard.yaml
 - ./helmrelease.yaml

--- a/kubernetes/apps/base/flux-system/headlamp/kustomization.yaml
+++ b/kubernetes/apps/base/flux-system/headlamp/kustomization.yaml
@@ -1,30 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: flux-system
-patches:
-- patch: |-
-    apiVersion: helm.toolkit.fluxcd.io/v2
-    kind: HelmRelease
-    metadata:
-      name: not-used
-    spec:
-      install:
-        crds: CreateReplace
-      rollback:
-        cleanupOnFail: true
-        recreate: true
-      timeout: 10m
-      upgrade:
-        cleanupOnFail: true
-        crds: CreateReplace
-        strategy:
-          name: RemediateOnFailure
-        remediation:
-          remediateLastFailure: true
-          retries: 2
-  target:
-    group: helm.toolkit.fluxcd.io
-    kind: HelmRelease
 resources:
 - ./externalsecret.yaml
 - ./helmrelease.yaml

--- a/kubernetes/apps/base/storage/volsync/kustomization.yaml
+++ b/kubernetes/apps/base/storage/volsync/kustomization.yaml
@@ -1,30 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: storage
-patches:
-- patch: |-
-    apiVersion: helm.toolkit.fluxcd.io/v2
-    kind: HelmRelease
-    metadata:
-      name: not-used
-    spec:
-      install:
-        crds: CreateReplace
-      rollback:
-        cleanupOnFail: true
-        recreate: true
-      timeout: 10m
-      upgrade:
-        cleanupOnFail: true
-        crds: CreateReplace
-        strategy:
-          name: RemediateOnFailure
-        remediation:
-          remediateLastFailure: true
-          retries: 2
-  target:
-    group: helm.toolkit.fluxcd.io
-    kind: HelmRelease
 resources:
 - ./grafanadashboard.yaml
 - ./helmrelease.yaml

--- a/kubernetes/clusters/main/apps.yaml
+++ b/kubernetes/clusters/main/apps.yaml
@@ -27,6 +27,10 @@ spec:
           name: not-used
         spec:
           deletionPolicy: WaitForTermination
+          postBuild:
+            substitute:
+              CLUSTER: ${CLUSTER}
+              SECRET_DOMAIN: ${SECRET_DOMAIN}
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/clusters/test/apps.yaml
+++ b/kubernetes/clusters/test/apps.yaml
@@ -31,6 +31,14 @@ spec:
           name: not-used
         spec:
           deletionPolicy: WaitForTermination
+          postBuild:
+            substitute:
+              CLUSTER: ${CLUSTER}
+              SECRET_DOMAIN: ${SECRET_DOMAIN}
+              STORAGE_HR: ${STORAGE_HR}
+              STORAGE_NS: ${STORAGE_NS}
+              VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
+              VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/clusters/utility/apps.yaml
+++ b/kubernetes/clusters/utility/apps.yaml
@@ -31,6 +31,14 @@ spec:
           name: not-used
         spec:
           deletionPolicy: WaitForTermination
+          postBuild:
+            substitute:
+              CLUSTER: ${CLUSTER}
+              SECRET_DOMAIN: ${SECRET_DOMAIN}
+              STORAGE_HR: ${STORAGE_HR}
+              STORAGE_NS: ${STORAGE_NS}
+              VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
+              VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
## Summary

- Move `postBuild.substitute` into the cluster-apps "Kustomization defaults" patch so child Flux Kustomizations inherit `CLUSTER`, `SECRET_DOMAIN`, and (on utility/test) the storage/volsync vars. Resolves the issue where `${CLUSTER}` couldn't be used in child Kustomization postBuild context — discovered while wiring up the new `onepassword-connect` ExternalSecret which references `1password-${CLUSTER}`.
- Remove redundant `HelmRelease` defaults patches from three base `kustomization.yaml` files (`flux-operator`, `headlamp`, `volsync`). The same patch already exists at cluster-apps level and applies to every HelmRelease in the cluster, so these per-app duplicates are dead weight.

Net diff: -72/+20 across 6 files. No behavioral change expected — `flux-local diff` should be empty.

## Test plan

- [ ] Flux Local Diff shows no resource changes across all 3 clusters
- [ ] Flux Local Test passes
- [ ] After merge: verify `onepassword-connect` ks finishes reconciling on all 3 clusters (it's been hanging on the literal `1password-${CLUSTER}` reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)