### PR TITLE
fix: pin pr-reviewer-action v1.1.2

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Analyze PR with reusable AI reviewer
         id: analyze
-        uses: misospace/pr-reviewer-action@14d5349357f8229c5e091b019f959e80868f44b6 # v1.1.0
+        uses: misospace/pr-reviewer-action@4a450e226d0acb8fac839a758b53cf318ddb0e54 # v1.1.2
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: "8"


### PR DESCRIPTION
## Summary

- update the pinned `misospace/pr-reviewer-action` SHA from broken `v1.1.0` to hotfix `v1.1.2`
- fixes setup-job failures caused by invalid `${{ ... :- ... }}` syntax in the old action manifest
- includes the follow-up runtime import fix for `pr_reviewer.*` modules when the composite action runs from the caller repo

## Validation

- parsed `.github/workflows/ai-pr-review.yaml` with PyYAML
- `git diff --check`

`v1.1.2` release: https://github.com/misospace/pr-reviewer-action/releases/tag/v1.1.2
