### PR TITLE
chore: restore explicit sourceRef + prune on child Kustomizations

### DIFF
--- a/kubernetes/apps/main/actions-runner-system/actions-runner-controller.yaml
+++ b/kubernetes/apps/main/actions-runner-system/actions-runner-controller.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/app
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -25,3 +30,8 @@ spec:
       CLUSTER: ${CLUSTER}
       maxRunners: "6" # 2 per node
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/cert-manager/cert-manager.yaml
+++ b/kubernetes/apps/main/cert-manager/cert-manager.yaml
@@ -20,3 +20,8 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/cert-manager/cert-manager
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/database/cloudnative-pg.yaml
+++ b/kubernetes/apps/main/database/cloudnative-pg.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/database/cloudnative-pg
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/database/dragonfly.yaml
+++ b/kubernetes/apps/main/database/dragonfly.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/database/dragonfly
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/autobrr.yaml
+++ b/kubernetes/apps/main/downloads/autobrr.yaml
@@ -14,3 +14,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/bazarr.yaml
+++ b/kubernetes/apps/main/downloads/bazarr.yaml
@@ -15,3 +15,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/brrpolice.yaml
+++ b/kubernetes/apps/main/downloads/brrpolice.yaml
@@ -15,3 +15,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/decluttarr.yaml
+++ b/kubernetes/apps/main/downloads/decluttarr.yaml
@@ -12,3 +12,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/deduparr.yaml
+++ b/kubernetes/apps/main/downloads/deduparr.yaml
@@ -12,3 +12,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/flaresolverr.yaml
+++ b/kubernetes/apps/main/downloads/flaresolverr.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/downloads/flaresolverr
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/kapowarr.yaml
+++ b/kubernetes/apps/main/downloads/kapowarr.yaml
@@ -15,3 +15,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/metube.yaml
+++ b/kubernetes/apps/main/downloads/metube.yaml
@@ -15,3 +15,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/mylar.yaml
+++ b/kubernetes/apps/main/downloads/mylar.yaml
@@ -15,3 +15,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/pinchflat.yaml
+++ b/kubernetes/apps/main/downloads/pinchflat.yaml
@@ -14,3 +14,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/prowlarr.yaml
+++ b/kubernetes/apps/main/downloads/prowlarr.yaml
@@ -19,3 +19,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/qbittorrent.yaml
+++ b/kubernetes/apps/main/downloads/qbittorrent.yaml
@@ -14,3 +14,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/qui.yaml
+++ b/kubernetes/apps/main/downloads/qui.yaml
@@ -14,3 +14,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/radarr.yaml
+++ b/kubernetes/apps/main/downloads/radarr.yaml
@@ -20,3 +20,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/recyclarr.yaml
+++ b/kubernetes/apps/main/downloads/recyclarr.yaml
@@ -17,3 +17,8 @@ spec:
       APP: *app
   targetNamespace: downloads
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/sabnzbd.yaml
+++ b/kubernetes/apps/main/downloads/sabnzbd.yaml
@@ -14,3 +14,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/sonarr.yaml
+++ b/kubernetes/apps/main/downloads/sonarr.yaml
@@ -20,3 +20,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/downloads/tdarr-node.yaml
+++ b/kubernetes/apps/main/downloads/tdarr-node.yaml
@@ -13,3 +13,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/external-secrets/external-secrets.yaml
+++ b/kubernetes/apps/main/external-secrets/external-secrets.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/external-secrets/external-secrets
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/external-secrets/onepassword-connect.yaml
+++ b/kubernetes/apps/main/external-secrets/onepassword-connect.yaml
@@ -23,3 +23,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/external-secrets/onepassword-connect
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/flux-system/addons.yaml
+++ b/kubernetes/apps/main/flux-system/addons.yaml
@@ -12,3 +12,8 @@ spec:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: flux-webhook
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/flux-system/flux-operator.yaml
+++ b/kubernetes/apps/main/flux-system/flux-operator.yaml
@@ -12,3 +12,8 @@ spec:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: flux
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/flux-system/headlamp.yaml
+++ b/kubernetes/apps/main/flux-system/headlamp.yaml
@@ -12,3 +12,8 @@ spec:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: headlamp
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/games/core-keeper.yaml
+++ b/kubernetes/apps/main/games/core-keeper.yaml
@@ -16,3 +16,8 @@ spec:
       VOLSYNC_UID: "1000"
       VOLSYNC_GID: "1000"
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/games/enshrouded.yaml
+++ b/kubernetes/apps/main/games/enshrouded.yaml
@@ -16,3 +16,8 @@ spec:
       VOLSYNC_UID: "10000"
       VOLSYNC_GID: "10000"
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/games/minecraft.yaml
+++ b/kubernetes/apps/main/games/minecraft.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/games/minecraft/mc-router
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -26,6 +31,11 @@ spec:
       APP: *app
       VOLSYNC_CAPACITY: 50Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -45,6 +55,11 @@ spec:
       APP: *app
       VOLSYNC_CAPACITY: 15Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 # ---
 # # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 # apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/kubernetes/apps/main/games/palworld.yaml
+++ b/kubernetes/apps/main/games/palworld.yaml
@@ -16,3 +16,8 @@ spec:
       VOLSYNC_UID: "1000"
       VOLSYNC_GID: "1000"
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/games/romm.yaml
+++ b/kubernetes/apps/main/games/romm.yaml
@@ -21,3 +21,8 @@ spec:
       APP: *app
       VOLSYNC_CAPACITY: 25Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/games/valheim.yaml
+++ b/kubernetes/apps/main/games/valheim.yaml
@@ -14,3 +14,8 @@ spec:
       APP: *app
       VOLSYNC_CAPACITY: 10Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/games/vrising.yaml
+++ b/kubernetes/apps/main/games/vrising.yaml
@@ -16,3 +16,8 @@ spec:
       VOLSYNC_UID: "1000"
       VOLSYNC_GID: "1000"
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/kube-system/amd-device-plugin.yaml
+++ b/kubernetes/apps/main/kube-system/amd-device-plugin.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/amd-device-plugin
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/kube-system/cilium.yaml
+++ b/kubernetes/apps/main/kube-system/cilium.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/cilium
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -19,3 +24,8 @@ spec:
   interval: 15m
   path: ./kubernetes/apps/${CLUSTER}/kube-system/cilium
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/kube-system/coredns.yaml
+++ b/kubernetes/apps/main/kube-system/coredns.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/coredns
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/kube-system/intel-gpu-resource-driver.yaml
+++ b/kubernetes/apps/main/kube-system/intel-gpu-resource-driver.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/intel-gpu-resource-driver
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/kube-system/irqbalance.yaml
+++ b/kubernetes/apps/main/kube-system/irqbalance.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/irqbalance
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/kube-system/metrics-server.yaml
+++ b/kubernetes/apps/main/kube-system/metrics-server.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       REPLICAS: "2"
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/kube-tools/descheduler.yaml
+++ b/kubernetes/apps/main/kube-tools/descheduler.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       REPLICAS: "2"
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/kube-tools/reloader.yaml
+++ b/kubernetes/apps/main/kube-tools/reloader.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-tools/reloader
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/kube-tools/spegel.yaml
+++ b/kubernetes/apps/main/kube-tools/spegel.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-tools/spegel
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/kube-tools/tuppr.yaml
+++ b/kubernetes/apps/main/kube-tools/tuppr.yaml
@@ -10,6 +10,11 @@ spec:
     substitute:
       REPLICAS: "2"
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -22,3 +27,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/${CLUSTER}/kube-tools/upgrades
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/llm/comfyui.yaml
+++ b/kubernetes/apps/main/llm/comfyui.yaml
@@ -16,6 +16,11 @@ spec:
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 200Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -32,3 +37,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/llm/hermes.yaml
+++ b/kubernetes/apps/main/llm/hermes.yaml
@@ -15,3 +15,8 @@ spec:
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 20Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/llm/litellm.yaml
+++ b/kubernetes/apps/main/llm/litellm.yaml
@@ -23,6 +23,11 @@ spec:
       VOLSYNC_STORAGECLASS: ceph-filesystem
       VOLSYNC_SNAPSHOTCLASS: csi-ceph-filesystem
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 # ---
 # # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 # apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -58,6 +63,11 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -74,6 +84,11 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 # ---
 # # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 # apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -109,3 +124,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/llm/open-webui.yaml
+++ b/kubernetes/apps/main/llm/open-webui.yaml
@@ -26,3 +26,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/llm/openclaw.yaml
+++ b/kubernetes/apps/main/llm/openclaw.yaml
@@ -14,6 +14,11 @@ spec:
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 50Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -30,6 +35,11 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -50,6 +60,11 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -70,6 +85,11 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/kubernetes/apps/main/llm/searxng.yaml
+++ b/kubernetes/apps/main/llm/searxng.yaml
@@ -17,6 +17,11 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -30,3 +35,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/llm/toolhive.yaml
+++ b/kubernetes/apps/main/llm/toolhive.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/crds
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -19,6 +24,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -41,6 +51,11 @@ spec:
     substitute:
       APP: *name
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -59,6 +74,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/arr-mcp
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -72,6 +92,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/comfyui-mcp
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -84,6 +109,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/garmin-connect-mcp
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -96,6 +126,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/github-mcp
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -110,6 +145,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/grafana-mcp
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -122,6 +162,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/ha-mcp
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -139,6 +184,11 @@ spec:
     substitute:
       APP: *name
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -151,6 +201,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/kubectl-mcp
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -168,3 +223,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/media/ersatztv.yaml
+++ b/kubernetes/apps/main/media/ersatztv.yaml
@@ -15,3 +15,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/media/kavita.yaml
+++ b/kubernetes/apps/main/media/kavita.yaml
@@ -14,3 +14,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/media/komga.yaml
+++ b/kubernetes/apps/main/media/komga.yaml
@@ -16,3 +16,8 @@ spec:
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 20Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/media/kyoo.yaml
+++ b/kubernetes/apps/main/media/kyoo.yaml
@@ -23,3 +23,8 @@ spec:
       SSLMODE: allow
       VOLSYNC_CAPACITY: 50Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/media/maintainerr.yaml
+++ b/kubernetes/apps/main/media/maintainerr.yaml
@@ -14,3 +14,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/media/plex.yaml
+++ b/kubernetes/apps/main/media/plex.yaml
@@ -13,6 +13,11 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -32,6 +37,11 @@ spec:
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 50Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 # ---
 # # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 # apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -72,6 +82,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/media/plex/plex-auto-languages
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -87,6 +102,11 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -105,3 +125,8 @@ spec:
       APP: *app
       VOLSYNC_CAPACITY: 500Mi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/media/seerr.yaml
+++ b/kubernetes/apps/main/media/seerr.yaml
@@ -19,3 +19,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/media/stash.yaml
+++ b/kubernetes/apps/main/media/stash.yaml
@@ -17,3 +17,8 @@ spec:
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 50Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/media/tautulli.yaml
+++ b/kubernetes/apps/main/media/tautulli.yaml
@@ -14,3 +14,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/media/wizarr.yaml
+++ b/kubernetes/apps/main/media/wizarr.yaml
@@ -16,3 +16,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/media/your-spotify.yaml
+++ b/kubernetes/apps/main/media/your-spotify.yaml
@@ -13,3 +13,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/network/certificates.yaml
+++ b/kubernetes/apps/main/network/certificates.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/import
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -17,6 +22,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/certificate
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -29,3 +39,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/export
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/network/cloudflare-dns.yaml
+++ b/kubernetes/apps/main/network/cloudflare-dns.yaml
@@ -18,3 +18,8 @@ spec:
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/network/cloudflare-tunnel.yaml
+++ b/kubernetes/apps/main/network/cloudflare-tunnel.yaml
@@ -14,3 +14,8 @@ spec:
       EXTERNAL_DOMAIN: external
       REPLICAS: "2"
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/network/echo.yaml
+++ b/kubernetes/apps/main/network/echo.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       SUBDOMAIN: echo
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/network/envoy-gateway.yaml
+++ b/kubernetes/apps/main/network/envoy-gateway.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/envoy-gateway/app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -28,3 +33,8 @@ spec:
       SVC_GATEWAY_EXTERNAL: 10.69.10.32
       SVC_GATEWAY_INTERNAL: 10.69.10.31
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/network/multus.yaml
+++ b/kubernetes/apps/main/network/multus.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/multus
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -19,3 +24,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/${CLUSTER}/network/multus
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/network/unifi-dns.yaml
+++ b/kubernetes/apps/main/network/unifi-dns.yaml
@@ -12,3 +12,8 @@ spec:
     substitute:
       CLUSTER: ${CLUSTER}
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/exporters/blackbox-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/blackbox-exporter.yaml
@@ -10,6 +10,11 @@ spec:
     substitute:
       SUBDOMAIN: blackbox
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -20,3 +25,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/blackbox-exporter-vpn
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/exporters/hoymiles-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/hoymiles-exporter.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/hoymiles-exporter
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/exporters/nut-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/nut-exporter.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/nut-exporter
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/exporters/rocm-smi-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/rocm-smi-exporter.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/rocm-smi-exporter
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/exporters/smartctl-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/smartctl-exporter.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/smartctl-exporter
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/exporters/speedtest-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/speedtest-exporter.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/speedtest-exporter
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/exporters/unpoller.yaml
+++ b/kubernetes/apps/main/observability/exporters/unpoller.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/unpoller
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/gatus.yaml
+++ b/kubernetes/apps/main/observability/gatus.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       SUBDOMAIN: status
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/grafana.yaml
+++ b/kubernetes/apps/main/observability/grafana.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/grafana/operator
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -24,6 +29,11 @@ spec:
     substitute:
       SUBDOMAIN: grafana
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -37,3 +47,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/karma.yaml
+++ b/kubernetes/apps/main/observability/karma.yaml
@@ -12,3 +12,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/kromgo.yaml
+++ b/kubernetes/apps/main/observability/kromgo.yaml
@@ -13,3 +13,8 @@ spec:
       CLUSTER: ${CLUSTER}
       GATUS_STATUS: "404"
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/kube-prometheus-stack.yaml
+++ b/kubernetes/apps/main/observability/kube-prometheus-stack.yaml
@@ -15,3 +15,8 @@ spec:
       STORAGECLASS: ceph-block
       SUBDOMAIN: prometheus
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/prometheus-adapter.yaml
+++ b/kubernetes/apps/main/observability/prometheus-adapter.yaml
@@ -9,3 +9,8 @@ spec:
   path: ./kubernetes/apps/base/observability/prometheus-adapter
   targetNamespace: observability
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/promxy.yaml
+++ b/kubernetes/apps/main/observability/promxy.yaml
@@ -7,3 +7,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/promxy
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/silence-operator.yaml
+++ b/kubernetes/apps/main/observability/silence-operator.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/silence-operator
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/victoria-logs.yaml
+++ b/kubernetes/apps/main/observability/victoria-logs.yaml
@@ -9,6 +9,11 @@ spec:
   path: ./kubernetes/apps/base/observability/victoria-logs/app
   targetNamespace: observability
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -21,3 +26,8 @@ spec:
   path: ./kubernetes/apps/base/observability/victoria-logs/collector
   targetNamespace: observability
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/renovate/renovate.yaml
+++ b/kubernetes/apps/main/renovate/renovate.yaml
@@ -11,6 +11,11 @@ spec:
       namespace: renovate
   interval: 1h
   path: ./kubernetes/apps/base/renovate/renovate-operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -23,3 +28,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/renovate/renovate-jobs
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/rook-ceph/rook-ceph.yaml
+++ b/kubernetes/apps/main/rook-ceph/rook-ceph.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/rook-ceph/rook-ceph/app
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -34,3 +39,8 @@ spec:
       current: status.ceph.health in ['HEALTH_OK', 'HEALTH_WARN']
   interval: 1h
   path: ./kubernetes/apps/base/rook-ceph/rook-ceph/cluster
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/security/authentik.yaml
+++ b/kubernetes/apps/main/security/authentik.yaml
@@ -20,3 +20,8 @@ spec:
       SUBDOMAIN: sso
       POOL_MODE: transaction
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/self-hosted/actual.yaml
+++ b/kubernetes/apps/main/self-hosted/actual.yaml
@@ -14,3 +14,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/self-hosted/archiveteam.yaml
+++ b/kubernetes/apps/main/self-hosted/archiveteam.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       STORAGECLASS: ceph-block
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/self-hosted/atuin.yaml
+++ b/kubernetes/apps/main/self-hosted/atuin.yaml
@@ -13,3 +13,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/self-hosted/bentopdf.yaml
+++ b/kubernetes/apps/main/self-hosted/bentopdf.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/self-hosted/manyfold.yaml
+++ b/kubernetes/apps/main/self-hosted/manyfold.yaml
@@ -16,3 +16,8 @@ spec:
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 15Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/self-hosted/paperless.yaml
+++ b/kubernetes/apps/main/self-hosted/paperless.yaml
@@ -27,3 +27,8 @@ spec:
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 15Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/self-hosted/picoshare.yaml
+++ b/kubernetes/apps/main/self-hosted/picoshare.yaml
@@ -14,3 +14,8 @@ spec:
       APP: *app
       VOLSYNC_CAPACITY: 50Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/self-hosted/spoolman.yaml
+++ b/kubernetes/apps/main/self-hosted/spoolman.yaml
@@ -14,3 +14,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/self-hosted/webhook.yaml
+++ b/kubernetes/apps/main/self-hosted/webhook.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/storage/kopia.yaml
+++ b/kubernetes/apps/main/storage/kopia.yaml
@@ -15,3 +15,8 @@ spec:
     substitute:
       APP: *app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/storage/openebs.yaml
+++ b/kubernetes/apps/main/storage/openebs.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/storage/openebs
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/storage/snapshot-controller.yaml
+++ b/kubernetes/apps/main/storage/snapshot-controller.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       REPLICAS: "2"
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/storage/volsync-maintenance.yaml
+++ b/kubernetes/apps/main/storage/volsync-maintenance.yaml
@@ -10,3 +10,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/storage/volsync-maintenance
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/storage/volsync.yaml
+++ b/kubernetes/apps/main/storage/volsync.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       REPLICAS: "2"
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/workadventure/coturn.yaml
+++ b/kubernetes/apps/main/workadventure/coturn.yaml
@@ -12,3 +12,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/workadventure/synapse.yaml
+++ b/kubernetes/apps/main/workadventure/synapse.yaml
@@ -21,3 +21,8 @@ spec:
       CLUSTER: ${CLUSTER}
       VOLSYNC_CAPACITY: 10Gi
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/workadventure/workadventure.yaml
+++ b/kubernetes/apps/main/workadventure/workadventure.yaml
@@ -19,3 +19,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/actions-runner-system/actions-runner-controller.yaml
+++ b/kubernetes/apps/test/actions-runner-system/actions-runner-controller.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/app
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -25,3 +30,8 @@ spec:
       CLUSTER: ${CLUSTER}
       maxRunners: "2" # 2 per node
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/cert-manager/cert-manager.yaml
+++ b/kubernetes/apps/test/cert-manager/cert-manager.yaml
@@ -20,3 +20,8 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/cert-manager/cert-manager
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/external-secrets/external-secrets.yaml
+++ b/kubernetes/apps/test/external-secrets/external-secrets.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/external-secrets/external-secrets
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/external-secrets/onepassword-connect.yaml
+++ b/kubernetes/apps/test/external-secrets/onepassword-connect.yaml
@@ -23,3 +23,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/external-secrets/onepassword-connect
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/flux-system/addons.yaml
+++ b/kubernetes/apps/test/flux-system/addons.yaml
@@ -12,3 +12,8 @@ spec:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: flux-webhook-${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/flux-system/flux-operator.yaml
+++ b/kubernetes/apps/test/flux-system/flux-operator.yaml
@@ -12,3 +12,8 @@ spec:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: flux-${CLUSTER}
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/flux-system/headlamp.yaml
+++ b/kubernetes/apps/test/flux-system/headlamp.yaml
@@ -12,3 +12,8 @@ spec:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: headlamp-${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/kube-system/cilium.yaml
+++ b/kubernetes/apps/test/kube-system/cilium.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/cilium
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -19,3 +24,8 @@ spec:
   interval: 15m
   path: ./kubernetes/apps/${CLUSTER}/kube-system/cilium
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/kube-system/coredns.yaml
+++ b/kubernetes/apps/test/kube-system/coredns.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/coredns
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/kube-system/metrics-server.yaml
+++ b/kubernetes/apps/test/kube-system/metrics-server.yaml
@@ -12,3 +12,8 @@ spec:
       REPLICAS: "1"
   targetNamespace: kube-system
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/kube-tools/reloader.yaml
+++ b/kubernetes/apps/test/kube-tools/reloader.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-tools/reloader
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/kube-tools/tuppr.yaml
+++ b/kubernetes/apps/test/kube-tools/tuppr.yaml
@@ -10,6 +10,11 @@ spec:
     substitute:
       REPLICAS: "1"
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -22,3 +27,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/${CLUSTER}/kube-tools/upgrades
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/network/certificates.yaml
+++ b/kubernetes/apps/test/network/certificates.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/import
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -17,3 +22,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/certificate
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/network/cloudflare-dns.yaml
+++ b/kubernetes/apps/test/network/cloudflare-dns.yaml
@@ -18,3 +18,8 @@ spec:
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/network/cloudflare-tunnel.yaml
+++ b/kubernetes/apps/test/network/cloudflare-tunnel.yaml
@@ -13,3 +13,8 @@ spec:
       CLUSTER: ${CLUSTER}
       EXTERNAL_DOMAIN: ${CLUSTER}-external
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/network/echo.yaml
+++ b/kubernetes/apps/test/network/echo.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       SUBDOMAIN: echo-${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/network/envoy-gateway.yaml
+++ b/kubernetes/apps/test/network/envoy-gateway.yaml
@@ -8,6 +8,11 @@ spec:
   path: ./kubernetes/apps/base/network/envoy-gateway/app
   targetNamespace: network
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -28,3 +33,8 @@ spec:
       SVC_GATEWAY_EXTERNAL: 10.69.10.232
       SVC_GATEWAY_INTERNAL: 10.69.10.231
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/network/unifi-dns.yaml
+++ b/kubernetes/apps/test/network/unifi-dns.yaml
@@ -12,3 +12,8 @@ spec:
     substitute:
       CLUSTER: ${CLUSTER}
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/storage/democratic-csi.yaml
+++ b/kubernetes/apps/test/storage/democratic-csi.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       STORAGE_PATH: /var/mnt/local-hostpath
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/storage/snapshot-controller.yaml
+++ b/kubernetes/apps/test/storage/snapshot-controller.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       REPLICAS: "1"
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/storage/volsync.yaml
+++ b/kubernetes/apps/test/storage/volsync.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       REPLICAS: "1"
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/actions-runner-system/actions-runner-controller.yaml
+++ b/kubernetes/apps/utility/actions-runner-system/actions-runner-controller.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/app
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -25,3 +30,8 @@ spec:
       CLUSTER: ${CLUSTER}
       maxRunners: "2" # 2 per node
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/cert-manager/cert-manager.yaml
+++ b/kubernetes/apps/utility/cert-manager/cert-manager.yaml
@@ -20,3 +20,8 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/cert-manager/cert-manager
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/external-secrets/external-secrets.yaml
+++ b/kubernetes/apps/utility/external-secrets/external-secrets.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/external-secrets/external-secrets
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/external-secrets/onepassword-connect.yaml
+++ b/kubernetes/apps/utility/external-secrets/onepassword-connect.yaml
@@ -23,3 +23,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/external-secrets/onepassword-connect
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/flux-system/addons.yaml
+++ b/kubernetes/apps/utility/flux-system/addons.yaml
@@ -12,3 +12,8 @@ spec:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: flux-webhook-${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/flux-system/flux-operator.yaml
+++ b/kubernetes/apps/utility/flux-system/flux-operator.yaml
@@ -12,3 +12,8 @@ spec:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: flux-${CLUSTER}
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/flux-system/headlamp.yaml
+++ b/kubernetes/apps/utility/flux-system/headlamp.yaml
@@ -12,3 +12,8 @@ spec:
       CLUSTER: ${CLUSTER}
       SUBDOMAIN: headlamp-${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/flux-system/tofu-controller.yaml
+++ b/kubernetes/apps/utility/flux-system/tofu-controller.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/flux-system/tofu-controller
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -19,3 +24,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/${CLUSTER}/flux-system/terraform
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/home-automation/home-assistant.yaml
+++ b/kubernetes/apps/utility/home-automation/home-assistant.yaml
@@ -17,3 +17,8 @@ spec:
       VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
       VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/home-automation/hoymiles-mqtt.yaml
+++ b/kubernetes/apps/utility/home-automation/hoymiles-mqtt.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/home-automation/hoymiles-mqtt
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/home-automation/matter-server.yaml
+++ b/kubernetes/apps/utility/home-automation/matter-server.yaml
@@ -17,3 +17,8 @@ spec:
       VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
       VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/home-automation/mosquitto.yaml
+++ b/kubernetes/apps/utility/home-automation/mosquitto.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/home-automation/mosquitto/
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/home-automation/rtlamr2mqtt.yaml
+++ b/kubernetes/apps/utility/home-automation/rtlamr2mqtt.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/home-automation/rtlamr2mqtt
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/home-automation/zigbee.yaml
+++ b/kubernetes/apps/utility/home-automation/zigbee.yaml
@@ -19,3 +19,8 @@ spec:
       VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
       VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/kube-system/cilium.yaml
+++ b/kubernetes/apps/utility/kube-system/cilium.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/cilium
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -19,3 +24,8 @@ spec:
   interval: 15m
   path: ./kubernetes/apps/${CLUSTER}/kube-system/cilium
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/kube-system/coredns.yaml
+++ b/kubernetes/apps/utility/kube-system/coredns.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/coredns
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/kube-system/metrics-server.yaml
+++ b/kubernetes/apps/utility/kube-system/metrics-server.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       REPLICAS: "1"
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/kube-tools/reloader.yaml
+++ b/kubernetes/apps/utility/kube-tools/reloader.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-tools/reloader
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/kube-tools/tuppr.yaml
+++ b/kubernetes/apps/utility/kube-tools/tuppr.yaml
@@ -10,6 +10,11 @@ spec:
     substitute:
       REPLICAS: "1"
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -22,3 +27,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/${CLUSTER}/kube-tools/upgrades
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/llm/llama-ryzen.yaml
+++ b/kubernetes/apps/utility/llm/llama-ryzen.yaml
@@ -12,3 +12,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/network/certificates.yaml
+++ b/kubernetes/apps/utility/network/certificates.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/import
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -17,3 +22,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/certificates/certificate
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/network/cloudflare-dns.yaml
+++ b/kubernetes/apps/utility/network/cloudflare-dns.yaml
@@ -18,3 +18,8 @@ spec:
   postBuild:
     substitute:
       CLUSTER: ${CLUSTER}
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/network/cloudflare-tunnel.yaml
+++ b/kubernetes/apps/utility/network/cloudflare-tunnel.yaml
@@ -13,3 +13,8 @@ spec:
       CLUSTER: ${CLUSTER}
       EXTERNAL_DOMAIN: ${CLUSTER}-external
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/network/echo.yaml
+++ b/kubernetes/apps/utility/network/echo.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       SUBDOMAIN: echo-${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/network/envoy-gateway.yaml
+++ b/kubernetes/apps/utility/network/envoy-gateway.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/envoy-gateway/app
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -26,3 +31,8 @@ spec:
       SVC_GATEWAY_EXTERNAL: 10.69.10.132
       SVC_GATEWAY_INTERNAL: 10.69.10.131
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/network/multus.yaml
+++ b/kubernetes/apps/utility/network/multus.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/network/multus
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -19,3 +24,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/${CLUSTER}/network/multus
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/network/unifi-dns.yaml
+++ b/kubernetes/apps/utility/network/unifi-dns.yaml
@@ -12,3 +12,8 @@ spec:
     substitute:
       CLUSTER: ${CLUSTER}
   wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/observability/exporters/blackbox-exporter.yaml
+++ b/kubernetes/apps/utility/observability/exporters/blackbox-exporter.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       SUBDOMAIN: blackbox-${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/observability/exporters/smartctl-exporter.yaml
+++ b/kubernetes/apps/utility/observability/exporters/smartctl-exporter.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/exporters/smartctl-exporter
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/observability/gatus.yaml
+++ b/kubernetes/apps/utility/observability/gatus.yaml
@@ -11,3 +11,8 @@ spec:
     substitute:
       SUBDOMAIN: status-${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/observability/grafana.yaml
+++ b/kubernetes/apps/utility/observability/grafana.yaml
@@ -7,6 +7,11 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/grafana/operator
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -24,3 +29,8 @@ spec:
     substitute:
       SUBDOMAIN: grafana-${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/observability/kube-prometheus-stack.yaml
+++ b/kubernetes/apps/utility/observability/kube-prometheus-stack.yaml
@@ -15,3 +15,8 @@ spec:
       STORAGECLASS: local-hostpath
       SUBDOMAIN: prometheus-${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/observability/prometheus-adapter.yaml
+++ b/kubernetes/apps/utility/observability/prometheus-adapter.yaml
@@ -9,3 +9,8 @@ spec:
   path: ./kubernetes/apps/base/observability/prometheus-adapter
   targetNamespace: observability
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/observability/silence-operator.yaml
+++ b/kubernetes/apps/utility/observability/silence-operator.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/silence-operator
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/self-hosted/acars.yaml
+++ b/kubernetes/apps/utility/self-hosted/acars.yaml
@@ -25,3 +25,8 @@ spec:
         name: acars-processor
         optional: false
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/self-hosted/free-game-notifier.yaml
+++ b/kubernetes/apps/utility/self-hosted/free-game-notifier.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/free-game-notifier
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/self-hosted/hypermind.yaml
+++ b/kubernetes/apps/utility/self-hosted/hypermind.yaml
@@ -12,3 +12,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/self-hosted/it-tools.yaml
+++ b/kubernetes/apps/utility/self-hosted/it-tools.yaml
@@ -12,3 +12,8 @@ spec:
       APP: *app
       CLUSTER: ${CLUSTER}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/self-hosted/meshcentral.yaml
+++ b/kubernetes/apps/utility/self-hosted/meshcentral.yaml
@@ -17,3 +17,8 @@ spec:
       VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
       VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/self-hosted/rss-forwarder.yaml
+++ b/kubernetes/apps/utility/self-hosted/rss-forwarder.yaml
@@ -8,3 +8,8 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/rss-forwarder
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/self-hosted/scanservjs.yaml
+++ b/kubernetes/apps/utility/self-hosted/scanservjs.yaml
@@ -17,3 +17,8 @@ spec:
       VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
       VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/self-hosted/thelounge.yaml
+++ b/kubernetes/apps/utility/self-hosted/thelounge.yaml
@@ -17,3 +17,8 @@ spec:
       VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
       VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/storage/democratic-csi.yaml
+++ b/kubernetes/apps/utility/storage/democratic-csi.yaml
@@ -12,3 +12,8 @@ spec:
       STORAGE_PATH: /var/mnt/local-hostpath ##Swap on next rebuild
   targetNamespace: storage
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/storage/snapshot-controller.yaml
+++ b/kubernetes/apps/utility/storage/snapshot-controller.yaml
@@ -12,3 +12,8 @@ spec:
       REPLICAS: "1"
   targetNamespace: storage
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/storage/volsync.yaml
+++ b/kubernetes/apps/utility/storage/volsync.yaml
@@ -12,3 +12,8 @@ spec:
       REPLICAS: "1"
   targetNamespace: storage
   wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/clusters/main/apps.yaml
+++ b/kubernetes/clusters/main/apps.yaml
@@ -27,11 +27,6 @@ spec:
           name: not-used
         spec:
           deletionPolicy: WaitForTermination
-          prune: true
-          sourceRef:
-            kind: GitRepository
-            name: flux-system
-            namespace: flux-system
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}

--- a/kubernetes/clusters/test/apps.yaml
+++ b/kubernetes/clusters/test/apps.yaml
@@ -31,11 +31,6 @@ spec:
           name: not-used
         spec:
           deletionPolicy: WaitForTermination
-          prune: true
-          sourceRef:
-            kind: GitRepository
-            name: flux-system
-            namespace: flux-system
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}

--- a/kubernetes/clusters/utility/apps.yaml
+++ b/kubernetes/clusters/utility/apps.yaml
@@ -31,11 +31,6 @@ spec:
           name: not-used
         spec:
           deletionPolicy: WaitForTermination
-          prune: true
-          sourceRef:
-            kind: GitRepository
-            name: flux-system
-            namespace: flux-system
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}


### PR DESCRIPTION
## Summary

Revert the centralization from #7160. The DRY win wasn't worth the DX cost — stripped child ks files are technically invalid per the [`kustomize.toolkit.fluxcd.io`](https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json) schema (\`sourceRef\` is a required field), so the YAML language server flags every child file as broken. Red squiggles on 170+ files is real friction, both for humans editing in the IDE and for AI tooling that reads manifests in isolation.

## What changes

- Re-add \`sourceRef: { kind: GitRepository, name: flux-system, namespace: flux-system }\` to every Flux Kustomization in the apps tree (171 files)
- Re-add \`prune: true\` to the same files
- Strip the (now redundant) inheritance lines from the cluster-apps "Kustomization defaults" patch in all 3 cluster apps.yaml

\`+1110 / -15\` net — exact inverse of #7160's strip plus three cleanups.

## What stays

PR #7155 (CLUSTER inheritance via parent patch) **stays as-is**. That one wasn't DRY-for-DRY — \`\${CLUSTER}\` substitution genuinely needed to reach child Kustomizations so onepassword-connect's ExternalSecret could resolve \`1password-\${CLUSTER}\`. Different category.

## Verification

\`flux-local diff hr\` against main — empty on all 3 clusters. Same rendered HelmRelease values, just with the required fields declared explicitly where the schema (and editor) expects them.

## Test plan

- [ ] Flux Local Test passes on all 3 clusters
- [ ] Flux Local Diff (helmrelease) is empty across all 3 clusters
- [ ] Flux Local Diff (kustomization) shows the sourceRef/prune fields restored on every child (the substantive diff; expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)