### PR TITLE
fix: pin pr-reviewer-action v1.1.4

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Analyze PR with reusable AI reviewer
         id: analyze
-        uses: misospace/pr-reviewer-action@4a450e226d0acb8fac839a758b53cf318ddb0e54 # v1.1.2
+        uses: misospace/pr-reviewer-action@bde971c3422cac07fda206761d546f80f2bfcd84 # v1.1.4
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: "8"


### PR DESCRIPTION
## Summary

- update pinned `misospace/pr-reviewer-action` from `v1.1.2` to `v1.1.4`
- pulls in the publish-step shell syntax fix for `ANALYSIS_ENGINE` values containing parenthesized provider text
- uses the hotfix release that also makes the new shell-syntax regression test dependency-free in CI

## Validation

- parsed `.github/workflows/ai-pr-review.yaml` with a simple Python check
- `git diff --check`

`v1.1.4` release: https://github.com/misospace/pr-reviewer-action/releases/tag/v1.1.4
