### PR TITLE
fix(ci): recut pr-reviewer-action to v1.1.5 (metadata marker fix)

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Analyze PR with reusable AI reviewer
         id: analyze
-        uses: misospace/pr-reviewer-action@47d9e852b96255df8475f5748945f8606dada794 # v1.1.5
+        uses: misospace/pr-reviewer-action@245e8e6ead548179282c1dc00d661ef73e5333f3 # v1.1.5
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: "8"


### PR DESCRIPTION
Recut `pr-reviewer-action` to `v1.1.5` which fixes the metadata marker HTML comment closing tag.

**Root cause**: The metadata marker was missing `-->` closing tag, causing GitHub to treat all review content as a hidden comment and making review comments appear empty/blank in the PR UI.

**Fix**: Added proper `-->` closing tag to the metadata marker.

Upstream fix: https://github.com/misospace/pr-reviewer-action/pull/153