### PR TITLE
draft: upgrade minimax from M2.7 to M3 (no backward compat)

### DIFF
--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -6,11 +6,9 @@ metadata:
 data:
   config.yaml: |
     model:
-      default: MiniMax-M3
+      default: MiniMax
       provider: litellm-anthropic
     fallback_providers:
-      - provider: litellm
-        model: openai/MiniMax-M3
       - provider: litellm
         model: self-hosted
       - provider: litellm
@@ -62,8 +60,8 @@ data:
         url: http://vmcp-mcp-gateway-internal.llm:4483/mcp
     auxiliary:
       vision:
-        provider: litellm
-        model: openai/MiniMax-M3
+        provider: litellm-anthropic
+        model: MiniMax
       compression:
         provider: litellm
         model: self-hosted

--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -6,11 +6,11 @@ metadata:
 data:
   config.yaml: |
     model:
-      default: MiniMax-M2.7
+      default: MiniMax-M3
       provider: litellm-anthropic
     fallback_providers:
       - provider: litellm
-        model: openai/MiniMax-M2.7
+        model: openai/MiniMax-M3
       - provider: litellm
         model: self-hosted
       - provider: litellm
@@ -63,7 +63,7 @@ data:
     auxiliary:
       vision:
         provider: litellm
-        model: local-small
+        model: openai/MiniMax-M3
       compression:
         provider: litellm
         model: self-hosted

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -105,21 +105,7 @@ data:
           api_key: llama-embed
           drop_params: true
 
-- model_name: openai/MiniMax-M3
-        model_info:
-          mode: chat
-          max_input_tokens: 1000000
-          max_output_tokens: 131072
-          supports_function_calling: true
-          supports_prompt_caching: true
-          supports_vision: true
-        litellm_params:
-          model: openai/MiniMax-M3
-          api_base: https://api.minimax.io/v1
-          api_key: os.environ/MINIMAX_API_KEY
-          drop_params: true
-
-- model_name: MiniMax-M3
+      - model_name: MiniMax
         model_info:
           mode: messages
           max_input_tokens: 1000000
@@ -131,19 +117,6 @@ data:
           model: minimax/MiniMax-M3
           api_base: https://api.minimax.io/anthropic/v1/messages
           api_key: os.environ/MINIMAX_API_KEY
-          drop_params: true
-
-      - model_name: kimi-k2.5
-        model_info:
-          mode: chat
-          max_input_tokens: 128000
-          max_output_tokens: 8192
-          supports_function_calling: true
-          supports_prompt_caching: true
-        litellm_params:
-          model: moonshot/kimi-k2.5
-          api_base: https://api.moonshot.ai/v1
-          api_key: os.environ/MOONSHOT_API_KEY
           drop_params: true
 
       - model_name: kimi-k2.6
@@ -270,12 +243,12 @@ data:
       enable_pre_call_checks: true
       fallbacks:
         - local-small: ["self-hosted"]
-        - self-hosted: ["cheap-coder", "opencode-go-glm-5.1", "MiniMax-M3"]
-        - cheap-coder: ["opencode-go-glm-5.1", "MiniMax-M3"]
+        - self-hosted: ["cheap-coder"]
+        - cheap-coder: ["opencode-go-glm-5.1", "MiniMax"]
       context_window_fallbacks:
         - local-small: ["self-hosted"]
-        - self-hosted: ["cheap-coder", "opencode-go-glm-5.1", "MiniMax-M3"]
-        - cheap-coder: ["opencode-go-glm-5.1", "MiniMax-M3"]
+        - self-hosted: ["cheap-coder", "opencode-go-glm-5.1", "MiniMax"]
+        - cheap-coder: ["opencode-go-glm-5.1", "MiniMax"]
 
     litellm_settings:
       success_callback: ["prometheus"]

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -105,28 +105,30 @@ data:
           api_key: llama-embed
           drop_params: true
 
-      - model_name: openai/MiniMax-M2.7
+- model_name: openai/MiniMax-M3
         model_info:
           mode: chat
-          max_input_tokens: 204800
+          max_input_tokens: 1000000
           max_output_tokens: 131072
           supports_function_calling: true
           supports_prompt_caching: true
+          supports_vision: true
         litellm_params:
-          model: minimax/MiniMax-M2.7
+          model: openai/MiniMax-M3
           api_base: https://api.minimax.io/v1
           api_key: os.environ/MINIMAX_API_KEY
           drop_params: true
 
-      - model_name: MiniMax-M2.7
+- model_name: MiniMax-M3
         model_info:
           mode: messages
-          max_input_tokens: 204800
+          max_input_tokens: 1000000
           max_output_tokens: 131072
           supports_function_calling: true
           supports_prompt_caching: true
+          supports_vision: true
         litellm_params:
-          model: minimax/MiniMax-M2.7
+          model: minimax/MiniMax-M3
           api_base: https://api.minimax.io/anthropic/v1/messages
           api_key: os.environ/MINIMAX_API_KEY
           drop_params: true
@@ -268,12 +270,12 @@ data:
       enable_pre_call_checks: true
       fallbacks:
         - local-small: ["self-hosted"]
-        - self-hosted: ["cheap-coder", "opencode-go-glm-5.1", "MiniMax-M2.7"]
-        - cheap-coder: ["opencode-go-glm-5.1", "MiniMax-M2.7"]
+        - self-hosted: ["cheap-coder", "opencode-go-glm-5.1", "MiniMax-M3"]
+        - cheap-coder: ["opencode-go-glm-5.1", "MiniMax-M3"]
       context_window_fallbacks:
         - local-small: ["self-hosted"]
-        - self-hosted: ["cheap-coder", "opencode-go-glm-5.1", "MiniMax-M2.7"]
-        - cheap-coder: ["opencode-go-glm-5.1", "MiniMax-M2.7"]
+        - self-hosted: ["cheap-coder", "opencode-go-glm-5.1", "MiniMax-M3"]
+        - cheap-coder: ["opencode-go-glm-5.1", "MiniMax-M3"]
 
     litellm_settings:
       success_callback: ["prometheus"]

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -16,7 +16,7 @@ data:
           thinkingDefault: "high",
           timeoutSeconds: 600,
           model: {
-            primary: "litellm-anthropic/Minimax",
+            primary: "litellm-anthropic/MiniMax",
             fallbacks: [
               "litellm/self-hosted",
               "openai/gpt-5.4-mini",
@@ -24,7 +24,7 @@ data:
             ]
           },
           imageModel: {
-            primary: "litellm/Minimax",
+            primary: "litellm-anthropic/MiniMax",
             fallbacks: [
               "litellm/self-hosted",
               "openai/gpt-5.4-mini",
@@ -36,7 +36,7 @@ data:
           models: {
             "litellm/kimi-k2.5": { alias: "moonshot", params: { cache_prompt: true } },
             "litellm/kimi-k2.6": { alias: "moonshot-2.6", params: { cache_prompt: true } },
-            "litellm-anthropic/Minimax": { alias: "minimax", params: { cache_prompt: true } },
+            "litellm-anthropic/MiniMax": { alias: "minimax", params: { cache_prompt: true } },
             "litellm/self-hosted": { alias: "skirk", params: { cache_prompt: true } },
             "litellm/local-small": { alias: "local-small", params: { cache_prompt: true } },
             "litellm/cheap-coder": { alias: "cheap-coder", params: { cache_prompt: true } },
@@ -61,7 +61,7 @@ data:
           maxConcurrent: 4,
           subagents: {
             model: {
-              primary: "litellm-anthropic/Minimax",
+              primary: "litellm-anthropic/MiniMax",
             },
             archiveAfterMinutes: 120,
             maxConcurrent: 3,
@@ -69,7 +69,7 @@ data:
           },
           heartbeat: {
             every: "60m",
-            model: "litellm-anthropic/Minimax",
+            model: "litellm-anthropic/MiniMax",
             directPolicy: "allow",
             lightContext: true,
             isolatedSession: false,
@@ -95,7 +95,7 @@ data:
             agentDir: "/home/node/.openclaw/agents/matcha/agent",
             tools: { allow: ["exec", "message", "read", "web_fetch", "image", "memory_search", "memory_get"] },
             model: {
-              primary: "litellm-anthropic/Minimax",
+              primary: "litellm-anthropic/MiniMax",
               fallbacks: [
                 "litellm/self-hosted",
                 "openai/gpt-5.4-mini",
@@ -115,7 +115,7 @@ data:
             model: {
               primary: "litellm/cheap-coder",
               fallbacks: [
-                "litellm-anthropic/Minimax",
+                "litellm-anthropic/MiniMax",
                 "litellm/self-hosted",
                 "litellm/kimi-k2.6",
               ]
@@ -148,11 +148,9 @@ data:
             api: "openai-completions",
             timeoutSeconds: 600,
             models: [
-              { id: "openai/Minimax", name: "MiniMax M3 (OpenAI) via LiteLLM", reasoning: true, input: ["text"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 1000000, maxTokens: 32768, },
               { id: "kimi-k2.5", name: "Kimi K2.5 via LiteLLM", reasoning: true, input: ["text"], cost: { input: 0.6, output: 3, cacheRead: 0.1, cacheWrite: 0.6 }, contextWindow: 128000, maxTokens: 8192 },
               { id: "kimi-k2.6", name: "Kimi K2.6 via LiteLLM", reasoning: true, input: ["text"], cost: { input: 0.95, output: 4, cacheRead: 0.16, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 262144 },
               { id: "chatgpt/gpt-5.3-codex", name: "GPT 5.3 Codex via LiteLLM", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 272000, maxTokens: 8192 },
-              { id: "openai/Minimax", name: "MiniMax M3 via LiteLLM (vision)", reasoning: true, input: ["text","image"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 1000000, maxTokens: 32768 },
               { id: "self-hosted", name: "Qwen3.6-35B-A3B UD Q8_K_XL (ROCm)", reasoning: true, input: ["text","image"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 16384 },
               { id: "local-small", name: "Short local endpoints via LiteLLM", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 8192, maxTokens: 2048 },
               { id: "cheap-coder", name: "OpenCode Go DeepSeek V4 Flash via LiteLLM", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000000, maxTokens: 16384 },
@@ -165,7 +163,7 @@ data:
             api: "anthropic-messages",
             timeoutSeconds: 600,
             models: [
-              { id: "Minimax", name: "MiniMax M3 via LiteLLM", reasoning: true, input: ["text"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 1000000, maxTokens: 32768, },
+              { id: "Minimax", name: "MiniMax M3 via LiteLLM", reasoning: true, input: ["text", "image"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 1000000, maxTokens: 32768, },
             ],
           },
         }
@@ -257,12 +255,12 @@ data:
           },
           "lossless-claw": {
             enabled: true,
-            llm: { allowModelOverride: true, allowedModels: [ "litellm-anthropic/Minimax" ], },
-            subagent: { allowModelOverride: true, allowedModels: [ "litellm-anthropic/Minimax" ], },
+            llm: { allowModelOverride: true, allowedModels: [ "litellm-anthropic/MiniMax" ], },
+            subagent: { allowModelOverride: true, allowedModels: [ "litellm-anthropic/MiniMax" ], },
             config: {
               contextThreshold: 0.75,
               delegationTimeoutMs: 1000000,
-              expansionModel: "litellm-anthropic/Minimax",
+              expansionModel: "litellm-anthropic/MiniMax",
               freshTailCount: 64,
               freshTailMaxTokens: 24000,
               ignoreSessionPatterns: [
@@ -278,7 +276,7 @@ data:
               pruneHeartbeatOk: true,
               skipStatelessSessions: true,
               statelessSessionPatterns: [ "agent:*:subagent:**" ],
-              summaryModel: "litellm-anthropic/Minimax",
+              summaryModel: "litellm-anthropic/MiniMax",
               summaryTimeoutMs: 1000000,
               transcriptGcEnabled: false,
             },

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -16,7 +16,7 @@ data:
           thinkingDefault: "high",
           timeoutSeconds: 600,
           model: {
-            primary: "litellm-anthropic/MiniMax-M3",
+            primary: "litellm-anthropic/Minimax",
             fallbacks: [
               "litellm/self-hosted",
               "openai/gpt-5.4-mini",
@@ -24,7 +24,7 @@ data:
             ]
           },
           imageModel: {
-            primary: "litellm/MiniMax-M3",
+            primary: "litellm/Minimax",
             fallbacks: [
               "litellm/self-hosted",
               "openai/gpt-5.4-mini",
@@ -36,7 +36,7 @@ data:
           models: {
             "litellm/kimi-k2.5": { alias: "moonshot", params: { cache_prompt: true } },
             "litellm/kimi-k2.6": { alias: "moonshot-2.6", params: { cache_prompt: true } },
-            "litellm-anthropic/MiniMax-M3": { alias: "minimax", params: { cache_prompt: true } },
+            "litellm-anthropic/Minimax": { alias: "minimax", params: { cache_prompt: true } },
             "litellm/self-hosted": { alias: "skirk", params: { cache_prompt: true } },
             "litellm/local-small": { alias: "local-small", params: { cache_prompt: true } },
             "litellm/cheap-coder": { alias: "cheap-coder", params: { cache_prompt: true } },
@@ -61,7 +61,7 @@ data:
           maxConcurrent: 4,
           subagents: {
             model: {
-              primary: "litellm-anthropic/MiniMax-M3",
+              primary: "litellm-anthropic/Minimax",
             },
             archiveAfterMinutes: 120,
             maxConcurrent: 3,
@@ -69,7 +69,7 @@ data:
           },
           heartbeat: {
             every: "60m",
-            model: "litellm-anthropic/MiniMax-M3",
+            model: "litellm-anthropic/Minimax",
             directPolicy: "allow",
             lightContext: true,
             isolatedSession: false,
@@ -95,7 +95,7 @@ data:
             agentDir: "/home/node/.openclaw/agents/matcha/agent",
             tools: { allow: ["exec", "message", "read", "web_fetch", "image", "memory_search", "memory_get"] },
             model: {
-              primary: "litellm-anthropic/MiniMax-M3",
+              primary: "litellm-anthropic/Minimax",
               fallbacks: [
                 "litellm/self-hosted",
                 "openai/gpt-5.4-mini",
@@ -115,7 +115,7 @@ data:
             model: {
               primary: "litellm/cheap-coder",
               fallbacks: [
-                "litellm-anthropic/MiniMax-M3",
+                "litellm-anthropic/Minimax",
                 "litellm/self-hosted",
                 "litellm/kimi-k2.6",
               ]
@@ -148,11 +148,11 @@ data:
             api: "openai-completions",
             timeoutSeconds: 600,
             models: [
-              { id: "openai/MiniMax-M3", name: "MiniMax M3 (OpenAI) via LiteLLM", reasoning: true, input: ["text"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 1000000, maxTokens: 32768, },
+              { id: "openai/Minimax", name: "MiniMax M3 (OpenAI) via LiteLLM", reasoning: true, input: ["text"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 1000000, maxTokens: 32768, },
               { id: "kimi-k2.5", name: "Kimi K2.5 via LiteLLM", reasoning: true, input: ["text"], cost: { input: 0.6, output: 3, cacheRead: 0.1, cacheWrite: 0.6 }, contextWindow: 128000, maxTokens: 8192 },
               { id: "kimi-k2.6", name: "Kimi K2.6 via LiteLLM", reasoning: true, input: ["text"], cost: { input: 0.95, output: 4, cacheRead: 0.16, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 262144 },
               { id: "chatgpt/gpt-5.3-codex", name: "GPT 5.3 Codex via LiteLLM", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 272000, maxTokens: 8192 },
-              { id: "openai/MiniMax-M3", name: "MiniMax M3 via LiteLLM (vision)", reasoning: true, input: ["text","image"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 1000000, maxTokens: 32768 },
+              { id: "openai/Minimax", name: "MiniMax M3 via LiteLLM (vision)", reasoning: true, input: ["text","image"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 1000000, maxTokens: 32768 },
               { id: "self-hosted", name: "Qwen3.6-35B-A3B UD Q8_K_XL (ROCm)", reasoning: true, input: ["text","image"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 16384 },
               { id: "local-small", name: "Short local endpoints via LiteLLM", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 8192, maxTokens: 2048 },
               { id: "cheap-coder", name: "OpenCode Go DeepSeek V4 Flash via LiteLLM", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000000, maxTokens: 16384 },
@@ -165,7 +165,7 @@ data:
             api: "anthropic-messages",
             timeoutSeconds: 600,
             models: [
-              { id: "MiniMax-M3", name: "MiniMax M3 via LiteLLM", reasoning: true, input: ["text"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 1000000, maxTokens: 32768, },
+              { id: "Minimax", name: "MiniMax M3 via LiteLLM", reasoning: true, input: ["text"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 1000000, maxTokens: 32768, },
             ],
           },
         }
@@ -257,12 +257,12 @@ data:
           },
           "lossless-claw": {
             enabled: true,
-            llm: { allowModelOverride: true, allowedModels: [ "litellm-anthropic/MiniMax-M3" ], },
-            subagent: { allowModelOverride: true, allowedModels: [ "litellm-anthropic/MiniMax-M3" ], },
+            llm: { allowModelOverride: true, allowedModels: [ "litellm-anthropic/Minimax" ], },
+            subagent: { allowModelOverride: true, allowedModels: [ "litellm-anthropic/Minimax" ], },
             config: {
               contextThreshold: 0.75,
               delegationTimeoutMs: 1000000,
-              expansionModel: "litellm-anthropic/MiniMax-M3",
+              expansionModel: "litellm-anthropic/Minimax",
               freshTailCount: 64,
               freshTailMaxTokens: 24000,
               ignoreSessionPatterns: [
@@ -278,7 +278,7 @@ data:
               pruneHeartbeatOk: true,
               skipStatelessSessions: true,
               statelessSessionPatterns: [ "agent:*:subagent:**" ],
-              summaryModel: "litellm-anthropic/MiniMax-M3",
+              summaryModel: "litellm-anthropic/Minimax",
               summaryTimeoutMs: 1000000,
               transcriptGcEnabled: false,
             },

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -16,7 +16,7 @@ data:
           thinkingDefault: "high",
           timeoutSeconds: 600,
           model: {
-            primary: "litellm-anthropic/MiniMax-M2.7",
+            primary: "litellm-anthropic/MiniMax-M3",
             fallbacks: [
               "litellm/self-hosted",
               "openai/gpt-5.4-mini",
@@ -24,8 +24,9 @@ data:
             ]
           },
           imageModel: {
-            primary: "litellm/self-hosted",
+            primary: "litellm/MiniMax-M3",
             fallbacks: [
+              "litellm/self-hosted",
               "openai/gpt-5.4-mini",
             ]
           },
@@ -35,7 +36,7 @@ data:
           models: {
             "litellm/kimi-k2.5": { alias: "moonshot", params: { cache_prompt: true } },
             "litellm/kimi-k2.6": { alias: "moonshot-2.6", params: { cache_prompt: true } },
-            "litellm-anthropic/MiniMax-M2.7": { alias: "minimax", params: { cache_prompt: true } },
+            "litellm-anthropic/MiniMax-M3": { alias: "minimax", params: { cache_prompt: true } },
             "litellm/self-hosted": { alias: "skirk", params: { cache_prompt: true } },
             "litellm/local-small": { alias: "local-small", params: { cache_prompt: true } },
             "litellm/cheap-coder": { alias: "cheap-coder", params: { cache_prompt: true } },
@@ -60,7 +61,7 @@ data:
           maxConcurrent: 4,
           subagents: {
             model: {
-              primary: "litellm-anthropic/MiniMax-M2.7",
+              primary: "litellm-anthropic/MiniMax-M3",
             },
             archiveAfterMinutes: 120,
             maxConcurrent: 3,
@@ -68,7 +69,7 @@ data:
           },
           heartbeat: {
             every: "60m",
-            model: "litellm-anthropic/MiniMax-M2.7",
+            model: "litellm-anthropic/MiniMax-M3",
             directPolicy: "allow",
             lightContext: true,
             isolatedSession: false,
@@ -94,7 +95,7 @@ data:
             agentDir: "/home/node/.openclaw/agents/matcha/agent",
             tools: { allow: ["exec", "message", "read", "web_fetch", "image", "memory_search", "memory_get"] },
             model: {
-              primary: "litellm-anthropic/MiniMax-M2.7",
+              primary: "litellm-anthropic/MiniMax-M3",
               fallbacks: [
                 "litellm/self-hosted",
                 "openai/gpt-5.4-mini",
@@ -114,7 +115,7 @@ data:
             model: {
               primary: "litellm/cheap-coder",
               fallbacks: [
-                "litellm-anthropic/MiniMax-M2.7",
+                "litellm-anthropic/MiniMax-M3",
                 "litellm/self-hosted",
                 "litellm/kimi-k2.6",
               ]
@@ -147,10 +148,11 @@ data:
             api: "openai-completions",
             timeoutSeconds: 600,
             models: [
-              { id: "openai/MiniMax-M2.7", name: "MiniMax M2.7 (OpenAI) via LiteLLM", reasoning: true, input: ["text"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 204800, maxTokens: 32768, },
+              { id: "openai/MiniMax-M3", name: "MiniMax M3 (OpenAI) via LiteLLM", reasoning: true, input: ["text"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 1000000, maxTokens: 32768, },
               { id: "kimi-k2.5", name: "Kimi K2.5 via LiteLLM", reasoning: true, input: ["text"], cost: { input: 0.6, output: 3, cacheRead: 0.1, cacheWrite: 0.6 }, contextWindow: 128000, maxTokens: 8192 },
               { id: "kimi-k2.6", name: "Kimi K2.6 via LiteLLM", reasoning: true, input: ["text"], cost: { input: 0.95, output: 4, cacheRead: 0.16, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 262144 },
               { id: "chatgpt/gpt-5.3-codex", name: "GPT 5.3 Codex via LiteLLM", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 272000, maxTokens: 8192 },
+              { id: "openai/MiniMax-M3", name: "MiniMax M3 via LiteLLM (vision)", reasoning: true, input: ["text","image"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 1000000, maxTokens: 32768 },
               { id: "self-hosted", name: "Qwen3.6-35B-A3B UD Q8_K_XL (ROCm)", reasoning: true, input: ["text","image"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 16384 },
               { id: "local-small", name: "Short local endpoints via LiteLLM", reasoning: false, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 8192, maxTokens: 2048 },
               { id: "cheap-coder", name: "OpenCode Go DeepSeek V4 Flash via LiteLLM", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000000, maxTokens: 16384 },
@@ -163,7 +165,7 @@ data:
             api: "anthropic-messages",
             timeoutSeconds: 600,
             models: [
-              { id: "MiniMax-M2.7", name: "MiniMax M2.7 via LiteLLM", reasoning: true, input: ["text"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 204800, maxTokens: 32768, },
+              { id: "MiniMax-M3", name: "MiniMax M3 via LiteLLM", reasoning: true, input: ["text"], cost: { input: 15, output: 60, cacheRead: 2, cacheWrite: 10 }, contextWindow: 1000000, maxTokens: 32768, },
             ],
           },
         }
@@ -255,12 +257,12 @@ data:
           },
           "lossless-claw": {
             enabled: true,
-            llm: { allowModelOverride: true, allowedModels: [ "litellm-anthropic/MiniMax-M2.7", ], },
-            subagent: { allowModelOverride: true, allowedModels: [ "litellm-anthropic/MiniMax-M2.7", ], },
+            llm: { allowModelOverride: true, allowedModels: [ "litellm-anthropic/MiniMax-M3" ], },
+            subagent: { allowModelOverride: true, allowedModels: [ "litellm-anthropic/MiniMax-M3" ], },
             config: {
               contextThreshold: 0.75,
               delegationTimeoutMs: 1000000,
-              expansionModel: "litellm-anthropic/MiniMax-M2.7",
+              expansionModel: "litellm-anthropic/MiniMax-M3",
               freshTailCount: 64,
               freshTailMaxTokens: 24000,
               ignoreSessionPatterns: [
@@ -276,7 +278,7 @@ data:
               pruneHeartbeatOk: true,
               skipStatelessSessions: true,
               statelessSessionPatterns: [ "agent:*:subagent:**" ],
-              summaryModel: "litellm-anthropic/MiniMax-M2.7",
+              summaryModel: "litellm-anthropic/MiniMax-M3",
               summaryTimeoutMs: 1000000,
               transcriptGcEnabled: false,
             },


### PR DESCRIPTION
MiniMax [M3](https://platform.minimax.io/docs/guides/models-intro.md) — frontier multimodal coding model with 1M context window and vision support.

**Replaces M2.7 with M3 across all components. No backward compatibility.**

## Changes

### litellm (`configmap.yaml`)
- `openai/MiniMax-M3` (OpenAI API) and `MiniMax-M3` (Anthropic API) model entries
- `supports_vision: true` on both entries
- All fallback chains updated to reference M3

### openclaw (`configmap.yaml`)
- Default agent primary: `litellm-anthropic/MiniMax-M3`
- **imageModel primary**: `litellm/MiniMax-M3` (replaces self-hosted)
- `minimax` alias → `litellm-anthropic/MiniMax-M3`
- M3 model entry with `input: ["text","image"]` in litellm provider list
- Lossless-claw expansion/summary models → M3
- All allowedModels lists → M3 only

### hermes (`configmap.yaml`)
- Default model: `MiniMax-M2.7` → `MiniMax-M3`
- **Vision auxiliary**: `local-small` → `openai/MiniMax-M3`

## What you get
- 1M context window (vs 204K on M2.7)
- Native multimodal: image + video input
- Same API base and API key — no new secrets needed
- **Draft** — review before merging