### PR TITLE
fix(ci): pin pr-reviewer-action to v1.1.5

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Analyze PR with reusable AI reviewer
         id: analyze
-        uses: misospace/pr-reviewer-action@bde971c3422cac07fda206761d546f80f2bfcd84 # v1.1.4
+        uses: misospace/pr-reviewer-action@47d9e852b96255df8475f5748945f8606dada794 # v1.1.5
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: "8"


### PR DESCRIPTION
Pin `pr-reviewer-action` to `v1.1.5` which fixes the `review_comment` publish mode so review comments are actually visible in the PR UI.

**Root cause**: `gh pr review --comment` creates a COMMENTED review that GitHub does NOT display in the PR timeline.

**Fix**: Use `gh pr comment --edit-last --create-if-none` instead for sticky, visible PR comments.

Upstream fix: https://github.com/misospace/pr-reviewer-action/pull/152