### PR TITLE
fix(ci): pin pr-reviewer-action to v1.1.1 (clean recut)

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Analyze PR with reusable AI reviewer
         id: analyze
-        uses: misospace/pr-reviewer-action@8f72b519d2aaa4824673f5f4cbaafb7aba299349 # v1.1.5
+        uses: misospace/pr-reviewer-action@8f72b519d2aaa4824673f5f4cbaafb7aba299349 # v1.1.1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: "8"


### PR DESCRIPTION
Recut `pr-reviewer-action` to `v1.1.1` as a clean restart from `v1.1.0`. All intermediate tags (v1.1.1–v1.1.5) were retired.

**What v1.1.1 contains (over v1.1.0):**
- Use `gh pr comment` for `review_comment` publish mode (visible in PR UI)
- Close HTML comment in metadata marker (was consuming all review content as hidden)

Upstream: https://github.com/misospace/pr-reviewer-action/releases/tag/v1.1.1