### PR TITLE
chore: centralize sourceRef + prune defaults

### DIFF
--- a/kubernetes/apps/main/actions-runner-system/actions-runner-controller.yaml
+++ b/kubernetes/apps/main/actions-runner-system/actions-runner-controller.yaml
@@ -5,13 +5,7 @@ metadata:
   name: actions-runner-controller
 spec:
   interval: 1h
-  path:
-    ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
+  path: ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/app
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -21,19 +15,13 @@ metadata:
   name: actions-runner-controller-runners
 spec:
   dependsOn:
-  - name: actions-runner-controller
-  - name: openebs
-    namespace: storage
+    - name: actions-runner-controller
+    - name: openebs
+      namespace: storage
   interval: 1h
-  path:
-    ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners
+  path: ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
       maxRunners: "6" # 2 per node
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/cert-manager/cert-manager.yaml
+++ b/kubernetes/apps/main/cert-manager/cert-manager.yaml
@@ -20,8 +20,3 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/cert-manager/cert-manager
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system

--- a/kubernetes/apps/main/database/cloudnative-pg.yaml
+++ b/kubernetes/apps/main/database/cloudnative-pg.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/database/cloudnative-pg
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/main/database/dragonfly.yaml
+++ b/kubernetes/apps/main/database/dragonfly.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/database/dragonfly
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/main/downloads/autobrr.yaml
+++ b/kubernetes/apps/main/downloads/autobrr.yaml
@@ -13,9 +13,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/bazarr.yaml
+++ b/kubernetes/apps/main/downloads/bazarr.yaml
@@ -14,9 +14,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/brrpolice.yaml
+++ b/kubernetes/apps/main/downloads/brrpolice.yaml
@@ -14,9 +14,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/decluttarr.yaml
+++ b/kubernetes/apps/main/downloads/decluttarr.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/deduparr.yaml
+++ b/kubernetes/apps/main/downloads/deduparr.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/flaresolverr.yaml
+++ b/kubernetes/apps/main/downloads/flaresolverr.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/downloads/flaresolverr
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/kapowarr.yaml
+++ b/kubernetes/apps/main/downloads/kapowarr.yaml
@@ -14,9 +14,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/metube.yaml
+++ b/kubernetes/apps/main/downloads/metube.yaml
@@ -14,9 +14,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/mylar.yaml
+++ b/kubernetes/apps/main/downloads/mylar.yaml
@@ -14,10 +14,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
-

--- a/kubernetes/apps/main/downloads/pinchflat.yaml
+++ b/kubernetes/apps/main/downloads/pinchflat.yaml
@@ -13,9 +13,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/prowlarr.yaml
+++ b/kubernetes/apps/main/downloads/prowlarr.yaml
@@ -18,9 +18,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/qbittorrent.yaml
+++ b/kubernetes/apps/main/downloads/qbittorrent.yaml
@@ -13,9 +13,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/qui.yaml
+++ b/kubernetes/apps/main/downloads/qui.yaml
@@ -13,9 +13,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/radarr.yaml
+++ b/kubernetes/apps/main/downloads/radarr.yaml
@@ -19,9 +19,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/recyclarr.yaml
+++ b/kubernetes/apps/main/downloads/recyclarr.yaml
@@ -15,10 +15,5 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: downloads
   wait: false

--- a/kubernetes/apps/main/downloads/sabnzbd.yaml
+++ b/kubernetes/apps/main/downloads/sabnzbd.yaml
@@ -13,9 +13,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/sonarr.yaml
+++ b/kubernetes/apps/main/downloads/sonarr.yaml
@@ -19,9 +19,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/downloads/tdarr-node.yaml
+++ b/kubernetes/apps/main/downloads/tdarr-node.yaml
@@ -12,9 +12,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/external-secrets/external-secrets.yaml
+++ b/kubernetes/apps/main/external-secrets/external-secrets.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/external-secrets/external-secrets
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/main/external-secrets/onepassword-connect.yaml
+++ b/kubernetes/apps/main/external-secrets/onepassword-connect.yaml
@@ -22,9 +22,4 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/external-secrets/onepassword-connect
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/main/flux-system/addons.yaml
+++ b/kubernetes/apps/main/flux-system/addons.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: flux-webhook
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/flux-system/flux-operator.yaml
+++ b/kubernetes/apps/main/flux-system/flux-operator.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: flux
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/main/flux-system/headlamp.yaml
+++ b/kubernetes/apps/main/flux-system/headlamp.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: headlamp
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/games/core-keeper.yaml
+++ b/kubernetes/apps/main/games/core-keeper.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app core-keeper
 spec:
   components:
-  - ../../../../components/volsync
+    - ../../../../components/volsync
   interval: 1h
   path: ./kubernetes/apps/base/games/core-keeper
   postBuild:
@@ -15,9 +15,4 @@ spec:
       VOLSYNC_CAPACITY: 50Gi
       VOLSYNC_UID: "1000"
       VOLSYNC_GID: "1000"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/games/enshrouded.yaml
+++ b/kubernetes/apps/main/games/enshrouded.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app enshrouded
 spec:
   components:
-  - ../../../../components/volsync
+    - ../../../../components/volsync
   interval: 1h
   path: ./kubernetes/apps/base/games/enshrouded
   postBuild:
@@ -15,9 +15,4 @@ spec:
       VOLSYNC_CAPACITY: 50Gi
       VOLSYNC_UID: "10000"
       VOLSYNC_GID: "10000"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/games/minecraft.yaml
+++ b/kubernetes/apps/main/games/minecraft.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/games/minecraft/mc-router
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -23,18 +18,13 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-  - ../../../../../components/volsync
+    - ../../../../../components/volsync
   interval: 1h
   path: ./kubernetes/apps/base/games/minecraft/cobbleverse
   postBuild:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 50Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -47,18 +37,13 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-  - ../../../../../components/volsync
+    - ../../../../../components/volsync
   interval: 1h
   path: ./kubernetes/apps/base/games/minecraft/jellycraft
   postBuild:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 15Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 # ---
 # # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json

--- a/kubernetes/apps/main/games/palworld.yaml
+++ b/kubernetes/apps/main/games/palworld.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app palworld
 spec:
   components:
-  - ../../../../components/volsync
+    - ../../../../components/volsync
   interval: 1h
   path: ./kubernetes/apps/base/games/palworld
   postBuild:
@@ -15,9 +15,4 @@ spec:
       VOLSYNC_CAPACITY: 50Gi
       VOLSYNC_UID: "1000"
       VOLSYNC_GID: "1000"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/games/romm.yaml
+++ b/kubernetes/apps/main/games/romm.yaml
@@ -6,23 +6,18 @@ metadata:
   name: &app romm
 spec:
   components:
-  - ../../../../components/dragonfly
-  - ../../../../components/postgres
-  - ../../../../components/volsync
+    - ../../../../components/dragonfly
+    - ../../../../components/postgres
+    - ../../../../components/volsync
   healthCheckExprs:
-  - apiVersion: postgresql.cnpg.io/v1
-    kind: Cluster
-    failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
-    current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      failed: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'False')
+      current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/games/romm
   postBuild:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 25Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/games/valheim.yaml
+++ b/kubernetes/apps/main/games/valheim.yaml
@@ -6,16 +6,11 @@ metadata:
   name: &app valheim
 spec:
   components:
-  - ../../../../components/volsync
+    - ../../../../components/volsync
   interval: 1h
   path: ./kubernetes/apps/base/games/valheim
   postBuild:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 10Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/games/vrising.yaml
+++ b/kubernetes/apps/main/games/vrising.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app vrising
 spec:
   components:
-  - ../../../../components/volsync
+    - ../../../../components/volsync
   interval: 1h
   path: ./kubernetes/apps/base/games/vrising
   postBuild:
@@ -15,9 +15,4 @@ spec:
       VOLSYNC_CAPACITY: 50Gi
       VOLSYNC_UID: "1000"
       VOLSYNC_GID: "1000"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/kube-system/amd-device-plugin.yaml
+++ b/kubernetes/apps/main/kube-system/amd-device-plugin.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/amd-device-plugin
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/main/kube-system/cilium.yaml
+++ b/kubernetes/apps/main/kube-system/cilium.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/cilium
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -20,12 +15,7 @@ metadata:
   name: cilium-config
 spec:
   dependsOn:
-  - name: cilium
+    - name: cilium
   interval: 15m
   path: ./kubernetes/apps/${CLUSTER}/kube-system/cilium
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/kube-system/coredns.yaml
+++ b/kubernetes/apps/main/kube-system/coredns.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/coredns
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/kube-system/intel-gpu-resource-driver.yaml
+++ b/kubernetes/apps/main/kube-system/intel-gpu-resource-driver.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/intel-gpu-resource-driver
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/main/kube-system/irqbalance.yaml
+++ b/kubernetes/apps/main/kube-system/irqbalance.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/irqbalance
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/main/kube-system/metrics-server.yaml
+++ b/kubernetes/apps/main/kube-system/metrics-server.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       REPLICAS: "2"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/kube-tools/descheduler.yaml
+++ b/kubernetes/apps/main/kube-tools/descheduler.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       REPLICAS: "2"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/kube-tools/reloader.yaml
+++ b/kubernetes/apps/main/kube-tools/reloader.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-tools/reloader
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/kube-tools/spegel.yaml
+++ b/kubernetes/apps/main/kube-tools/spegel.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-tools/spegel
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/kube-tools/tuppr.yaml
+++ b/kubernetes/apps/main/kube-tools/tuppr.yaml
@@ -9,11 +9,6 @@ spec:
   postBuild:
     substitute:
       REPLICAS: "2"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -23,12 +18,7 @@ metadata:
   name: tuppr-upgrades
 spec:
   dependsOn:
-  - name: tuppr
+    - name: tuppr
   interval: 1h
   path: ./kubernetes/apps/${CLUSTER}/kube-tools/upgrades
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/llm/comfyui.yaml
+++ b/kubernetes/apps/main/llm/comfyui.yaml
@@ -15,11 +15,6 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 200Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -36,9 +31,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/llm/hermes.yaml
+++ b/kubernetes/apps/main/llm/hermes.yaml
@@ -14,9 +14,4 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 20Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/llm/litellm.yaml
+++ b/kubernetes/apps/main/llm/litellm.yaml
@@ -22,11 +22,6 @@ spec:
       VOLSYNC_ACCESSMODES: ReadWriteMany
       VOLSYNC_STORAGECLASS: ceph-filesystem
       VOLSYNC_SNAPSHOTCLASS: csi-ceph-filesystem
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 # ---
 # # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -55,18 +50,13 @@ metadata:
   name: &app llama-intel
 spec:
   components:
-  - ../../../../../components/gpu
+    - ../../../../../components/gpu
   interval: 1h
   path: ./kubernetes/apps/base/llm/litellm/llama-intel
   postBuild:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -76,18 +66,13 @@ metadata:
   name: &app llama-embed
 spec:
   components:
-  - ../../../../../components/gpu
+    - ../../../../../components/gpu
   interval: 1h
   path: ./kubernetes/apps/base/llm/litellm/llama-embed
   postBuild:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 # ---
 # # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -123,9 +108,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/llm/open-webui.yaml
+++ b/kubernetes/apps/main/llm/open-webui.yaml
@@ -25,9 +25,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/llm/openclaw.yaml
+++ b/kubernetes/apps/main/llm/openclaw.yaml
@@ -5,7 +5,7 @@ metadata:
   name: &app openclaw
 spec:
   components:
-  - ../../../../../components/volsync
+    - ../../../../../components/volsync
   interval: 1h
   path: ./kubernetes/apps/base/llm/openclaw/app
   postBuild:
@@ -13,11 +13,6 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 50Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -27,18 +22,13 @@ metadata:
   name: &app extended-memory
 spec:
   components:
-  - ../../../../../components/volsync
+    - ../../../../../components/volsync
   interval: 1h
   path: ./kubernetes/apps/base/llm/openclaw/extended-memory
   postBuild:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -48,22 +38,17 @@ metadata:
   name: &app miso-chat
 spec:
   components:
-  - ../../../../../components/dragonfly
+    - ../../../../../components/dragonfly
   healthCheckExprs:
-  - apiVersion: dragonflydb.io/v1alpha1
-    kind: Dragonfly
-    failed: status.phase != 'ready'
-    current: status.phase == 'ready'
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      failed: status.phase != 'ready'
+      current: status.phase == 'ready'
   interval: 1h
   path: ./kubernetes/apps/base/llm/openclaw/miso-chat
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -84,11 +69,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 apiVersion: v1

--- a/kubernetes/apps/main/llm/searxng.yaml
+++ b/kubernetes/apps/main/llm/searxng.yaml
@@ -5,22 +5,17 @@ metadata:
   name: &app searxng
 spec:
   components:
-  - ../../../../../components/dragonfly
+    - ../../../../../components/dragonfly
   healthCheckExprs:
-  - apiVersion: dragonflydb.io/v1alpha1
-    kind: Dragonfly
-    failed: status.phase != 'ready'
-    current: status.phase == 'ready'
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      failed: status.phase != 'ready'
+      current: status.phase == 'ready'
   interval: 1h
   path: ./kubernetes/apps/base/llm/searxng/app
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -34,9 +29,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/llm/toolhive.yaml
+++ b/kubernetes/apps/main/llm/toolhive.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/crds
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -20,14 +15,9 @@ metadata:
   name: &name toolhive
 spec:
   dependsOn:
-  - name: toolhive-crds
+    - name: toolhive-crds
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -37,24 +27,19 @@ metadata:
   name: &name toolhive-config
 spec:
   components:
-  - ../../../../../components/dragonfly
+    - ../../../../../components/dragonfly
   dependsOn:
-  - name: toolhive
+    - name: toolhive
   healthCheckExprs:
-  - apiVersion: dragonflydb.io/v1alpha1
-    kind: Dragonfly
-    failed: status.phase != 'ready'
-    current: status.phase == 'ready'
+    - apiVersion: dragonflydb.io/v1alpha1
+      kind: Dragonfly
+      failed: status.phase != 'ready'
+      current: status.phase == 'ready'
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/config
   postBuild:
     substitute:
       APP: *name
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -64,20 +49,15 @@ metadata:
   name: &name arr-mcp
 spec:
   dependsOn:
-  - name: toolhive
-  - name: radarr
-    namespace: downloads
-  - name: sonarr
-    namespace: downloads
-  - name: prowlarr
-    namespace: downloads
+    - name: toolhive
+    - name: radarr
+      namespace: downloads
+    - name: sonarr
+      namespace: downloads
+    - name: prowlarr
+      namespace: downloads
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/arr-mcp
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -87,15 +67,10 @@ metadata:
   name: &name comfyui-mcp
 spec:
   dependsOn:
-  - name: toolhive
-  - name: comfyui
+    - name: toolhive
+    - name: comfyui
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/comfyui-mcp
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -105,14 +80,9 @@ metadata:
   name: &name garmin-connect-mcp
 spec:
   dependsOn:
-  - name: toolhive
+    - name: toolhive
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/garmin-connect-mcp
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -122,14 +92,9 @@ metadata:
   name: &name github-mcp
 spec:
   dependsOn:
-  - name: toolhive
+    - name: toolhive
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/github-mcp
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -139,16 +104,11 @@ metadata:
   name: &name grafana-mcp
 spec:
   dependsOn:
-  - name: toolhive
-  - name: grafana
-    namespace: observability
+    - name: toolhive
+    - name: grafana
+      namespace: observability
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/grafana-mcp
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -158,14 +118,9 @@ metadata:
   name: &name ha-mcp
 spec:
   dependsOn:
-  - name: toolhive
+    - name: toolhive
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/ha-mcp
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -175,21 +130,15 @@ metadata:
   name: &name memory-mcp
 spec:
   components:
-  - ../../../../../../components/volsync
+    - ../../../../../../components/volsync
   dependsOn:
-  - name: toolhive
+    - name: toolhive
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/memory-mcp
   postBuild:
     substitute:
       APP: *name
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
-
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -198,14 +147,9 @@ metadata:
   name: &name kubectl-mcp
 spec:
   dependsOn:
-  - name: toolhive
+    - name: toolhive
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/kubectl-mcp
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -215,17 +159,12 @@ metadata:
   name: &app seerr-mcp
 spec:
   dependsOn:
-  - name: toolhive
-  - name: seerr
-    namespace: media
+    - name: toolhive
+    - name: seerr
+      namespace: media
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/seerr-mcp
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/media/ersatztv.yaml
+++ b/kubernetes/apps/main/media/ersatztv.yaml
@@ -14,9 +14,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/media/kavita.yaml
+++ b/kubernetes/apps/main/media/kavita.yaml
@@ -13,9 +13,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/media/komga.yaml
+++ b/kubernetes/apps/main/media/komga.yaml
@@ -15,9 +15,4 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 20Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/media/kyoo.yaml
+++ b/kubernetes/apps/main/media/kyoo.yaml
@@ -22,9 +22,4 @@ spec:
       CLUSTER: ${CLUSTER}
       SSLMODE: allow
       VOLSYNC_CAPACITY: 50Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/media/maintainerr.yaml
+++ b/kubernetes/apps/main/media/maintainerr.yaml
@@ -13,9 +13,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/media/plex.yaml
+++ b/kubernetes/apps/main/media/plex.yaml
@@ -5,18 +5,13 @@ metadata:
   name: &app agregarr
 spec:
   components:
-  - ../../../../../components/volsync
-  - ../../../../../components/zeroscaler
+    - ../../../../../components/volsync
+    - ../../../../../components/zeroscaler
   interval: 1h
   path: ./kubernetes/apps/base/media/plex/agregarr
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -26,9 +21,9 @@ metadata:
   name: &app plex
 spec:
   components:
-  - ../../../../../components/gpu
-  - ../../../../../components/volsync
-  - ../../../../../components/zeroscaler
+    - ../../../../../components/gpu
+    - ../../../../../components/volsync
+    - ../../../../../components/zeroscaler
   interval: 1h
   path: ./kubernetes/apps/base/media/plex/app
   postBuild:
@@ -36,11 +31,6 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 50Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 # ---
 # # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -78,14 +68,9 @@ metadata:
   name: plex-auto-languages
 spec:
   dependsOn:
-  - name: plex
+    - name: plex
   interval: 1h
   path: ./kubernetes/apps/base/media/plex/plex-auto-languages
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -95,17 +80,12 @@ metadata:
   name: &app imagemaid
 spec:
   dependsOn:
-  - name: plex
+    - name: plex
   interval: 1h
   path: ./kubernetes/apps/base/media/plex/imagemaid
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -115,18 +95,13 @@ metadata:
   name: &app plex-trakt-sync
 spec:
   components:
-  - ../../../../../components/volsync
+    - ../../../../../components/volsync
   dependsOn:
-  - name: plex
+    - name: plex
   interval: 1h
   path: ./kubernetes/apps/base/media/plex/plex-trakt-sync
   postBuild:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 500Mi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/media/seerr.yaml
+++ b/kubernetes/apps/main/media/seerr.yaml
@@ -18,9 +18,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/media/stash.yaml
+++ b/kubernetes/apps/main/media/stash.yaml
@@ -16,9 +16,4 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 50Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/media/tautulli.yaml
+++ b/kubernetes/apps/main/media/tautulli.yaml
@@ -13,9 +13,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/media/wizarr.yaml
+++ b/kubernetes/apps/main/media/wizarr.yaml
@@ -15,9 +15,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/media/your-spotify.yaml
+++ b/kubernetes/apps/main/media/your-spotify.yaml
@@ -12,9 +12,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/network/certificates.yaml
+++ b/kubernetes/apps/main/network/certificates.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/import
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -21,11 +16,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/certificate
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -35,12 +25,7 @@ metadata:
   name: certificates-export
 spec:
   dependsOn:
-  - name: certificate
+    - name: certificate
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/export
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/main/network/cloudflare-dns.yaml
+++ b/kubernetes/apps/main/network/cloudflare-dns.yaml
@@ -18,8 +18,3 @@ spec:
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system

--- a/kubernetes/apps/main/network/cloudflare-tunnel.yaml
+++ b/kubernetes/apps/main/network/cloudflare-tunnel.yaml
@@ -13,9 +13,4 @@ spec:
       CLUSTER: ${CLUSTER}
       EXTERNAL_DOMAIN: external
       REPLICAS: "2"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/network/echo.yaml
+++ b/kubernetes/apps/main/network/echo.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       SUBDOMAIN: echo
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/network/envoy-gateway.yaml
+++ b/kubernetes/apps/main/network/envoy-gateway.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/envoy-gateway/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -20,8 +15,8 @@ metadata:
   name: envoy-config
 spec:
   dependsOn:
-  - name: certificates-import
-  - name: envoy-gateway
+    - name: certificates-import
+    - name: envoy-gateway
   interval: 1h
   path: ./kubernetes/apps/base/network/envoy-gateway/config
   postBuild:
@@ -32,9 +27,4 @@ spec:
       REPLICAS: "2"
       SVC_GATEWAY_EXTERNAL: 10.69.10.32
       SVC_GATEWAY_INTERNAL: 10.69.10.31
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/network/multus.yaml
+++ b/kubernetes/apps/main/network/multus.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/multus
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -20,12 +15,7 @@ metadata:
   name: multus-networks
 spec:
   dependsOn:
-  - name: multus
+    - name: multus
   interval: 1h
   path: ./kubernetes/apps/${CLUSTER}/network/multus
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/main/network/unifi-dns.yaml
+++ b/kubernetes/apps/main/network/unifi-dns.yaml
@@ -11,9 +11,4 @@ spec:
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/main/observability/exporters/blackbox-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/blackbox-exporter.yaml
@@ -9,11 +9,6 @@ spec:
   postBuild:
     substitute:
       SUBDOMAIN: blackbox
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -24,9 +19,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/blackbox-exporter-vpn
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/observability/exporters/hoymiles-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/hoymiles-exporter.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/hoymiles-exporter
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/observability/exporters/nut-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/nut-exporter.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/nut-exporter
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/observability/exporters/rocm-smi-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/rocm-smi-exporter.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/rocm-smi-exporter
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/observability/exporters/smartctl-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/smartctl-exporter.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/smartctl-exporter
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/observability/exporters/speedtest-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/speedtest-exporter.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/speedtest-exporter
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/observability/exporters/unpoller.yaml
+++ b/kubernetes/apps/main/observability/exporters/unpoller.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/unpoller
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/observability/fluent-bit.yaml
+++ b/kubernetes/apps/main/observability/fluent-bit.yaml
@@ -7,10 +7,5 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/fluent-bit
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: observability
   wait: false

--- a/kubernetes/apps/main/observability/gatus.yaml
+++ b/kubernetes/apps/main/observability/gatus.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       SUBDOMAIN: status
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/observability/grafana.yaml
+++ b/kubernetes/apps/main/observability/grafana.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/grafana/operator
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -20,19 +15,14 @@ metadata:
   name: grafana-instance
 spec:
   dependsOn:
-  - name: grafana
-  - name: rook-ceph-cluster
-    namespace: rook-ceph
+    - name: grafana
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
   interval: 1h
   path: ./kubernetes/apps/base/observability/grafana/instance
   postBuild:
     substitute:
       SUBDOMAIN: grafana
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -46,9 +36,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/observability/karma.yaml
+++ b/kubernetes/apps/main/observability/karma.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/observability/kromgo.yaml
+++ b/kubernetes/apps/main/observability/kromgo.yaml
@@ -12,9 +12,4 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
       GATUS_STATUS: "404"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/observability/kube-prometheus-stack.yaml
+++ b/kubernetes/apps/main/observability/kube-prometheus-stack.yaml
@@ -14,10 +14,4 @@ spec:
       PVC_CAPACITY: "75"
       STORAGECLASS: ceph-block
       SUBDOMAIN: prometheus
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
-

--- a/kubernetes/apps/main/observability/prometheus-adapter.yaml
+++ b/kubernetes/apps/main/observability/prometheus-adapter.yaml
@@ -7,10 +7,5 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/prometheus-adapter
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: observability
   wait: false

--- a/kubernetes/apps/main/observability/promxy.yaml
+++ b/kubernetes/apps/main/observability/promxy.yaml
@@ -6,9 +6,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/promxy
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/observability/silence-operator.yaml
+++ b/kubernetes/apps/main/observability/silence-operator.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/silence-operator
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/observability/victoria-logs.yaml
+++ b/kubernetes/apps/main/observability/victoria-logs.yaml
@@ -7,10 +7,5 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/victoria-logs
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: observability
   wait: false

--- a/kubernetes/apps/main/renovate/renovate.yaml
+++ b/kubernetes/apps/main/renovate/renovate.yaml
@@ -5,17 +5,12 @@ metadata:
   name: &app renovate-operator
 spec:
   healthChecks:
-  - apiVersion: helm.toolkit.fluxcd.io/v2
-    kind: HelmRelease
-    name: renovate-operator
-    namespace: renovate
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: renovate-operator
+      namespace: renovate
   interval: 1h
   path: ./kubernetes/apps/base/renovate/renovate-operator
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -24,12 +19,7 @@ metadata:
   name: &app renovate-operator-jobs
 spec:
   dependsOn:
-  - name: renovate-operator
+    - name: renovate-operator
   interval: 1h
   path: ./kubernetes/apps/base/renovate/renovate-jobs
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/rook-ceph/rook-ceph.yaml
+++ b/kubernetes/apps/main/rook-ceph/rook-ceph.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/rook-ceph/rook-ceph/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -20,27 +15,22 @@ metadata:
   name: &app rook-ceph-cluster
 spec:
   dependsOn:
-  - name: rook-ceph
-  - name: volsync
-    namespace: storage
+    - name: rook-ceph
+    - name: volsync
+      namespace: storage
   healthChecks:
-  - apiVersion: helm.toolkit.fluxcd.io/v2
-    kind: HelmRelease
-    name: *app
-    namespace: rook-ceph
-  - apiVersion: ceph.rook.io/v1
-    kind: CephCluster
-    name: rook-ceph
-    namespace: rook-ceph
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: *app
+      namespace: rook-ceph
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      name: rook-ceph
+      namespace: rook-ceph
   healthCheckExprs:
-  - apiVersion: ceph.rook.io/v1
-    kind: CephCluster
-    failed: status.ceph.health == 'HEALTH_ERR'
-    current: status.ceph.health in ['HEALTH_OK', 'HEALTH_WARN']
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      failed: status.ceph.health == 'HEALTH_ERR'
+      current: status.ceph.health in ['HEALTH_OK', 'HEALTH_WARN']
   interval: 1h
   path: ./kubernetes/apps/base/rook-ceph/rook-ceph/cluster
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system

--- a/kubernetes/apps/main/security/authentik.yaml
+++ b/kubernetes/apps/main/security/authentik.yaml
@@ -19,9 +19,4 @@ spec:
       APP: *app
       SUBDOMAIN: sso
       POOL_MODE: transaction
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/self-hosted/actual.yaml
+++ b/kubernetes/apps/main/self-hosted/actual.yaml
@@ -13,9 +13,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/self-hosted/archiveteam.yaml
+++ b/kubernetes/apps/main/self-hosted/archiveteam.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       STORAGECLASS: ceph-block
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/self-hosted/atuin.yaml
+++ b/kubernetes/apps/main/self-hosted/atuin.yaml
@@ -12,9 +12,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/self-hosted/bentopdf.yaml
+++ b/kubernetes/apps/main/self-hosted/bentopdf.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/self-hosted/manyfold.yaml
+++ b/kubernetes/apps/main/self-hosted/manyfold.yaml
@@ -15,9 +15,4 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 15Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/self-hosted/paperless.yaml
+++ b/kubernetes/apps/main/self-hosted/paperless.yaml
@@ -26,9 +26,4 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 15Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/self-hosted/picoshare.yaml
+++ b/kubernetes/apps/main/self-hosted/picoshare.yaml
@@ -13,9 +13,4 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 50Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/self-hosted/spoolman.yaml
+++ b/kubernetes/apps/main/self-hosted/spoolman.yaml
@@ -13,9 +13,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/self-hosted/webhook.yaml
+++ b/kubernetes/apps/main/self-hosted/webhook.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/storage/kopia.yaml
+++ b/kubernetes/apps/main/storage/kopia.yaml
@@ -14,9 +14,4 @@ spec:
   postBuild:
     substitute:
       APP: *app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/storage/openebs.yaml
+++ b/kubernetes/apps/main/storage/openebs.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/storage/openebs
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/storage/snapshot-controller.yaml
+++ b/kubernetes/apps/main/storage/snapshot-controller.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       REPLICAS: "2"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/storage/volsync-maintenance.yaml
+++ b/kubernetes/apps/main/storage/volsync-maintenance.yaml
@@ -9,9 +9,4 @@ spec:
     - name: volsync
   interval: 1h
   path: ./kubernetes/apps/base/storage/volsync-maintenance
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/storage/volsync.yaml
+++ b/kubernetes/apps/main/storage/volsync.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       REPLICAS: "2"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/workadventure/coturn.yaml
+++ b/kubernetes/apps/main/workadventure/coturn.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/workadventure/synapse.yaml
+++ b/kubernetes/apps/main/workadventure/synapse.yaml
@@ -20,9 +20,4 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 10Gi
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/main/workadventure/workadventure.yaml
+++ b/kubernetes/apps/main/workadventure/workadventure.yaml
@@ -18,9 +18,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/test/actions-runner-system/actions-runner-controller.yaml
+++ b/kubernetes/apps/test/actions-runner-system/actions-runner-controller.yaml
@@ -5,13 +5,7 @@ metadata:
   name: actions-runner-controller
 spec:
   interval: 1h
-  path:
-    ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
+  path: ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/app
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -21,19 +15,13 @@ metadata:
   name: actions-runner-controller-runners
 spec:
   dependsOn:
-  - name: actions-runner-controller
-  - name: democratic-csi
-    namespace: storage
+    - name: actions-runner-controller
+    - name: democratic-csi
+      namespace: storage
   interval: 1h
-  path:
-    ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners
+  path: ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
       maxRunners: "2" # 2 per node
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/test/cert-manager/cert-manager.yaml
+++ b/kubernetes/apps/test/cert-manager/cert-manager.yaml
@@ -20,8 +20,3 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/cert-manager/cert-manager
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system

--- a/kubernetes/apps/test/external-secrets/external-secrets.yaml
+++ b/kubernetes/apps/test/external-secrets/external-secrets.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/external-secrets/external-secrets
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/test/external-secrets/onepassword-connect.yaml
+++ b/kubernetes/apps/test/external-secrets/onepassword-connect.yaml
@@ -22,9 +22,4 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/external-secrets/onepassword-connect
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/test/flux-system/addons.yaml
+++ b/kubernetes/apps/test/flux-system/addons.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: flux-webhook-${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/test/flux-system/flux-operator.yaml
+++ b/kubernetes/apps/test/flux-system/flux-operator.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: flux-${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/test/flux-system/headlamp.yaml
+++ b/kubernetes/apps/test/flux-system/headlamp.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: headlamp-${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/test/kube-system/cilium.yaml
+++ b/kubernetes/apps/test/kube-system/cilium.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/cilium
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -20,12 +15,7 @@ metadata:
   name: cilium-config
 spec:
   dependsOn:
-  - name: cilium
+    - name: cilium
   interval: 15m
   path: ./kubernetes/apps/${CLUSTER}/kube-system/cilium
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/test/kube-system/coredns.yaml
+++ b/kubernetes/apps/test/kube-system/coredns.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/coredns
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/test/kube-system/metrics-server.yaml
+++ b/kubernetes/apps/test/kube-system/metrics-server.yaml
@@ -10,10 +10,5 @@ spec:
   postBuild:
     substitute:
       REPLICAS: "1"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: kube-system
   wait: false

--- a/kubernetes/apps/test/kube-tools/reloader.yaml
+++ b/kubernetes/apps/test/kube-tools/reloader.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-tools/reloader
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/test/kube-tools/tuppr.yaml
+++ b/kubernetes/apps/test/kube-tools/tuppr.yaml
@@ -9,11 +9,6 @@ spec:
   postBuild:
     substitute:
       REPLICAS: "1"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -23,12 +18,7 @@ metadata:
   name: tuppr-upgrades
 spec:
   dependsOn:
-  - name: tuppr
+    - name: tuppr
   interval: 1h
   path: ./kubernetes/apps/${CLUSTER}/kube-tools/upgrades
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/test/network/certificates.yaml
+++ b/kubernetes/apps/test/network/certificates.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/import
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -21,9 +16,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/certificate
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/test/network/cloudflare-dns.yaml
+++ b/kubernetes/apps/test/network/cloudflare-dns.yaml
@@ -18,8 +18,3 @@ spec:
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system

--- a/kubernetes/apps/test/network/cloudflare-tunnel.yaml
+++ b/kubernetes/apps/test/network/cloudflare-tunnel.yaml
@@ -12,9 +12,4 @@ spec:
       CLOUDFLARED_TUNNEL_ID: 51921033-9888-483b-aa37-1572275acd11
       CLUSTER: ${CLUSTER}
       EXTERNAL_DOMAIN: ${CLUSTER}-external
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/test/network/echo.yaml
+++ b/kubernetes/apps/test/network/echo.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       SUBDOMAIN: echo-${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/test/network/envoy-gateway.yaml
+++ b/kubernetes/apps/test/network/envoy-gateway.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/envoy-gateway/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: network
   wait: false
 ---
@@ -21,8 +16,8 @@ metadata:
   name: envoy-config
 spec:
   dependsOn:
-  - name: certificates-import
-  - name: envoy-gateway
+    - name: certificates-import
+    - name: envoy-gateway
   interval: 1h
   path: ./kubernetes/apps/base/network/envoy-gateway/config
   postBuild:
@@ -32,9 +27,4 @@ spec:
       INTERNAL_DOMAIN: ${CLUSTER}-internal
       SVC_GATEWAY_EXTERNAL: 10.69.10.232
       SVC_GATEWAY_INTERNAL: 10.69.10.231
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/test/network/unifi-dns.yaml
+++ b/kubernetes/apps/test/network/unifi-dns.yaml
@@ -11,9 +11,4 @@ spec:
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/test/storage/democratic-csi.yaml
+++ b/kubernetes/apps/test/storage/democratic-csi.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       STORAGE_PATH: /var/mnt/local-hostpath
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/test/storage/snapshot-controller.yaml
+++ b/kubernetes/apps/test/storage/snapshot-controller.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       REPLICAS: "1"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/test/storage/volsync.yaml
+++ b/kubernetes/apps/test/storage/volsync.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       REPLICAS: "1"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/actions-runner-system/actions-runner-controller.yaml
+++ b/kubernetes/apps/utility/actions-runner-system/actions-runner-controller.yaml
@@ -5,13 +5,7 @@ metadata:
   name: actions-runner-controller
 spec:
   interval: 1h
-  path:
-    ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
+  path: ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/app
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -21,19 +15,13 @@ metadata:
   name: actions-runner-controller-runners
 spec:
   dependsOn:
-  - name: actions-runner-controller
-  - name: democratic-csi
-    namespace: storage
+    - name: actions-runner-controller
+    - name: democratic-csi
+      namespace: storage
   interval: 1h
-  path:
-    ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners
+  path: ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
       maxRunners: "2" # 2 per node
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/cert-manager/cert-manager.yaml
+++ b/kubernetes/apps/utility/cert-manager/cert-manager.yaml
@@ -20,8 +20,3 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/cert-manager/cert-manager
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system

--- a/kubernetes/apps/utility/external-secrets/external-secrets.yaml
+++ b/kubernetes/apps/utility/external-secrets/external-secrets.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/external-secrets/external-secrets
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/utility/external-secrets/onepassword-connect.yaml
+++ b/kubernetes/apps/utility/external-secrets/onepassword-connect.yaml
@@ -22,9 +22,4 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/external-secrets/onepassword-connect
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/utility/flux-system/addons.yaml
+++ b/kubernetes/apps/utility/flux-system/addons.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: flux-webhook-${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/flux-system/flux-operator.yaml
+++ b/kubernetes/apps/utility/flux-system/flux-operator.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: flux-${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/utility/flux-system/headlamp.yaml
+++ b/kubernetes/apps/utility/flux-system/headlamp.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: headlamp-${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/flux-system/tofu-controller.yaml
+++ b/kubernetes/apps/utility/flux-system/tofu-controller.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/flux-system/tofu-controller
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -20,12 +15,7 @@ metadata:
   name: tofu-controller-terraforms
 spec:
   dependsOn:
-  - name: tofu-controller
+    - name: tofu-controller
   interval: 1h
   path: ./kubernetes/apps/${CLUSTER}/flux-system/terraform
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/home-automation/home-assistant.yaml
+++ b/kubernetes/apps/utility/home-automation/home-assistant.yaml
@@ -16,9 +16,4 @@ spec:
       STORAGE_NS: ${STORAGE_NS}
       VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
       VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/home-automation/hoymiles-mqtt.yaml
+++ b/kubernetes/apps/utility/home-automation/hoymiles-mqtt.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/home-automation/hoymiles-mqtt
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/home-automation/matter-server.yaml
+++ b/kubernetes/apps/utility/home-automation/matter-server.yaml
@@ -16,9 +16,4 @@ spec:
       STORAGE_NS: ${STORAGE_NS}
       VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
       VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/home-automation/mosquitto.yaml
+++ b/kubernetes/apps/utility/home-automation/mosquitto.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/home-automation/mosquitto/
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/home-automation/rtlamr2mqtt.yaml
+++ b/kubernetes/apps/utility/home-automation/rtlamr2mqtt.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/home-automation/rtlamr2mqtt
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/home-automation/zigbee.yaml
+++ b/kubernetes/apps/utility/home-automation/zigbee.yaml
@@ -18,9 +18,4 @@ spec:
       STORAGE_NS: ${STORAGE_NS}
       VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
       VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/kube-system/cilium.yaml
+++ b/kubernetes/apps/utility/kube-system/cilium.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/cilium
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -20,12 +15,7 @@ metadata:
   name: cilium-config
 spec:
   dependsOn:
-  - name: cilium
+    - name: cilium
   interval: 15m
   path: ./kubernetes/apps/${CLUSTER}/kube-system/cilium
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/kube-system/coredns.yaml
+++ b/kubernetes/apps/utility/kube-system/coredns.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/coredns
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/kube-system/metrics-server.yaml
+++ b/kubernetes/apps/utility/kube-system/metrics-server.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       REPLICAS: "1"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/kube-tools/reloader.yaml
+++ b/kubernetes/apps/utility/kube-tools/reloader.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-tools/reloader
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/kube-tools/tuppr.yaml
+++ b/kubernetes/apps/utility/kube-tools/tuppr.yaml
@@ -9,11 +9,6 @@ spec:
   postBuild:
     substitute:
       REPLICAS: "1"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -23,12 +18,7 @@ metadata:
   name: tuppr-upgrades
 spec:
   dependsOn:
-  - name: tuppr
+    - name: tuppr
   interval: 1h
   path: ./kubernetes/apps/${CLUSTER}/kube-tools/upgrades
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/llm/llama-ryzen.yaml
+++ b/kubernetes/apps/utility/llm/llama-ryzen.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/network/certificates.yaml
+++ b/kubernetes/apps/utility/network/certificates.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/import
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -21,9 +16,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/certificate
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/utility/network/cloudflare-dns.yaml
+++ b/kubernetes/apps/utility/network/cloudflare-dns.yaml
@@ -18,8 +18,3 @@ spec:
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system

--- a/kubernetes/apps/utility/network/cloudflare-tunnel.yaml
+++ b/kubernetes/apps/utility/network/cloudflare-tunnel.yaml
@@ -12,9 +12,4 @@ spec:
       CLOUDFLARED_TUNNEL_ID: 4e64e0e1-a45d-40c2-bb22-1d94f3bb51ba
       CLUSTER: ${CLUSTER}
       EXTERNAL_DOMAIN: ${CLUSTER}-external
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/network/echo.yaml
+++ b/kubernetes/apps/utility/network/echo.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       SUBDOMAIN: echo-${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/network/envoy-gateway.yaml
+++ b/kubernetes/apps/utility/network/envoy-gateway.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/envoy-gateway/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -20,7 +15,7 @@ metadata:
   name: envoy-config
 spec:
   dependsOn:
-  - name: envoy-gateway
+    - name: envoy-gateway
   interval: 1h
   path: ./kubernetes/apps/base/network/envoy-gateway/config
   postBuild:
@@ -30,9 +25,4 @@ spec:
       INTERNAL_DOMAIN: ${CLUSTER}-internal
       SVC_GATEWAY_EXTERNAL: 10.69.10.132
       SVC_GATEWAY_INTERNAL: 10.69.10.131
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/network/multus.yaml
+++ b/kubernetes/apps/utility/network/multus.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/multus
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -20,12 +15,7 @@ metadata:
   name: multus-networks
 spec:
   dependsOn:
-  - name: multus
+    - name: multus
   interval: 1h
   path: ./kubernetes/apps/${CLUSTER}/network/multus
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/utility/network/unifi-dns.yaml
+++ b/kubernetes/apps/utility/network/unifi-dns.yaml
@@ -11,9 +11,4 @@ spec:
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: true

--- a/kubernetes/apps/utility/observability/exporters/blackbox-exporter.yaml
+++ b/kubernetes/apps/utility/observability/exporters/blackbox-exporter.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       SUBDOMAIN: blackbox-${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/observability/exporters/smartctl-exporter.yaml
+++ b/kubernetes/apps/utility/observability/exporters/smartctl-exporter.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/smartctl-exporter
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/observability/gatus.yaml
+++ b/kubernetes/apps/utility/observability/gatus.yaml
@@ -10,9 +10,4 @@ spec:
   postBuild:
     substitute:
       SUBDOMAIN: status-${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/observability/grafana.yaml
+++ b/kubernetes/apps/utility/observability/grafana.yaml
@@ -6,11 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/grafana/operator
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
@@ -20,17 +15,12 @@ metadata:
   name: grafana-instance
 spec:
   dependsOn:
-  - name: grafana
-  - name: democratic-csi
-    namespace: storage
+    - name: grafana
+    - name: democratic-csi
+      namespace: storage
   interval: 1h
   path: ./kubernetes/apps/base/observability/grafana/instance
   postBuild:
     substitute:
       SUBDOMAIN: grafana-${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/observability/kube-prometheus-stack.yaml
+++ b/kubernetes/apps/utility/observability/kube-prometheus-stack.yaml
@@ -14,9 +14,4 @@ spec:
       PVC_CAPACITY: "50"
       STORAGECLASS: local-hostpath
       SUBDOMAIN: prometheus-${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/observability/prometheus-adapter.yaml
+++ b/kubernetes/apps/utility/observability/prometheus-adapter.yaml
@@ -7,10 +7,5 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/prometheus-adapter
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: observability
   wait: false

--- a/kubernetes/apps/utility/observability/silence-operator.yaml
+++ b/kubernetes/apps/utility/observability/silence-operator.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/silence-operator
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/self-hosted/acars.yaml
+++ b/kubernetes/apps/utility/self-hosted/acars.yaml
@@ -24,9 +24,4 @@ spec:
       - kind: Secret
         name: acars-processor
         optional: false
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/self-hosted/free-game-notifier.yaml
+++ b/kubernetes/apps/utility/self-hosted/free-game-notifier.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/free-game-notifier
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/self-hosted/hypermind.yaml
+++ b/kubernetes/apps/utility/self-hosted/hypermind.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/self-hosted/it-tools.yaml
+++ b/kubernetes/apps/utility/self-hosted/it-tools.yaml
@@ -11,9 +11,4 @@ spec:
     substitute:
       APP: *app
       CLUSTER: ${CLUSTER}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/self-hosted/meshcentral.yaml
+++ b/kubernetes/apps/utility/self-hosted/meshcentral.yaml
@@ -16,9 +16,4 @@ spec:
       STORAGE_NS: ${STORAGE_NS}
       VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
       VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/self-hosted/rss-forwarder.yaml
+++ b/kubernetes/apps/utility/self-hosted/rss-forwarder.yaml
@@ -7,9 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/rss-forwarder
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/self-hosted/scanservjs.yaml
+++ b/kubernetes/apps/utility/self-hosted/scanservjs.yaml
@@ -16,9 +16,4 @@ spec:
       STORAGE_NS: ${STORAGE_NS}
       VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
       VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/self-hosted/thelounge.yaml
+++ b/kubernetes/apps/utility/self-hosted/thelounge.yaml
@@ -16,9 +16,4 @@ spec:
       STORAGE_NS: ${STORAGE_NS}
       VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
       VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   wait: false

--- a/kubernetes/apps/utility/storage/democratic-csi.yaml
+++ b/kubernetes/apps/utility/storage/democratic-csi.yaml
@@ -9,11 +9,6 @@ spec:
   path: ./kubernetes/apps/base/storage/democratic-csi
   postBuild:
     substitute:
-      STORAGE_PATH: /var/mnt/local-hostpath  ##Swap on next rebuild
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
+      STORAGE_PATH: /var/mnt/local-hostpath ##Swap on next rebuild
   targetNamespace: storage
   wait: false

--- a/kubernetes/apps/utility/storage/snapshot-controller.yaml
+++ b/kubernetes/apps/utility/storage/snapshot-controller.yaml
@@ -10,10 +10,5 @@ spec:
   postBuild:
     substitute:
       REPLICAS: "1"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: storage
   wait: false

--- a/kubernetes/apps/utility/storage/volsync.yaml
+++ b/kubernetes/apps/utility/storage/volsync.yaml
@@ -10,10 +10,5 @@ spec:
   postBuild:
     substitute:
       REPLICAS: "1"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: storage
   wait: false

--- a/kubernetes/clusters/main/apps.yaml
+++ b/kubernetes/clusters/main/apps.yaml
@@ -27,6 +27,11 @@ spec:
           name: not-used
         spec:
           deletionPolicy: WaitForTermination
+          prune: true
+          sourceRef:
+            kind: GitRepository
+            name: flux-system
+            namespace: flux-system
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}

--- a/kubernetes/clusters/test/apps.yaml
+++ b/kubernetes/clusters/test/apps.yaml
@@ -31,6 +31,11 @@ spec:
           name: not-used
         spec:
           deletionPolicy: WaitForTermination
+          prune: true
+          sourceRef:
+            kind: GitRepository
+            name: flux-system
+            namespace: flux-system
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}

--- a/kubernetes/clusters/utility/apps.yaml
+++ b/kubernetes/clusters/utility/apps.yaml
@@ -31,6 +31,11 @@ spec:
           name: not-used
         spec:
           deletionPolicy: WaitForTermination
+          prune: true
+          sourceRef:
+            kind: GitRepository
+            name: flux-system
+            namespace: flux-system
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}


### PR DESCRIPTION
## Summary

Centralize the boilerplate `sourceRef` and `prune` fields into the parent `cluster-apps` Kustomization's "defaults" patch, so they're inherited by every child Flux Kustomization. Strip the now-redundant fields from each per-cluster ks file.

**Note on interval:** the original audit recommended centralizing `interval: 1h` too. Aborted that — kustomize strategic merge patches *override* child values rather than acting as defaults, which would force 12 apps with intentional non-default intervals (`1m`/`15m`/`12h`) back to `1h`. Per-app interval stays explicit. Survey results that made this safe vs. unsafe:

- `prune: true` — 222/222 files use this value → safe to centralize
- `sourceRef: { kind: GitRepository, name: flux-system, namespace: flux-system }` — 222/222 Flux Kustomizations use this value (the 3 `name: terraform` references are in tofu-controller `Terraform` resources, different kind, not patched) → safe to centralize
- `interval` — has 12 legitimate overrides → NOT centralized

## Verification

Ran `flux-local diff ks` for each cluster against `main` — zero output (zero behavioral change). The render passes through identically:

```
=== main ===   (empty)
=== utility === (empty)
=== test ===   (empty)
```

Per-app reconcile frequencies (e.g., the `rook-ceph` 15m, `external-dns` 1m) all preserved because interval wasn't centralized.

## Net diff

- `+137` insertions
- `-1241` deletions  
- 175 files changed (172 child ks files + 3 cluster apps.yaml)

Roughly 1100 lines of YAML removed with no behavioral change.

## Test plan

- [ ] Flate Test passes on all 3 clusters × 2 resource kinds
- [ ] Flate Diff shows empty diff (the substantive verification)
- [ ] After merge: `kubectl get ks -A --no-headers | wc -l` returns the same count as before (sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)