### PR TITLE
fix(agentmemory): set LOG_LEVEL=warn to suppress observation logs

### DIFF
--- a/kubernetes/apps/base/llm/agentmemory/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/agentmemory/helmrelease.yaml
@@ -50,6 +50,7 @@ spec:
               EMBEDDING_PROVIDER: openai
               GRAPH_EXTRACTION_ENABLED: "true"
               III_REST_PORT: "3111"
+              LOG_LEVEL: warn
               OPENAI_BASE_URL: http://llama-embed.llm:8080/v1
               OPENAI_EMBEDDING_DIMENSIONS: "384"
               OPENAI_EMBEDDING_MODEL: sentence-transformers/all-MiniLM-L6-v2


### PR DESCRIPTION
Suppress info-level observation logs in agentmemory pod logs.

Conversation content is currently being exposed in pod logs and Victoria Logs at info level. Setting LOG_LEVEL=warn prevents this.