### PR TITLE
fix(agentmemory): use llama-embed for embeddings directly

### DIFF
--- a/kubernetes/apps/base/llm/agentmemory/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/agentmemory/helmrelease.yaml
@@ -50,7 +50,7 @@ spec:
               EMBEDDING_PROVIDER: openai
               GRAPH_EXTRACTION_ENABLED: "true"
               III_REST_PORT: "3111"
-              OPENAI_BASE_URL: http://litellm.llm:4000/v1
+              OPENAI_BASE_URL: http://llama-embed.llm:8080/v1
               OPENAI_EMBEDDING_DIMENSIONS: "384"
               OPENAI_EMBEDDING_MODEL: sentence-transformers/all-MiniLM-L6-v2
               TZ: America/Edmonton


### PR DESCRIPTION
Point OPENAI_BASE_URL to llama-embed.llm:8080 instead of litellm.llm:4000. This routes embedding requests through llama-embed directly.

One-line change: `OPENAI_BASE_URL: http://litellm.llm:4000/v1` → `OPENAI_BASE_URL: http://llama-embed.llm:8080/v1`