### PR TITLE
docs(agents): replace flux-local examples with flate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,13 +63,16 @@ Flux recursively searches `kubernetes/${cluster}/apps/` for `kustomization.yaml`
 - **Update app**: Merge renovate PR or manually edit and push
 - **Troubleshoot**: Check `flux get all -n <namespace>`, `kubectl get events --sort-by=.lastTimestamp`
 - **Scripts**: `hack/` contains operational scripts (cert-extract.sh, delete-stuck-ns.sh, etc.)
-- **Validate locally**: Run `flux-local` before pushing GitOps changes:
+- **Validate locally**: Run `flate` (auto-installed via `.mise.toml`) before pushing GitOps changes:
   ```bash
-  # Test both kustomizations and HelmReleases
-  /Users/joryirving/.local/share/mise/installs/pipx-flux-local/8.1.0/bin/flux-local test --enable-helm --path ./kubernetes/clusters/main
+  # Test Kustomizations + HelmReleases for a cluster
+  flate test ks --path ./kubernetes/clusters/main
 
-  # Diff a specific HelmRelease or Kustomization
-  /Users/joryirving/.local/share/mise/installs/pipx-flux-local/8.1.0/bin/flux-local diff helmrelease --path ./kubernetes/clusters/main --limit-bytes 10000
+  # Diff against a baseline (e.g., main branch)
+  git worktree add --detach /tmp/baseline origin/main
+  flate diff ks --path ./kubernetes/clusters/main --path-orig /tmp/baseline/kubernetes/clusters/main
+  flate diff hr --path ./kubernetes/clusters/main --path-orig /tmp/baseline/kubernetes/clusters/main
+  git worktree remove /tmp/baseline --force
   ```
 - **Gateway policy namespace rule**: `ClientTrafficPolicy` and `EnvoyPatchPolicy` that target a `Gateway` must live in the same namespace as that `Gateway`. For `envoy-internal`, put those resources in `kubernetes/apps/base/network/envoy-gateway/config/` with namespace `network`.
 


### PR DESCRIPTION
Catches AGENTS.md up to PR #7156. Replaces the \`flux-local\` examples in the "Validate locally" section with flate equivalents.

- \`flate\` is on PATH (auto-installed via \`.mise.toml\`), so no hardcoded path
- \`flate test\` doesn't take \`--enable-helm\` (it's default-on)
- \`flate diff\` requires \`--path-orig\` for changed-only mode; added a worktree setup/teardown pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)