### PR TITLE
[codex] Add agentmemory for OpenClaw

### DIFF
--- a/kubernetes/apps/base/llm/agentmemory/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/agentmemory/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name agentmemory
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        OPENAI_API_KEY: "{{ .LITELLM_MASTER_KEY }}"
+  dataFrom:
+    - extract:
+        key: litellm

--- a/kubernetes/apps/base/llm/agentmemory/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/agentmemory/helmrelease.yaml
@@ -30,8 +30,8 @@ spec:
         containers:
           app:
             image:
-              repository: registry.erwanleboucher.dev/eleboucher/agentmemory
-              tag: 0.9.21-dcb0cfd@sha256:1622de34550cb2540185693092a1e398c8bd9317f4a181755f519608629797ca
+              repository: ghcr.io/joryirving/agentmemory
+              tag: 0.9.21@sha256:2c92f9188ea333ddb79e5e66a237c3868aee236a412c179e43869c1eaaa29393
             command:
               - /usr/bin/catatonit
               - --

--- a/kubernetes/apps/base/llm/agentmemory/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/agentmemory/helmrelease.yaml
@@ -1,0 +1,122 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: agentmemory
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 15m
+  dependsOn: []
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      agentmemory:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: Recreate
+        type: deployment
+        containers:
+          app:
+            image:
+              repository: registry.erwanleboucher.dev/eleboucher/agentmemory
+              tag: 0.9.21-dcb0cfd@sha256:1622de34550cb2540185693092a1e398c8bd9317f4a181755f519608629797ca
+            command:
+              - /usr/bin/catatonit
+              - --
+              - /bin/sh
+              - -c
+              - |
+                PREFS_HOME="${HOME:-/home/node}"
+                mkdir -p "$PREFS_HOME/.agentmemory"
+                if [ ! -s "$PREFS_HOME/.agentmemory/preferences.json" ]; then
+                  printf '%s\n' '{"schemaVersion":1,"lastAgent":null,"lastAgents":[],"lastProvider":null,"skipSplash":true,"skipNpxHint":true,"skipGlobalInstall":true,"skipConsoleInstall":true,"firstRunAt":"1970-01-01T00:00:00.000Z"}' > "$PREFS_HOME/.agentmemory/preferences.json"
+                fi
+                exec /entrypoint.sh
+            env:
+              AGENTMEMORY_DROP_STALE_INDEX: "true"
+              AGENTMEMORY_TOOLS: all
+              EMBEDDING_PROVIDER: openai
+              GRAPH_EXTRACTION_ENABLED: "true"
+              III_REST_PORT: "3111"
+              OPENAI_BASE_URL: http://litellm.llm:4000/v1
+              OPENAI_EMBEDDING_DIMENSIONS: "384"
+              OPENAI_EMBEDDING_MODEL: sentence-transformers/all-MiniLM-L6-v2
+              TZ: America/Edmonton
+            envFrom:
+              - secretRef:
+                  name: agentmemory
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /agentmemory/livez
+                    port: 3111
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /agentmemory/livez
+                    port: 3111
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  failureThreshold: 60
+                  httpGet:
+                    path: /agentmemory/livez
+                    port: 3111
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /home/node
+      data:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    service:
+      app:
+        controller: agentmemory
+        ports:
+          api:
+            port: 3111
+          viewer:
+            port: 3113

--- a/kubernetes/apps/base/llm/agentmemory/kustomization.yaml
+++ b/kubernetes/apps/base/llm/agentmemory/kustomization.yaml
@@ -3,9 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./agentmemory-plugin.yaml
-  - ./configmap.yaml
   - ./externalsecret.yaml
-  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
-#  openclaw models auth login --provider openai-codex

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -47,11 +47,11 @@ data:
           api_key: llama-ryzen
           drop_params: true
 
-      - model_name: nomic-embed-text-v1.5
+      - model_name: sentence-transformers/all-MiniLM-L6-v2
         model_info:
           mode: embedding
         litellm_params:
-          model: openai/nomic-embed-text-v1.5
+          model: openai/sentence-transformers/all-MiniLM-L6-v2
           api_base: http://llama-embed.llm:8080/v1
           api_key: llama-embed
           drop_params: true

--- a/kubernetes/apps/base/llm/litellm/llama-embed/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-embed/helmrelease.yaml
@@ -40,17 +40,17 @@ spec:
               - |
                 set -euo pipefail
 
-                if [ ! -s /models/nomic-embed-text-v1.5/nomic-embed-text-v1.5.Q8_0.gguf ]; then
+                if [ ! -s /models/all-MiniLM-L6-v2/all-MiniLM-L6-v2-Q8_0.gguf ]; then
                   pip install --no-cache-dir "huggingface_hub[hf_transfer]"
-                  mkdir -p /models/nomic-embed-text-v1.5
-                  rm -rf /models/nomic-embed-text-v1.5/.cache/huggingface/download/nomic-embed-text-v1.5.Q8_0.ggufflock
+                  mkdir -p /models/all-MiniLM-L6-v2
+                  rm -rf /models/all-MiniLM-L6-v2/.cache/huggingface/download/all-MiniLM-L6-v2-Q8_0.ggufflock
                   hf download \
-                    nomic-ai/nomic-embed-text-v1.5-GGUF \
-                    nomic-embed-text-v1.5.Q8_0.gguf \
-                    --local-dir /models/nomic-embed-text-v1.5
-                  echo "nomic-embed-text-v1.5 download complete"
+                    second-state/All-MiniLM-L6-v2-Embedding-GGUF \
+                    all-MiniLM-L6-v2-Q8_0.gguf \
+                    --local-dir /models/all-MiniLM-L6-v2
+                  echo "all-MiniLM-L6-v2 download complete"
                 else
-                  echo "nomic-embed-text-v1.5 already downloaded, skipping"
+                  echo "all-MiniLM-L6-v2 already downloaded, skipping"
                 fi
             env:
               HF_HUB_ENABLE_HF_TRANSFER: "1"
@@ -76,9 +76,9 @@ spec:
               - --port
               - "8080"
               - --alias
-              - nomic-embed-text-v1.5
+              - sentence-transformers/all-MiniLM-L6-v2
               - --model
-              - /models/nomic-embed-text-v1.5/nomic-embed-text-v1.5.Q8_0.gguf
+              - /models/all-MiniLM-L6-v2/all-MiniLM-L6-v2-Q8_0.gguf
               - --embeddings
               - --pooling
               - mean

--- a/kubernetes/apps/base/llm/openclaw/app/agentmemory-plugin.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/agentmemory-plugin.yaml
@@ -21,7 +21,9 @@ data:
           "token_budget": { "type": "number" },
           "min_confidence": { "type": "number" },
           "fallback_on_error": { "type": "boolean" },
-          "timeout_ms": { "type": "number" }
+          "timeout_ms": { "type": "number" },
+          "default_agent": { "type": "string" },
+          "project_prefix": { "type": "string" }
         }
       }
     }
@@ -51,6 +53,8 @@ data:
         min_confidence: { type: "number" },
         fallback_on_error: { type: "boolean" },
         timeout_ms: { type: "number" },
+        default_agent: { type: "string" },
+        project_prefix: { type: "string" },
       },
     };
 
@@ -99,6 +103,72 @@ data:
           return `- $${title} ($${type})$${narrative ? `: $${narrative}` : ""}`;
         })
         .join("\n");
+    }
+
+    function nonEmptyString(value) {
+      return typeof value === "string" && value.trim() ? value.trim() : "";
+    }
+
+    function firstString(...values) {
+      for (const value of values) {
+        const str = nonEmptyString(value);
+        if (str) return str;
+      }
+      return "";
+    }
+
+    function sanitizeSegment(value) {
+      return nonEmptyString(value)
+        .replace(/[^a-zA-Z0-9_.:-]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 80);
+    }
+
+    function parseAgentIdFromSessionKey(value) {
+      const str = nonEmptyString(value);
+      if (!str) return "";
+      const match = str.match(/(?:^|[:/])agent[:/]([^:/]+)/);
+      return match ? sanitizeSegment(match[1]) : "";
+    }
+
+    function deriveAgentId(event, cfg) {
+      const direct = firstString(
+        event?.agentId,
+        event?.agent_id,
+        event?.agent?.id,
+        event?.agent?.name,
+        event?.session?.agentId,
+        event?.session?.agent_id,
+      );
+      if (direct) return sanitizeSegment(direct);
+
+      const parsed = firstString(
+        parseAgentIdFromSessionKey(event?.sessionKey),
+        parseAgentIdFromSessionKey(event?.sessionId),
+        parseAgentIdFromSessionKey(event?.runId),
+      );
+      if (parsed) return parsed;
+
+      return sanitizeSegment(cfg.default_agent || "main");
+    }
+
+    function deriveScope(event, cfg) {
+      const agentId = deriveAgentId(event, cfg);
+      const projectPrefix = sanitizeSegment(cfg.project_prefix || "openclaw");
+      const project = `$${projectPrefix}:$${agentId}`;
+      const rawSessionId = firstString(
+        event?.sessionId,
+        event?.sessionKey,
+        event?.runId,
+        event?.id,
+        `session-$${Date.now()}`,
+      );
+      return {
+        agentId,
+        project,
+        cwd: firstString(event?.cwd, event?.workspace, event?.workspacePath, event?.agent?.workspace, project),
+        sessionId: `$${project}:$${rawSessionId}`,
+      };
     }
 
     function normalizedHostname(hostname) {
@@ -182,8 +252,22 @@ data:
           min_confidence: api.pluginConfig?.min_confidence || 0.5,
           fallback_on_error: api.pluginConfig?.fallback_on_error !== false,
           timeout_ms: api.pluginConfig?.timeout_ms || DEFAULT_TIMEOUT_MS,
+          default_agent: api.pluginConfig?.default_agent || "main",
+          project_prefix: api.pluginConfig?.project_prefix || "openclaw",
         };
         const client = createClient(cfg, api);
+        const registeredSessions = new Set();
+
+        async function ensureSession(scope, title) {
+          if (registeredSessions.has(scope.sessionId)) return;
+          await client.postJson("/agentmemory/session/start", {
+            sessionId: scope.sessionId,
+            project: scope.project,
+            cwd: scope.cwd,
+            title,
+          });
+          registeredSessions.add(scope.sessionId);
+        }
 
         if (typeof api.registerMemoryCapability === "function") {
           api.registerMemoryCapability({
@@ -199,14 +283,23 @@ data:
           if (!cfg.enabled) return;
           const prompt = typeof event?.prompt === "string" ? event.prompt.trim() : "";
           if (!prompt) return;
-          const result = await client.postJson("/agentmemory/smart-search", {
+          const scope = deriveScope(event, cfg);
+          await ensureSession(scope, prompt.slice(0, 200));
+          const result = await client.postJson("/agentmemory/search", {
+            format: "full",
+            project: scope.project,
             query: prompt,
             limit: 5,
+            token_budget: cfg.token_budget,
           });
-          const block = formatResults(result?.results || []);
+          const memories = (result?.results || []).filter((item) => {
+            const confidence = item?.observation?.confidence;
+            return typeof confidence !== "number" || confidence >= cfg.min_confidence;
+          });
+          const block = formatResults(memories);
           if (!block) return;
           return {
-            prependContext: `Relevant long-term memory from agentmemory:\n$${block}`,
+            prependContext: `Relevant long-term memory from agentmemory for $${scope.agentId}:\n$${block}`,
           };
         });
 
@@ -215,13 +308,17 @@ data:
           const userText = latestUserText(event.messages);
           const assistantText = lastAssistantText(event.messages);
           if (!userText || !assistantText) return;
-          const sessionId = event.sessionId || event.sessionKey || event.runId || `openclaw-$${Date.now()}`;
+          const scope = deriveScope(event, cfg);
+          await ensureSession(scope, userText.slice(0, 200));
           await client.postJson("/agentmemory/observe", {
             hookType: "post_tool_use",
-            sessionId,
+            sessionId: scope.sessionId,
+            project: scope.project,
+            cwd: scope.cwd,
             timestamp: new Date().toISOString(),
             data: {
               tool_name: "conversation",
+              agent_id: scope.agentId,
               tool_input: userText.slice(0, 1000),
               tool_output: assistantText.slice(0, 4000),
             },

--- a/kubernetes/apps/base/llm/openclaw/app/agentmemory-plugin.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/agentmemory-plugin.yaml
@@ -1,0 +1,233 @@
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.18.0/configmap-v1.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-agentmemory-plugin
+data:
+  openclaw.plugin.json: |
+    {
+      "id": "agentmemory",
+      "kind": "memory",
+      "name": "agentmemory",
+      "description": "Persistent cross-session memory for OpenClaw via agentmemory.",
+      "version": "0.9.4",
+      "configSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "base_url": { "type": "string" },
+          "token_budget": { "type": "number" },
+          "min_confidence": { "type": "number" },
+          "fallback_on_error": { "type": "boolean" },
+          "timeout_ms": { "type": "number" }
+        }
+      }
+    }
+  package.json: |
+    {
+      "name": "agentmemory",
+      "version": "0.9.4",
+      "type": "module",
+      "openclaw": {
+        "extensions": [
+          "./plugin.mjs"
+        ]
+      }
+    }
+  plugin.mjs: |
+    const DEFAULT_BASE_URL = "http://localhost:3111";
+    const DEFAULT_TIMEOUT_MS = 5000;
+    const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+    const configSchema = {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        enabled: { type: "boolean" },
+        base_url: { type: "string" },
+        token_budget: { type: "number" },
+        min_confidence: { type: "number" },
+        fallback_on_error: { type: "boolean" },
+        timeout_ms: { type: "number" },
+      },
+    };
+
+    function extractText(content) {
+      if (typeof content === "string") return content;
+      if (!Array.isArray(content)) return "";
+      return content
+        .flatMap((block) => {
+          if (!block || typeof block !== "object") return [];
+          if (block.type === "text" && typeof block.text === "string") return [block.text];
+          return [];
+        })
+        .join("\n")
+        .trim();
+    }
+
+    function lastAssistantText(messages) {
+      for (const message of [...messages].reverse()) {
+        if (!message || typeof message !== "object") continue;
+        if (message.role !== "assistant") continue;
+        const text = extractText(message.content);
+        if (text) return text;
+      }
+      return "";
+    }
+
+    function latestUserText(messages) {
+      for (const message of [...messages].reverse()) {
+        if (!message || typeof message !== "object") continue;
+        if (message.role !== "user") continue;
+        const text = extractText(message.content);
+        if (text) return text;
+      }
+      return "";
+    }
+
+    function formatResults(results) {
+      if (!Array.isArray(results) || results.length === 0) return "";
+      return results
+        .slice(0, 5)
+        .map((result, index) => {
+          const obs = result?.observation ?? result ?? {};
+          const title = (obs.title || `Memory $${index + 1}`).trim();
+          const narrative = (obs.narrative || "").trim();
+          const type = (obs.type || "memory").trim();
+          return `- $${title} ($${type})$${narrative ? `: $${narrative}` : ""}`;
+        })
+        .join("\n");
+    }
+
+    function normalizedHostname(hostname) {
+      return hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    }
+
+    function usesPlaintextBearerAuth(baseUrl, secret) {
+      if (!secret) return false;
+      try {
+        const parsed = new URL(baseUrl);
+        return parsed.protocol === "http:" && !LOOPBACK_HOSTS.has(normalizedHostname(parsed.hostname));
+      } catch {
+        return false;
+      }
+    }
+
+    function plaintextBearerAuthMessage(baseUrl) {
+      return `agentmemory: AGENTMEMORY_SECRET is configured for plaintext HTTP to $${baseUrl}. Bearer tokens and memory payloads can be observed on the network; use HTTPS or an SSH tunnel.`;
+    }
+
+    export function createPlaintextBearerAuthGuard(warn, env) {
+      let warned = false;
+      return function guardPlaintextBearerAuth(baseUrl, secret) {
+        if (!usesPlaintextBearerAuth(baseUrl, secret)) return;
+        const message = plaintextBearerAuthMessage(baseUrl);
+        if ((env || process.env).AGENTMEMORY_REQUIRE_HTTPS === "1") throw new Error(message);
+        if (!warned) {
+          warned = true;
+          warn(message);
+        }
+      };
+    }
+
+    function createClient(cfg, api) {
+      const baseUrl = String(cfg.base_url || DEFAULT_BASE_URL).replace(/\/+$/, "");
+      const timeoutMs = Number(cfg.timeout_ms || DEFAULT_TIMEOUT_MS);
+      const fallbackOnError = cfg.fallback_on_error !== false;
+      const secret = process.env.AGENTMEMORY_SECRET;
+      const guardPlaintextBearerAuth = createPlaintextBearerAuthGuard((message) => api.logger.warn?.(message));
+      if (process.env.AGENTMEMORY_REQUIRE_HTTPS === "1") {
+        guardPlaintextBearerAuth(baseUrl, secret);
+      }
+
+      async function postJson(path, payload) {
+        guardPlaintextBearerAuth(baseUrl, secret);
+        const headers = { "Content-Type": "application/json" };
+        if (secret) headers.Authorization = `Bearer $${secret}`;
+        try {
+          const res = await fetch(`$${baseUrl}$${path}`, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(payload),
+            signal: AbortSignal.timeout(timeoutMs),
+          });
+          if (!res.ok) {
+            if (fallbackOnError) return null;
+            const body = await res.text().catch(() => "");
+            throw new Error(`agentmemory $${path} failed: $${res.status} $${body}`);
+          }
+          return await res.json();
+        } catch (error) {
+          if (!fallbackOnError) throw error;
+          api.logger.warn?.(`agentmemory: $${String(error)}`);
+          return null;
+        }
+      }
+
+      return { postJson, baseUrl };
+    }
+
+    const plugin = {
+      id: "agentmemory",
+      name: "agentmemory",
+      description: "Shared cross-session memory via the local agentmemory server.",
+      configSchema,
+      register(api) {
+        const cfg = {
+          enabled: api.pluginConfig?.enabled !== false,
+          base_url: api.pluginConfig?.base_url || DEFAULT_BASE_URL,
+          token_budget: api.pluginConfig?.token_budget || 2000,
+          min_confidence: api.pluginConfig?.min_confidence || 0.5,
+          fallback_on_error: api.pluginConfig?.fallback_on_error !== false,
+          timeout_ms: api.pluginConfig?.timeout_ms || DEFAULT_TIMEOUT_MS,
+        };
+        const client = createClient(cfg, api);
+
+        if (typeof api.registerMemoryCapability === "function") {
+          api.registerMemoryCapability({
+            promptBuilder: (_params) => [
+              "Long-term memory provider: agentmemory (external REST service on " + client.baseUrl + ").",
+              "agentmemory recalls relevant prior observations before each turn via the before_agent_start hook and captures completed turns via agent_end.",
+              "Treat recalled context as background, not authoritative; prefer current workspace state and explicit user instructions when they conflict.",
+            ],
+          });
+        }
+
+        api.on("before_agent_start", async (event) => {
+          if (!cfg.enabled) return;
+          const prompt = typeof event?.prompt === "string" ? event.prompt.trim() : "";
+          if (!prompt) return;
+          const result = await client.postJson("/agentmemory/smart-search", {
+            query: prompt,
+            limit: 5,
+          });
+          const block = formatResults(result?.results || []);
+          if (!block) return;
+          return {
+            prependContext: `Relevant long-term memory from agentmemory:\n$${block}`,
+          };
+        });
+
+        api.on("agent_end", async (event) => {
+          if (!cfg.enabled || !event?.success || !Array.isArray(event.messages)) return;
+          const userText = latestUserText(event.messages);
+          const assistantText = lastAssistantText(event.messages);
+          if (!userText || !assistantText) return;
+          const sessionId = event.sessionId || event.sessionKey || event.runId || `openclaw-$${Date.now()}`;
+          await client.postJson("/agentmemory/observe", {
+            hookType: "post_tool_use",
+            sessionId,
+            timestamp: new Date().toISOString(),
+            data: {
+              tool_name: "conversation",
+              tool_input: userText.slice(0, 1000),
+              tool_output: assistantText.slice(0, 4000),
+            },
+          });
+        });
+      },
+    };
+
+    export default plugin;

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -326,9 +326,19 @@ data:
           "memory-core": {
             enabled: true,
           },
+          agentmemory: {
+            enabled: true,
+            config: {
+              base_url: "http://agentmemory.llm:3111/",
+              token_budget: 2000,
+              min_confidence: 0.5,
+              fallback_on_error: true,
+              timeout_ms: 5000,
+            },
+          },
         },
         slots: {
-          memory: "memory-core",
+          memory: "agentmemory",
           contextEngine: "lossless-claw"
         },
       },

--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -33,9 +33,16 @@ spec:
               - -c
               - |
                 set -euo pipefail
+                mkdir -p /home/node/.openclaw/extensions/agentmemory
                 cp /tmp/openclaw.json /home/node/.openclaw/openclaw.json
+                cp /tmp/agentmemory-plugin/openclaw.plugin.json /home/node/.openclaw/extensions/agentmemory/openclaw.plugin.json
+                cp /tmp/agentmemory-plugin/package.json /home/node/.openclaw/extensions/agentmemory/package.json
+                cp /tmp/agentmemory-plugin/plugin.mjs /home/node/.openclaw/extensions/agentmemory/plugin.mjs
                 chown 1000:100 /home/node/.openclaw/openclaw.json
+                chown -R 1000:100 /home/node/.openclaw/extensions/agentmemory
                 chmod 400 /home/node/.openclaw/openclaw.json
+                chmod 500 /home/node/.openclaw/extensions/agentmemory
+                chmod 400 /home/node/.openclaw/extensions/agentmemory/*
           daemon:
             image:
               repository: docker
@@ -160,6 +167,17 @@ spec:
         globalMounts:
         - path: /tmp/openclaw.json
           subPath: openclaw.json
+      agentmemory-plugin:
+        type: configMap
+        name: openclaw-agentmemory-plugin
+        defaultMode: 0755
+        globalMounts:
+        - path: /tmp/agentmemory-plugin/openclaw.plugin.json
+          subPath: openclaw.plugin.json
+        - path: /tmp/agentmemory-plugin/package.json
+          subPath: package.json
+        - path: /tmp/agentmemory-plugin/plugin.mjs
+          subPath: plugin.mjs
     rbac:
       roles:
         # Cluster-wide pod delete — restart any pod in any namespace

--- a/kubernetes/apps/main/llm/agentmemory.yaml
+++ b/kubernetes/apps/main/llm/agentmemory.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app agentmemory
+spec:
+  components:
+    - ../../../../components/volsync
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/agentmemory
+  postBuild:
+    substitute:
+      APP: *app
+      CLUSTER: ${CLUSTER}
+      VOLSYNC_CAPACITY: 10Gi
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/llm/kustomization.yaml
+++ b/kubernetes/apps/main/llm/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 replacements:
   - path: ../../../components/replacements/ks.yaml
 resources:
+  - ./agentmemory.yaml
   - ./comfyui.yaml
   - ./hermes.yaml
   - ./litellm.yaml


### PR DESCRIPTION
## Summary

Adds AgentMemory as a standalone `llm` namespace app on the main cluster and wires OpenClaw to use the native AgentMemory memory plugin instead of MCP.

## Changes

- Adds a standalone `agentmemory` app-template HelmRelease with VolSync storage.
- Adds an AgentMemory ExternalSecret that maps `OPENAI_API_KEY` from the `litellm` 1Password item’s `LITELLM_MASTER_KEY`.
- Points AgentMemory embeddings at LiteLLM on `http://litellm.llm:4000/v1`.
- Updates `llama-embed` to serve `sentence-transformers/all-MiniLM-L6-v2` and updates LiteLLM’s embedding model alias to match.
- Mounts the OpenClaw AgentMemory plugin files and switches OpenClaw’s memory slot to `agentmemory`.
- Scopes OpenClaw AgentMemory sessions and searches by OpenClaw agent (`openclaw:<agentId>`) so Miso/Saffron memories stay isolated while sharing the same backend.

## Validation

- Earlier local validation passed with `flux-local test --enable-helm --path ./kubernetes/clusters/main`.
- After later review fixes, local heavy validation was intentionally skipped so CI can do the heavier validation.
- Ran `git diff --check` for the per-agent isolation patch.