### PR TITLE
chore: switch flux-local to flate

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -106,12 +106,9 @@ jobs:
           CLUSTER: ${{ matrix.cluster }}
         run: |
           flate diff "$RESOURCE" \
-            --limit-bytes 10000 \
-            --output-file diff.patch \
             --path ./pull/kubernetes/clusters/"$CLUSTER" \
             --path-orig ./default/kubernetes/clusters/"$CLUSTER" \
-            --strip-attrs "helm.sh/chart,checksum/config,app.kubernetes.io/version,chart" \
-            --unified 6
+            > diff.patch
 
       - name: Generate Diff
         id: diff

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -56,7 +56,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           tool_versions: |
-            github:home-operations/flate 0.1.3
+            github:home-operations/flate 0.1.20
 
       - name: Run flate test
         env:
@@ -98,7 +98,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           tool_versions: |
-            github:home-operations/flate 0.1.3
+            github:home-operations/flate 0.1.20
 
       - name: Run flate diff
         env:

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: Flux Local
+name: Flate
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   filter:
-    name: Flux Local - Filter
+    name: Flate - Filter
     runs-on: ubuntu-latest
     outputs:
       changed-files: ${{ steps.changed-files.outputs.changed_files }}
@@ -29,36 +29,49 @@ jobs:
   test:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
     needs: filter
-    name: Flux Local - Test
+    name: Flate - Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
         cluster: ["main", "test", "utility"]
+        resource: ["helmrelease", "kustomization"]
+      fail-fast: false
     steps:
-      - name: Checkout
+      - name: Checkout Pull Request Branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          path: pull
 
-      - name: Run flux-local test
+      - name: Checkout Default Branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+          path: default
+
+      - name: Setup Mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          tool_versions: |
+            github:home-operations/flate latest
+
+      - name: Run flate test
+        env:
+          RESOURCE: ${{ matrix.resource }}
+          CLUSTER: ${{ matrix.cluster }}
         run: |
-          bash .github/scripts/retry.sh \
-            docker run --rm \
-            --volume "$GITHUB_WORKSPACE:/github/workspace" \
-            --workdir /github/workspace \
-            ghcr.io/allenporter/flux-local:v8.1.0 \
-            test \
-            --all-namespaces \
-            --enable-helm \
-            --path /github/workspace/kubernetes/clusters/${{ matrix.cluster }} \
-            --verbose
+          flate test "$RESOURCE" \
+            --path ./pull/kubernetes/clusters/"$CLUSTER" \
+            --path-orig ./default/kubernetes/clusters/"$CLUSTER"
 
   diff:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
     needs: filter
-    name: Flux Local - Diff
+    name: Flate - Diff
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     strategy:
       matrix:
@@ -69,36 +82,38 @@ jobs:
       - name: Checkout Pull Request Branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          path: pull
           persist-credentials: false
+          path: pull
 
       - name: Checkout Default Branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          path: default
           persist-credentials: false
           ref: ${{ github.event.repository.default_branch }}
+          path: default
 
-      - name: Run flux-local diff
+      - name: Setup Mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          tool_versions: |
+            github:home-operations/flate latest
+
+      - name: Run flate diff
+        env:
+          RESOURCE: ${{ matrix.resource }}
+          CLUSTER: ${{ matrix.cluster }}
         run: |
-          bash pull/.github/scripts/retry.sh \
-            docker run --rm \
-            --volume "$GITHUB_WORKSPACE:/github/workspace" \
-            --workdir /github/workspace \
-            ghcr.io/allenporter/flux-local:v8.1.0 \
-            diff ${{ matrix.resource }} \
-            --unified 6 \
-            --path /github/workspace/pull/kubernetes/clusters/${{ matrix.cluster }} \
-            --path-orig /github/workspace/default/kubernetes/clusters/${{ matrix.cluster }} \
-            --strip-attrs "helm.sh/chart,checksum/config,app.kubernetes.io/version,chart" \
+          flate diff "$RESOURCE" \
             --limit-bytes 10000 \
-            --all-namespaces \
-            --sources "flux-system" \
-            --output-file diff.patch
+            --output-file diff.patch \
+            --path ./pull/kubernetes/clusters/"$CLUSTER" \
+            --path-orig ./default/kubernetes/clusters/"$CLUSTER" \
+            --strip-attrs "helm.sh/chart,checksum/config,app.kubernetes.io/version,chart" \
+            --unified 6
 
       - name: Generate Diff
         id: diff
-        run: |
+        run: |-
           echo 'diff<<EOF' >> $GITHUB_OUTPUT
           cat diff.patch >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
@@ -117,7 +132,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          header: ${{ github.event.pull_request.number }}/kubernetes/${{ matrix.resource }}
+          header: ${{ github.event.pull_request.number }}/${{ matrix.cluster }}/${{ matrix.resource }}
           message: |
             ```diff
             ${{ steps.diff.outputs.diff }}
@@ -126,7 +141,7 @@ jobs:
   success:
     if: ${{ !cancelled() }}
     needs: ["test", "diff"]
-    name: Flux Local - Success
+    name: Flate - Success
     runs-on: ubuntu-latest
     steps:
       - name: Any jobs failed?

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -31,6 +31,8 @@ jobs:
     needs: filter
     name: Flate - Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         cluster: ["main", "test", "utility"]
@@ -54,7 +56,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           tool_versions: |
-            github:home-operations/flate latest
+            github:home-operations/flate 0.1.3
 
       - name: Run flate test
         env:
@@ -96,7 +98,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           tool_versions: |
-            github:home-operations/flate latest
+            github:home-operations/flate 0.1.3
 
       - name: Run flate diff
         env:

--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -61,9 +61,9 @@ jobs:
         run: |
           flate diff images \
             --output json \
-            --output-file images.json \
             --path ./pull/kubernetes/clusters/"$CLUSTER" \
-            --path-orig ./default/kubernetes/clusters/"$CLUSTER"
+            --path-orig ./default/kubernetes/clusters/"$CLUSTER" \
+            > images.json
 
       - name: Summarize
         env:

--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           tool_versions: |
-            github:home-operations/flate 0.1.3
+            github:home-operations/flate 0.1.20
 
       - name: Diff Images
         env:

--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           tool_versions: |
-            github:home-operations/flate latest
+            github:home-operations/flate 0.1.3
 
       - name: Diff Images
         env:

--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -26,98 +26,55 @@ jobs:
         with:
           patterns: kubernetes/**/*
 
-  extract:
+  diff:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
     needs: filter
-    name: Image Pull - Extract Images
+    name: Image Pull - Diff Images
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        branch: ["default", "pull"]
         cluster: ["main", "utility"]
       fail-fast: false
     steps:
-      - name: Checkout
+      - name: Checkout Pull Request Branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          ref: ${{ matrix.branch == 'default' && github.event.repository.default_branch || '' }}
+          path: pull
 
-      - name: Gather Images
+      - name: Checkout Default Branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+          path: default
+
+      - name: Setup Mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          tool_versions: |
+            github:home-operations/flate latest
+
+      - name: Diff Images
+        env:
+          CLUSTER: ${{ matrix.cluster }}
         run: |
-          bash .github/scripts/retry.sh \
-            docker run --rm \
-            --volume "$GITHUB_WORKSPACE:/github/workspace" \
-            --workdir /github/workspace \
-            ghcr.io/allenporter/flux-local:v8.1.0 \
-            get cluster \
-            --all-namespaces \
-            --path /github/workspace/kubernetes/clusters/${{ matrix.cluster }} \
-            --enable-images \
-            --only-images \
+          flate diff images \
             --output json \
-            --output-file images.json
+            --output-file images.json \
+            --path ./pull/kubernetes/clusters/"$CLUSTER" \
+            --path-orig ./default/kubernetes/clusters/"$CLUSTER"
 
-      - name: Extract Images and Summarize
+      - name: Summarize
+        env:
+          CLUSTER: ${{ matrix.cluster }}
         run: |
-          mkdir -p output
-          jq --compact-output '.' images.json > output/images.json
-
-          echo "## Branch: \`${{ matrix.branch }}\` — Cluster: \`${{ matrix.cluster }}\` Images" >> $GITHUB_STEP_SUMMARY
+          echo "## New images for cluster \`$CLUSTER\`" >> $GITHUB_STEP_SUMMARY
           echo '```json' >> $GITHUB_STEP_SUMMARY
           jq '.' images.json >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
-      - name: Upload Image JSON
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: images-${{ matrix.cluster }}-${{ matrix.branch }}
-          path: output/images.json
-
-  diff:
-    name: Image Pull - Diff Images
-    needs: extract
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        cluster: ["main", "utility"]
-      fail-fast: false
-    outputs:
-      images: ${{ steps.diff.outputs.images }}
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: artifacts
-
-      - name: Diff Images
-        id: diff
-        run: |
-          default_file="artifacts/images-${{ matrix.cluster }}-default/images.json"
-          pull_file="artifacts/images-${{ matrix.cluster }}-pull/images.json"
-
-          if [[ ! -f "$default_file" || ! -f "$pull_file" ]]; then
-            echo "images=[]" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          images=$(jq --compact-output --null-input \
-            --argjson f1 "$(cat "$default_file")" \
-            --argjson f2 "$(cat "$pull_file")" \
-            '$f2 - $f1')
-
-          echo "images=$images" >> $GITHUB_OUTPUT
-
-          echo '## New images to Pull' >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          echo $images | jq >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-      - name: Save Image List
-        run: |
-          echo '${{ steps.diff.outputs.images }}' > images.json
-        # Upload image list for pull step
-      - name: Upload Diff
+      - name: Upload Image List
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: diff-${{ matrix.cluster }}
@@ -138,30 +95,15 @@ jobs:
           name: diff-${{ matrix.cluster }}
           path: .
 
-      - name: Read Images from JSON
-        id: read-images
-        run: |
-          mapfile -t images < <(jq -r '.[]' images.json)
-          echo "images_count=${#images[@]}" >> $GITHUB_OUTPUT
-          for i in "${!images[@]}"; do
-            echo "image_$i=${images[$i]}" >> $GITHUB_OUTPUT
-          done
-          if [[ -z "$images" ]]; then
-            echo "No images to pull for cluster ${{ matrix.cluster }}"
-            exit 0
-          fi
-
       - name: Install talosctl
         run: |
           for attempt in 1 2 3; do
             if curl -fsSL https://talos.dev/install | sh; then
               exit 0
             fi
-
             if [[ "$attempt" -eq 3 ]]; then
               exit 1
             fi
-
             echo "talosctl install failed; retrying in 20s (${attempt}/3)..." >&2
             sleep 20
           done
@@ -169,17 +111,19 @@ jobs:
       - name: Pull Images
         run: |
           images=$(jq -r '.[]' images.json)
+          if [[ -z "$images" ]]; then
+            echo "No images to pull for cluster ${{ matrix.cluster }}"
+            exit 0
+          fi
           for image in $images; do
             echo "Pulling $image"
             for attempt in 1 2 3; do
               if talosctl --nodes $NODE image pull "$image"; then
                 break
               fi
-
               if [[ "$attempt" -eq 3 ]]; then
                 exit 1
               fi
-
               echo "Image pull failed for $image; retrying in 20s (${attempt}/3)..." >&2
               sleep 20
             done

--- a/.mise.toml
+++ b/.mise.toml
@@ -12,3 +12,6 @@ TALOS_DIR = "{{config_root}}/talos"
 _.file = [
   "{{config_root}}/.secrets.env",
 ]
+
+[tools]
+"github:home-operations/flate" = "0.1.3"

--- a/.mise.toml
+++ b/.mise.toml
@@ -14,4 +14,4 @@ _.file = [
 ]
 
 [tools]
-"github:home-operations/flate" = "0.1.3"
+"github:home-operations/flate" = "0.1.20"


### PR DESCRIPTION
## Summary

Replace the docker-based [flux-local](https://github.com/allenporter/flux-local) workflow with [flate](https://github.com/home-operations/flate), a single-binary Go rewrite by the home-operations org. Installed via mise per the upstream pattern.

- **Delete** `.github/workflows/flux-local.yaml`
- **Add** `.github/workflows/flate.yaml` — same `cluster × resource` matrix; sticky PR comments scoped per cluster/resource so all three clusters comment independently
- **Simplify** `.github/workflows/image-pull.yaml` — flate's native `diff images` subcommand collapses the old extract + diff + jq pipeline into a single step per cluster

Net diff: 138 lines of flux-local YAML out, 164 lines of flate YAML in (most of the difference is the cluster matrix that onedr0p's reference workflow doesn't have since he's single-cluster). Image-pull went from ~200 lines to ~95.

Per-cluster matrix preserved:
- flate test + diff: main/utility/test
- image pull: main/utility (test cluster doesn't pre-pull, same as before)

PR bot token still sourced from GitHub secrets (`BOT_APP_ID` / `BOT_APP_PRIVATE_KEY`) — no 1Password Service Account required since this account is on Family tier.

References:
- onedr0p/home-ops [f36dce128](https://github.com/onedr0p/home-ops/commit/f36dce1281f6528271a1031e1b924920674b3a53), [467516a88](https://github.com/onedr0p/home-ops/commit/467516a8877f7cdf33ac5f82e348666884565821), [118b003ca](https://github.com/onedr0p/home-ops/commit/118b003ca608c1f0b575cfccf5c8b5f0ec8e5aa5)

## Test plan

- [ ] Flate Test passes on all 3 clusters × 2 resource kinds
- [ ] Flate Diff posts sticky comment per cluster/resource (or stays quiet when no diff)
- [ ] Image Pull Diff runs for main/utility, finds expected new images (this PR adds none, so expect empty lists)
- [ ] Image Pull successfully pre-pulls on main/utility runners (or skips cleanly when no images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)