### PR TITLE
chore: centralize REPLICAS + EXTERNAL/INTERNAL_DOMAIN substitutes

### DIFF
--- a/kubernetes/apps/main/kube-system/metrics-server.yaml
+++ b/kubernetes/apps/main/kube-system/metrics-server.yaml
@@ -7,7 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/metrics-server
-  postBuild:
-    substitute:
-      REPLICAS: "2"
   wait: false

--- a/kubernetes/apps/main/kube-tools/descheduler.yaml
+++ b/kubernetes/apps/main/kube-tools/descheduler.yaml
@@ -7,7 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-tools/descheduler
-  postBuild:
-    substitute:
-      REPLICAS: "2"
   wait: false

--- a/kubernetes/apps/main/kube-tools/tuppr.yaml
+++ b/kubernetes/apps/main/kube-tools/tuppr.yaml
@@ -6,9 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-tools/tuppr
-  postBuild:
-    substitute:
-      REPLICAS: "2"
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json

--- a/kubernetes/apps/main/network/cloudflare-tunnel.yaml
+++ b/kubernetes/apps/main/network/cloudflare-tunnel.yaml
@@ -11,6 +11,4 @@ spec:
     substitute:
       CLOUDFLARED_TUNNEL_ID: 85be482d-5cf9-4ee5-a9a0-c489e3dd6188
       CLUSTER: ${CLUSTER}
-      EXTERNAL_DOMAIN: external
-      REPLICAS: "2"
   wait: false

--- a/kubernetes/apps/main/network/envoy-gateway.yaml
+++ b/kubernetes/apps/main/network/envoy-gateway.yaml
@@ -22,9 +22,6 @@ spec:
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
-      EXTERNAL_DOMAIN: external
-      INTERNAL_DOMAIN: internal
-      REPLICAS: "2"
       SVC_GATEWAY_EXTERNAL: 10.69.10.32
       SVC_GATEWAY_INTERNAL: 10.69.10.31
   wait: false

--- a/kubernetes/apps/main/storage/snapshot-controller.yaml
+++ b/kubernetes/apps/main/storage/snapshot-controller.yaml
@@ -7,7 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/storage/snapshot-controller
-  postBuild:
-    substitute:
-      REPLICAS: "2"
   wait: false

--- a/kubernetes/apps/main/storage/volsync.yaml
+++ b/kubernetes/apps/main/storage/volsync.yaml
@@ -7,7 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/storage/volsync
-  postBuild:
-    substitute:
-      REPLICAS: "2"
   wait: false

--- a/kubernetes/apps/test/kube-system/metrics-server.yaml
+++ b/kubernetes/apps/test/kube-system/metrics-server.yaml
@@ -7,8 +7,5 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/metrics-server
-  postBuild:
-    substitute:
-      REPLICAS: "1"
   targetNamespace: kube-system
   wait: false

--- a/kubernetes/apps/test/kube-tools/tuppr.yaml
+++ b/kubernetes/apps/test/kube-tools/tuppr.yaml
@@ -6,9 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-tools/tuppr
-  postBuild:
-    substitute:
-      REPLICAS: "1"
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json

--- a/kubernetes/apps/test/network/cloudflare-tunnel.yaml
+++ b/kubernetes/apps/test/network/cloudflare-tunnel.yaml
@@ -11,5 +11,4 @@ spec:
     substitute:
       CLOUDFLARED_TUNNEL_ID: 51921033-9888-483b-aa37-1572275acd11
       CLUSTER: ${CLUSTER}
-      EXTERNAL_DOMAIN: ${CLUSTER}-external
   wait: false

--- a/kubernetes/apps/test/network/envoy-gateway.yaml
+++ b/kubernetes/apps/test/network/envoy-gateway.yaml
@@ -23,8 +23,6 @@ spec:
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
-      EXTERNAL_DOMAIN: ${CLUSTER}-external
-      INTERNAL_DOMAIN: ${CLUSTER}-internal
       SVC_GATEWAY_EXTERNAL: 10.69.10.232
       SVC_GATEWAY_INTERNAL: 10.69.10.231
   wait: false

--- a/kubernetes/apps/test/storage/snapshot-controller.yaml
+++ b/kubernetes/apps/test/storage/snapshot-controller.yaml
@@ -7,7 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/storage/snapshot-controller
-  postBuild:
-    substitute:
-      REPLICAS: "1"
   wait: false

--- a/kubernetes/apps/test/storage/volsync.yaml
+++ b/kubernetes/apps/test/storage/volsync.yaml
@@ -7,7 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/storage/volsync
-  postBuild:
-    substitute:
-      REPLICAS: "1"
   wait: false

--- a/kubernetes/apps/utility/kube-system/metrics-server.yaml
+++ b/kubernetes/apps/utility/kube-system/metrics-server.yaml
@@ -7,7 +7,4 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/metrics-server
-  postBuild:
-    substitute:
-      REPLICAS: "1"
   wait: false

--- a/kubernetes/apps/utility/kube-tools/tuppr.yaml
+++ b/kubernetes/apps/utility/kube-tools/tuppr.yaml
@@ -6,9 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-tools/tuppr
-  postBuild:
-    substitute:
-      REPLICAS: "1"
   wait: true
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json

--- a/kubernetes/apps/utility/network/cloudflare-tunnel.yaml
+++ b/kubernetes/apps/utility/network/cloudflare-tunnel.yaml
@@ -11,5 +11,4 @@ spec:
     substitute:
       CLOUDFLARED_TUNNEL_ID: 4e64e0e1-a45d-40c2-bb22-1d94f3bb51ba
       CLUSTER: ${CLUSTER}
-      EXTERNAL_DOMAIN: ${CLUSTER}-external
   wait: false

--- a/kubernetes/apps/utility/network/envoy-gateway.yaml
+++ b/kubernetes/apps/utility/network/envoy-gateway.yaml
@@ -21,8 +21,6 @@ spec:
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
-      EXTERNAL_DOMAIN: ${CLUSTER}-external
-      INTERNAL_DOMAIN: ${CLUSTER}-internal
       SVC_GATEWAY_EXTERNAL: 10.69.10.132
       SVC_GATEWAY_INTERNAL: 10.69.10.131
   wait: false

--- a/kubernetes/apps/utility/storage/snapshot-controller.yaml
+++ b/kubernetes/apps/utility/storage/snapshot-controller.yaml
@@ -7,8 +7,5 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/storage/snapshot-controller
-  postBuild:
-    substitute:
-      REPLICAS: "1"
   targetNamespace: storage
   wait: false

--- a/kubernetes/apps/utility/storage/volsync.yaml
+++ b/kubernetes/apps/utility/storage/volsync.yaml
@@ -7,8 +7,5 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/storage/volsync
-  postBuild:
-    substitute:
-      REPLICAS: "1"
   targetNamespace: storage
   wait: false

--- a/kubernetes/clusters/main/apps.yaml
+++ b/kubernetes/clusters/main/apps.yaml
@@ -12,6 +12,9 @@ spec:
   postBuild:
     substitute:
       CLUSTER: main
+      EXTERNAL_DOMAIN: external
+      INTERNAL_DOMAIN: internal
+      REPLICAS: "2"
       SECRET_DOMAIN: jory.dev
   prune: true
   sourceRef:
@@ -35,6 +38,9 @@ spec:
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}
+              EXTERNAL_DOMAIN: ${EXTERNAL_DOMAIN}
+              INTERNAL_DOMAIN: ${INTERNAL_DOMAIN}
+              REPLICAS: ${REPLICAS}
               SECRET_DOMAIN: ${SECRET_DOMAIN}
           patches:
             - patch: |-

--- a/kubernetes/clusters/test/apps.yaml
+++ b/kubernetes/clusters/test/apps.yaml
@@ -12,6 +12,9 @@ spec:
   postBuild:
     substitute:
       CLUSTER: test
+      EXTERNAL_DOMAIN: ${CLUSTER}-external
+      INTERNAL_DOMAIN: ${CLUSTER}-internal
+      REPLICAS: "1"
       SECRET_DOMAIN: jory.dev
       STORAGE_HR: democratic-csi
       STORAGE_NS: storage
@@ -39,6 +42,9 @@ spec:
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}
+              EXTERNAL_DOMAIN: ${EXTERNAL_DOMAIN}
+              INTERNAL_DOMAIN: ${INTERNAL_DOMAIN}
+              REPLICAS: ${REPLICAS}
               SECRET_DOMAIN: ${SECRET_DOMAIN}
               STORAGE_HR: ${STORAGE_HR}
               STORAGE_NS: ${STORAGE_NS}

--- a/kubernetes/clusters/utility/apps.yaml
+++ b/kubernetes/clusters/utility/apps.yaml
@@ -12,6 +12,9 @@ spec:
   postBuild:
     substitute:
       CLUSTER: utility
+      EXTERNAL_DOMAIN: ${CLUSTER}-external
+      INTERNAL_DOMAIN: ${CLUSTER}-internal
+      REPLICAS: "1"
       SECRET_DOMAIN: jory.dev
       STORAGE_HR: democratic-csi
       STORAGE_NS: storage
@@ -39,6 +42,9 @@ spec:
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}
+              EXTERNAL_DOMAIN: ${EXTERNAL_DOMAIN}
+              INTERNAL_DOMAIN: ${INTERNAL_DOMAIN}
+              REPLICAS: ${REPLICAS}
               SECRET_DOMAIN: ${SECRET_DOMAIN}
               STORAGE_HR: ${STORAGE_HR}
               STORAGE_NS: ${STORAGE_NS}


### PR DESCRIPTION
## Summary

Continuing the PR A/B centralization pattern. Move three more substitute values from per-app ks files into each cluster-apps Kustomization, inherited by every child via the "Kustomization defaults" patch.

| Substitute | main | utility | test |
|---|---|---|---|
| `REPLICAS` | `"2"` | `"1"` | `"1"` |
| `EXTERNAL_DOMAIN` | `external` | `${CLUSTER}-external` | `${CLUSTER}-external` |
| `INTERNAL_DOMAIN` | `internal` | `${CLUSTER}-internal` | `${CLUSTER}-internal` |

Stripped from:
- **REPLICAS**: 7 main + 4 utility + 4 test child ks files (storage/snapshot-controller, storage/volsync, kube-tools/tuppr, kube-tools/descheduler, kube-system/metrics-server, network/envoy-gateway, network/cloudflare-tunnel — varies by cluster)
- **EXTERNAL_DOMAIN/INTERNAL_DOMAIN**: cloudflare-tunnel.yaml + envoy-gateway.yaml across all 3 clusters

All three values are uniform-per-cluster (no app-specific overrides), so safe to centralize via the parent patch without PR B's "interval override" issue.

## Verification

`flux-local diff hr` against `main` — empty on all 3 clusters. HelmRelease render is byte-identical.

The Kustomization-level diff shows the new substitute keys propagating to every child Kustomization (the inheritance pattern working as designed); the actual HR values consumed via `${REPLICAS:=1}`, `${EXTERNAL_DOMAIN}`, etc. resolve to the same final string in every case.

## Net diff

- 22 files changed, +18 / -50
- 3 cluster apps.yaml files gain the new substitutes
- 19 per-cluster ks files strip the now-redundant lines

## Deferred

**`#7` SUBDOMAIN_SUFFIX centralization** — requires coordinated edits to ~9 base HRs to use `${SUBDOMAIN}${SUBDOMAIN_SUFFIX}` instead of bare `${SUBDOMAIN}`. Bigger blast radius, will follow up if PR C lands cleanly.

## Test plan

- [ ] Flux Local Test passes on all 3 clusters
- [ ] Flux Local Diff (helmrelease) is empty (the substantive verification)
- [ ] Flux Local Diff (kustomization) shows the new substitute keys appearing on every child — that's expected and benign

🤖 Generated with [Claude Code](https://claude.com/claude-code)