### PR TITLE
Add Hermes agentmemory integration

### DIFF
--- a/kubernetes/apps/base/llm/hermes/agentmemory-plugin.yaml
+++ b/kubernetes/apps/base/llm/hermes/agentmemory-plugin.yaml
@@ -1,0 +1,251 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-agentmemory-plugin
+data:
+  plugin.yaml: |
+    name: agentmemory
+    version: 0.9.21
+    description: "Persistent cross-session memory for Hermes Agent via agentmemory."
+    author: "Rohit Ghumare"
+    homepage: "https://github.com/rohitg00/agentmemory"
+    hooks:
+      - on_session_end
+      - on_pre_compress
+      - on_memory_write
+  __init__.py: |
+    from __future__ import annotations
+
+    import json
+    import os
+    import sys
+    import threading
+    import time
+    from typing import Any, Callable
+    from urllib.error import URLError
+    from urllib.parse import urlparse
+    from urllib.request import Request, urlopen
+
+    try:
+        from agent.memory_provider import MemoryProvider
+    except ImportError:
+        from abc import ABC, abstractmethod
+
+        class MemoryProvider(ABC):
+            @property
+            @abstractmethod
+            def name(self) -> str: ...
+            @abstractmethod
+            def is_available(self) -> bool: ...
+            @abstractmethod
+            def initialize(self, session_id: str, **kwargs: Any) -> None: ...
+            @abstractmethod
+            def get_tool_schemas(self) -> list[dict]: ...
+            @abstractmethod
+            def handle_tool_call(self, name: str, args: dict) -> str: ...
+            def system_prompt_block(self) -> str: return ""
+            def prefetch(self, query: str, **kwargs: Any) -> str: return ""
+            def queue_prefetch(self, query: str, **kwargs: Any) -> None: pass
+            def sync_turn(self, user: str, assistant: str, **kwargs: Any) -> None: pass
+            def on_session_end(self, messages: list, **kwargs: Any) -> None: pass
+            def on_pre_compress(self, messages: list, **kwargs: Any) -> None: pass
+            def on_memory_write(self, action: str, target: str, content: str, **kwargs: Any) -> None: pass
+            def shutdown(self, **kwargs: Any) -> None: pass
+
+
+    DEFAULT_BASE_URL = "http://agentmemory.llm:3111"
+    DEFAULT_PROJECT = "hermes"
+    TIMEOUT = 5
+    LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+    _plaintext_bearer_warned = False
+
+
+    def _validate_url(base: str) -> bool:
+        if not base:
+            return False
+        try:
+            parsed = urlparse(base)
+            _ = parsed.port
+        except ValueError:
+            return False
+        return parsed.scheme in ("http", "https") and bool(parsed.hostname)
+
+
+    def _uses_plaintext_bearer_auth(base: str, secret: str = "") -> bool:
+        if not secret:
+            return False
+        parsed = urlparse(base)
+        return parsed.scheme == "http" and (parsed.hostname or "").lower() not in LOOPBACK_HOSTS
+
+
+    def _check_plaintext_bearer_guard(base: str, secret: str = "", warn: Callable[[str], None] | None = None) -> None:
+        global _plaintext_bearer_warned
+        if not _uses_plaintext_bearer_auth(base, secret):
+            return
+        message = f"agentmemory: AGENTMEMORY_SECRET is configured for plaintext HTTP to {base}."
+        if os.environ.get("AGENTMEMORY_REQUIRE_HTTPS") == "1":
+            raise RuntimeError(message)
+        if not _plaintext_bearer_warned:
+            _plaintext_bearer_warned = True
+            (warn or (lambda msg: print(msg, file=sys.stderr)))(message)
+
+
+    def _api(base: str, path: str, body: dict | None = None, method: str = "POST") -> dict | None:
+        if not _validate_url(base):
+            return None
+        secret = os.environ.get("AGENTMEMORY_SECRET", "")
+        _check_plaintext_bearer_guard(base, secret)
+        headers = {"Content-Type": "application/json"}
+        if secret:
+            headers["Authorization"] = f"Bearer {secret}"
+        req = Request(
+            f"{base.rstrip('/')}/agentmemory/{path}",
+            data=json.dumps(body).encode() if body else None,
+            headers=headers,
+            method=method,
+        )
+        try:
+            with urlopen(req, timeout=TIMEOUT) as resp:
+                return json.loads(resp.read().decode())
+        except (URLError, TimeoutError, json.JSONDecodeError):
+            return None
+
+
+    def _api_bg(base: str, path: str, body: dict | None = None) -> None:
+        threading.Thread(target=_api, args=(base, path, body), daemon=True).start()
+
+
+    class AgentMemoryProvider(MemoryProvider):
+        @property
+        def name(self) -> str:
+            return "agentmemory"
+
+        def is_available(self) -> bool:
+            return _validate_url(os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL))
+
+        def initialize(self, session_id: str, **kwargs: Any) -> None:
+            self._base = os.environ.get("AGENTMEMORY_URL", DEFAULT_BASE_URL)
+            self._project = os.environ.get("AGENTMEMORY_PROJECT", DEFAULT_PROJECT)
+            self._cwd = kwargs.get("cwd") or os.environ.get("HERMES_HOME") or os.getcwd()
+            self._session_id = f"{self._project}:{session_id}"
+            _api(self._base, "session/start", {
+                "sessionId": self._session_id,
+                "project": self._project,
+                "cwd": self._cwd,
+            })
+
+        def system_prompt_block(self) -> str:
+            result = _api(self._base, "context", {
+                "sessionId": self._session_id,
+                "project": self._project,
+            })
+            return result.get("context", "") if result else ""
+
+        def prefetch(self, query: str, **kwargs: Any) -> str:
+            result = _api(self._base, "search", {
+                "project": self._project,
+                "query": query,
+                "limit": 5,
+            })
+            lines = []
+            for item in (result or {}).get("results", [])[:5]:
+                obs = item.get("observation", item)
+                title = obs.get("title", "")
+                narrative = obs.get("narrative", "")
+                if title:
+                    lines.append(f"- {title}: {narrative[:200]}")
+            return "\n".join(lines)
+
+        def queue_prefetch(self, query: str, **kwargs: Any) -> None:
+            _api_bg(self._base, "search", {
+                "project": self._project,
+                "query": query,
+                "limit": 3,
+            })
+
+        def get_tool_schemas(self) -> list[dict]:
+            return [
+                {
+                    "name": "memory_recall",
+                    "description": "Search Hermes-scoped agentmemory observations.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                            "limit": {"type": "integer", "default": 10},
+                        },
+                        "required": ["query"],
+                    },
+                },
+                {
+                    "name": "memory_save",
+                    "description": "Save a Hermes-scoped long-term memory.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "content": {"type": "string"},
+                            "type": {"type": "string", "default": "fact"},
+                        },
+                        "required": ["content"],
+                    },
+                },
+            ]
+
+        def handle_tool_call(self, name: str, args: dict) -> str:
+            if name == "memory_recall":
+                result = _api(self._base, "search", {
+                    "project": self._project,
+                    "query": args["query"],
+                    "limit": args.get("limit", 10),
+                })
+                return json.dumps({"results": (result or {}).get("results", [])})
+
+            if name == "memory_save":
+                _api(self._base, "observe", self._observation_payload(
+                    args["content"],
+                    "",
+                    args.get("type", "fact"),
+                ))
+                return json.dumps({"success": True})
+
+            return json.dumps({"error": f"Unknown tool: {name}"})
+
+        def _observation_payload(self, tool_input: str, tool_output: str, memory_type: str = "conversation") -> dict:
+            return {
+                "hookType": "post_tool_use",
+                "sessionId": self._session_id,
+                "project": self._project,
+                "cwd": self._cwd,
+                "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "data": {
+                    "tool_name": memory_type,
+                    "tool_input": tool_input[:1000],
+                    "tool_output": tool_output[:4000],
+                },
+            }
+
+        def sync_turn(self, user: str, assistant: str, **kwargs: Any) -> None:
+            _api_bg(self._base, "observe", self._observation_payload(user, assistant))
+
+        def on_session_end(self, messages: list, **kwargs: Any) -> None:
+            _api(self._base, "session/end", {"sessionId": self._session_id})
+
+        def on_pre_compress(self, messages: list, **kwargs: Any) -> None:
+            context = self.system_prompt_block()
+            if context:
+                messages.insert(0, {
+                    "role": "user",
+                    "content": f"[agentmemory context before compaction]\n{context}",
+                })
+
+        def on_memory_write(self, action: str, target: str, content: str, **kwargs: Any) -> None:
+            if action in ("add", "update") and content:
+                _api_bg(self._base, "observe", self._observation_payload(content, "", "memory_write"))
+
+        def shutdown(self, **kwargs: Any) -> None:
+            pass
+
+
+    def register(ctx: Any) -> None:
+        ctx.register_memory_provider(AgentMemoryProvider())

--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -35,6 +35,7 @@ data:
       timeout: 180
       persistent_shell: true
     memory:
+      provider: agentmemory
       auto_migrate: true
     compression:
       enabled: true

--- a/kubernetes/apps/base/llm/hermes/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/hermes/externalsecret.yaml
@@ -17,6 +17,7 @@ spec:
         DISCORD_BOT_TOKEN: "{{ .SAKE_BOT_TOKEN }}"
         DISCORD_HOME_CHANNEL: "{{ .SAKE_HOME_CHANNEL }}"
         GITHUB_PERSONAL_ACCESS_TOKEN: "{{ .GITHUB_TOKEN }}"
+        AGENTMEMORY_SECRET: "{{ .AGENTMEMORY_SECRET }}"
         LITELLM_API_KEY: "{{ .LITELLM_MASTER_KEY }}"
         TELEGRAM_HOME_CHANNEL: "{{ .TELEGRAM_ALLOWED_USERS }}"
         TELEGRAM_ALLOWED_USERS: "{{ .TELEGRAM_ALLOWED_USERS }}"
@@ -24,6 +25,8 @@ spec:
   dataFrom:
     - extract:
         key: hermes-agent
+    - extract:
+        key: agentmemory
     - extract:
         key: github-miso
     - extract:

--- a/kubernetes/apps/base/llm/hermes/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/hermes/helmrelease.yaml
@@ -41,6 +41,8 @@ spec:
               tag: v2026.5.16@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33
             args: ["gateway", "run",]
             env:
+              AGENTMEMORY_PROJECT: hermes
+              AGENTMEMORY_URL: http://agentmemory.llm:3111
               HERMES_HOME: /opt/data
               HOME: /opt/data
               TZ: America/Edmonton
@@ -143,6 +145,12 @@ spec:
         globalMounts:
           - path: /tmp/config.yaml
             subPath: config.yaml
+      agentmemory-plugin:
+        type: configMap
+        name: hermes-agentmemory-plugin
+        defaultMode: 0755
+        globalMounts:
+          - path: /opt/data/plugins/agentmemory
       gallery:
         type: nfs
         server: voyager.internal

--- a/kubernetes/apps/base/llm/hermes/kustomization.yaml
+++ b/kubernetes/apps/base/llm/hermes/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./agentmemory-plugin.yaml
   - ./configmap.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -334,6 +334,8 @@ data:
               min_confidence: 0.5,
               fallback_on_error: true,
               timeout_ms: 5000,
+              default_agent: "main",
+              project_prefix: "openclaw",
             },
           },
         },


### PR DESCRIPTION
## Summary
- add a Hermes agentmemory memory provider plugin mounted from ConfigMap
- configure Hermes to use the shared agentmemory service with project scope `hermes`
- keep OpenClaw on its existing `openclaw` scoped memory prefix explicitly

## Validation
- `git diff --check`
- `flux-local test --enable-helm --path ./kubernetes/clusters/main`