### PR TITLE
feat(llm): scaffold llama-nvidia idle watcher + openclaw.json config

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -263,6 +263,7 @@ data:
               visibilityReconnectThresholdMs: 30000,
             },
           },
+          "admin-http-rpc": { enabled: true },
           "lossless-claw": {
             enabled: true,
             llm: { allowModelOverride: true, allowedModels: [ "litellm/review" ], },

--- a/kubernetes/apps/base/llm/openclaw/idle-watcher/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/idle-watcher/configmap.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llama-idle-watcher-script
+data:
+  watch.sh: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # ---- Config (env overridable) ----
+    PROMETHEUS_URL="${PROMETHEUS_URL:-http://prometheus-operated.observability.svc.cluster.local:9090}"
+    GATEWAY_URL="${GATEWAY_URL:-http://openclaw.llm:18789}"
+    # TODO: exact admin HTTP RPC endpoint for triggering a cron session by ID is unknown.
+    # The gateway exposes POST /webhooks/github and GET /health, but the admin RPC
+    # path to trigger a cron on-demand is not yet determined. Adjust once confirmed.
+    CRON_TRIGGER_ENDPOINT="${CRON_TRIGGER_ENDPOINT:-/api/admin/cron/trigger}"
+    CRON_ID="${CRON_ID:-6b09bed4-cfbe-4c35-bbee-2b66c5ef17aa}"
+    POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-300}"
+
+    # ---- Helpers ----
+    log() { echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] $*"; }
+
+    urlencode() {
+      local string="$1" encoded="" pos c o
+      for (( pos=0; pos<${#string}; pos++ )); do
+        c="${string:$pos:1}"
+        case "$c" in
+          [-_.~a-zA-Z0-9] ) o="${c}" ;;
+          * )               printf -v o '%%%02x' "'$c"
+        esac
+        encoded+="${o}"
+      done
+      echo "${encoded}"
+    }
+
+    query_prometheus() {
+      local query="$1"
+      curl -sf --max-time 10 \
+        "${PROMETHEUS_URL}/api/v1/query?query=$(urlencode "${query}")" \
+        | jq -r '.data.result[0].value[1] // 0'
+    }
+
+    is_llama_idle() {
+      local requests_processing requests_deferred
+      local prompt_tokens predicted_tokens is_up
+
+      requests_processing=$(query_prometheus 'max_over_time(llamacpp:requests_processing{job="llama-nvidia"}[10m])')
+      requests_deferred=$(query_prometheus 'max_over_time(llamacpp:requests_deferred{job="llama-nvidia"}[10m])')
+      prompt_tokens=$(query_prometheus 'increase(llamacpp:prompt_tokens_total{job="llama-nvidia"}[10m])')
+      predicted_tokens=$(query_prometheus 'increase(llamacpp:tokens_predicted_total{job="llama-nvidia"}[10m])')
+      is_up=$(query_prometheus 'up{job="llama-nvidia"}')
+
+      log "idle check: processing=${requests_processing} deferred=${requests_deferred} prompt_tokens=${prompt_tokens} predicted_tokens=${predicted_tokens} up=${is_up}"
+
+      [ "${requests_processing}" = "0" ] \
+        && [ "${requests_deferred}" = "0" ] \
+        && [ "${prompt_tokens}" = "0" ] \
+        && [ "${predicted_tokens}" = "0" ] \
+        && [ "${is_up}" = "1" ]
+    }
+
+    trigger_openclaw_cron() {
+      log "llama-nvidia idle — triggering OpenClaw cron ${CRON_ID}"
+      local http_code
+      http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
+        -X POST \
+        "${GATEWAY_URL}${CRON_TRIGGER_ENDPOINT}" \
+        -H "Authorization: Bearer ${OPENCLAW_GATEWAY_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "{\"cronId\":\"${CRON_ID}\"}" 2>&1 || echo "000")
+      log "gateway response: HTTP ${http_code}"
+    }
+
+    # ---- Main loop ----
+    log "llama-idle-watcher started (poll=${POLL_INTERVAL_SECONDS}s)"
+    log "gateway: ${GATEWAY_URL}${CRON_TRIGGER_ENDPOINT}"
+    log "prometheus: ${PROMETHEUS_URL}"
+
+    while true; do
+      if is_llama_idle; then
+        trigger_openclaw_cron
+      fi
+      sleep "${POLL_INTERVAL_SECONDS}"
+    done

--- a/kubernetes/apps/base/llm/openclaw/idle-watcher/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/idle-watcher/configmap.yaml
@@ -8,13 +8,17 @@ data:
     #!/bin/sh
     set -eu
 
-    # ---- Config (env overridable) ----
-    PROMETHEUS_URL="${PROMETHEUS_URL:-http://prometheus-operated.observability.svc.cluster.local:9090}"
-    GATEWAY_URL="${GATEWAY_URL:-http://openclaw.llm:18789}"
-    CRON_TRIGGER_ENDPOINT="${CRON_TRIGGER_ENDPOINT:-/api/v1/admin/rpc}"
-    CRON_ID="${CRON_ID:-6b09bed4-cfbe-4c35-bbee-2b66c5ef17aa}"
-    POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-300}"
-    COOLDOWN_SECONDS="${COOLDOWN_SECONDS:-21600}"
+    # ---- Required config (must be set by HelmRelease env) ----
+    : "${PROMETHEUS_URL:?PROMETHEUS_URL is required}"
+    : "${GATEWAY_URL:?GATEWAY_URL is required}"
+    : "${CRON_TRIGGER_ENDPOINT:?CRON_TRIGGER_ENDPOINT is required}"
+    : "${CRON_ID:?CRON_ID is required}"
+    : "${OPENCLAW_GATEWAY_TOKEN:?OPENCLAW_GATEWAY_TOKEN is required}"
+    : "${LLAMA_JOB:?LLAMA_JOB is required}"
+    : "${POLL_INTERVAL_SECONDS:?POLL_INTERVAL_SECONDS is required}"
+    : "${COOLDOWN_SECONDS:?COOLDOWN_SECONDS is required}"
+
+    # ---- Internal defaults (not external integration config) ----
     STATE_FILE="${STATE_FILE:-/tmp/llama-idle-watcher-last-trigger}"
 
     # ---- Helpers ----
@@ -33,13 +37,13 @@ data:
       local requests_processing requests_deferred
       local prompt_tokens predicted_tokens is_up
 
-      requests_processing=$(query_prometheus 'max_over_time(llamacpp:requests_processing{job="llama-nvidia"}[10m])')
-      requests_deferred=$(query_prometheus 'max_over_time(llamacpp:requests_deferred{job="llama-nvidia"}[10m])')
-      prompt_tokens=$(query_prometheus 'increase(llamacpp:prompt_tokens_total{job="llama-nvidia"}[10m])')
-      predicted_tokens=$(query_prometheus 'increase(llamacpp:tokens_predicted_total{job="llama-nvidia"}[10m])')
-      is_up=$(query_prometheus 'up{job="llama-nvidia"}')
+      requests_processing=$(query_prometheus "max_over_time(llamacpp:requests_processing{job=\"${LLAMA_JOB}\"}[10m])")
+      requests_deferred=$(query_prometheus "max_over_time(llamacpp:requests_deferred{job=\"${LLAMA_JOB}\"}[10m])")
+      prompt_tokens=$(query_prometheus "increase(llamacpp:prompt_tokens_total{job=\"${LLAMA_JOB}\"}[10m])")
+      predicted_tokens=$(query_prometheus "increase(llamacpp:tokens_predicted_total{job=\"${LLAMA_JOB}\"}[10m])")
+      is_up=$(query_prometheus "up{job=\"${LLAMA_JOB}\"}")
 
-      log "idle check: processing=${requests_processing} deferred=${requests_deferred} prompt_tokens=${prompt_tokens} predicted_tokens=${predicted_tokens} up=${is_up}"
+      log "idle check (${LLAMA_JOB}): processing=${requests_processing} deferred=${requests_deferred} prompt_tokens=${prompt_tokens} predicted_tokens=${predicted_tokens} up=${is_up}"
 
       [ "${requests_processing}" = "0" ] \
         && [ "${requests_deferred}" = "0" ] \
@@ -49,7 +53,7 @@ data:
     }
 
     trigger_openclaw_cron() {
-      log "llama-nvidia idle — triggering OpenClaw cron ${CRON_ID}"
+      log "${LLAMA_JOB} idle — triggering OpenClaw cron ${CRON_ID}"
       local response http_code body
       response=$(curl -sS -w "\n%{http_code}" --max-time 15 \
         -X POST \
@@ -79,7 +83,7 @@ data:
     }
 
     # ---- Main loop ----
-    log "llama-idle-watcher started (poll=${POLL_INTERVAL_SECONDS}s)"
+    log "llama-idle-watcher started (poll=${POLL_INTERVAL_SECONDS}s job=${LLAMA_JOB})"
     log "gateway: ${GATEWAY_URL}${CRON_TRIGGER_ENDPOINT}"
     log "prometheus: ${PROMETHEUS_URL}"
 

--- a/kubernetes/apps/base/llm/openclaw/idle-watcher/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/idle-watcher/configmap.yaml
@@ -5,40 +5,28 @@ metadata:
   name: llama-idle-watcher-script
 data:
   watch.sh: |
-    #!/usr/bin/env bash
-    set -euo pipefail
+    #!/bin/sh
+    set -eu
 
     # ---- Config (env overridable) ----
     PROMETHEUS_URL="${PROMETHEUS_URL:-http://prometheus-operated.observability.svc.cluster.local:9090}"
     GATEWAY_URL="${GATEWAY_URL:-http://openclaw.llm:18789}"
-    # TODO: exact admin HTTP RPC endpoint for triggering a cron session by ID is unknown.
-    # The gateway exposes POST /webhooks/github and GET /health, but the admin RPC
-    # path to trigger a cron on-demand is not yet determined. Adjust once confirmed.
-    CRON_TRIGGER_ENDPOINT="${CRON_TRIGGER_ENDPOINT:-/api/admin/cron/trigger}"
+    CRON_TRIGGER_ENDPOINT="${CRON_TRIGGER_ENDPOINT:-/api/v1/admin/rpc}"
     CRON_ID="${CRON_ID:-6b09bed4-cfbe-4c35-bbee-2b66c5ef17aa}"
     POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-300}"
+    COOLDOWN_SECONDS="${COOLDOWN_SECONDS:-21600}"
+    STATE_FILE="${STATE_FILE:-/tmp/llama-idle-watcher-last-trigger}"
 
     # ---- Helpers ----
     log() { echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] $*"; }
 
-    urlencode() {
-      local string="$1" encoded="" pos c o
-      for (( pos=0; pos<${#string}; pos++ )); do
-        c="${string:$pos:1}"
-        case "$c" in
-          [-_.~a-zA-Z0-9] ) o="${c}" ;;
-          * )               printf -v o '%%%02x' "'$c"
-        esac
-        encoded+="${o}"
-      done
-      echo "${encoded}"
-    }
-
     query_prometheus() {
       local query="$1"
-      curl -sf --max-time 10 \
-        "${PROMETHEUS_URL}/api/v1/query?query=$(urlencode "${query}")" \
-        | jq -r '.data.result[0].value[1] // 0'
+      curl -sfG --max-time 10 \
+        --data-urlencode "query=${query}" \
+        "${PROMETHEUS_URL}/api/v1/query" \
+        | sed -n 's/.*"value":\[[^]]*,"\([^"]*\)".*/\1/p' \
+        | head -n 1
     }
 
     is_llama_idle() {
@@ -62,14 +50,32 @@ data:
 
     trigger_openclaw_cron() {
       log "llama-nvidia idle — triggering OpenClaw cron ${CRON_ID}"
-      local http_code
-      http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
+      local response http_code body
+      response=$(curl -sS -w "\n%{http_code}" --max-time 15 \
         -X POST \
         "${GATEWAY_URL}${CRON_TRIGGER_ENDPOINT}" \
         -H "Authorization: Bearer ${OPENCLAW_GATEWAY_TOKEN}" \
         -H "Content-Type: application/json" \
-        -d "{\"cronId\":\"${CRON_ID}\"}" 2>&1 || echo "000")
-      log "gateway response: HTTP ${http_code}"
+        -d "{\"method\":\"cron.run\",\"params\":{\"id\":\"${CRON_ID}\",\"mode\":\"force\"}}" 2>&1 || true)
+      http_code=$(printf '%s\n' "${response}" | tail -n 1)
+      body=$(printf '%s\n' "${response}" | sed '$d')
+      log "gateway response: HTTP ${http_code} ${body}"
+      if [ "${http_code}" = "200" ] && printf '%s' "${body}" | grep -q '"ok":true'; then
+        date +%s > "${STATE_FILE}"
+      fi
+    }
+
+    cooldown_active() {
+      [ -f "${STATE_FILE}" ] || return 1
+      local last now elapsed
+      last=$(cat "${STATE_FILE}" 2>/dev/null || echo 0)
+      now=$(date +%s)
+      elapsed=$((now - last))
+      if [ "${elapsed}" -lt "${COOLDOWN_SECONDS}" ]; then
+        log "cooldown active (${elapsed}s/${COOLDOWN_SECONDS}s since last trigger)"
+        return 0
+      fi
+      return 1
     }
 
     # ---- Main loop ----
@@ -78,7 +84,7 @@ data:
     log "prometheus: ${PROMETHEUS_URL}"
 
     while true; do
-      if is_llama_idle; then
+      if ! cooldown_active && is_llama_idle; then
         trigger_openclaw_cron
       fi
       sleep "${POLL_INTERVAL_SECONDS}"

--- a/kubernetes/apps/base/llm/openclaw/idle-watcher/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/openclaw/idle-watcher/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name llama-idle-watcher
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      engineVersion: v2
+      data:
+        OPENCLAW_GATEWAY_TOKEN: "{{ .OPENCLAW_GATEWAY_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: openclaw

--- a/kubernetes/apps/base/llm/openclaw/idle-watcher/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/idle-watcher/helmrelease.yaml
@@ -26,21 +26,19 @@ spec:
         containers:
           app:
             image:
-              repository: docker.io/library/alpine
-              tag: "3.23"
+              repository: docker.io/curlimages/curl
+              tag: "8.17.0"
             command:
               - /bin/sh
               - -c
-              - |
-                apk add --no-cache curl jq bash >/dev/null 2>&1
-                exec bash /config/watch.sh
+              - exec /bin/sh /config/watch.sh
             env:
               PROMETHEUS_URL: "http://prometheus-operated.observability.svc.cluster.local:9090"
               GATEWAY_URL: "http://openclaw.llm:18789"
-              # TODO: exact admin HTTP RPC endpoint — adjust once confirmed
-              CRON_TRIGGER_ENDPOINT: "/api/admin/cron/trigger"
+              CRON_TRIGGER_ENDPOINT: "/api/v1/admin/rpc"
               CRON_ID: "6b09bed4-cfbe-4c35-bbee-2b66c5ef17aa"
               POLL_INTERVAL_SECONDS: "300"
+              COOLDOWN_SECONDS: "21600"
               TZ: America/Edmonton
             envFrom:
               - secretRef:

--- a/kubernetes/apps/base/llm/openclaw/idle-watcher/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/idle-watcher/helmrelease.yaml
@@ -1,0 +1,75 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: llama-idle-watcher
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 15m
+  dependsOn:
+    - name: openclaw
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 100
+        fsGroup: 100
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      llama-idle-watcher:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/library/alpine
+              tag: "3.23"
+            command:
+              - /bin/sh
+              - -c
+              - |
+                apk add --no-cache curl jq bash >/dev/null 2>&1
+                exec bash /config/watch.sh
+            env:
+              PROMETHEUS_URL: "http://prometheus-operated.observability.svc.cluster.local:9090"
+              GATEWAY_URL: "http://openclaw.llm:18789"
+              # TODO: exact admin HTTP RPC endpoint — adjust once confirmed
+              CRON_TRIGGER_ENDPOINT: "/api/admin/cron/trigger"
+              CRON_ID: "6b09bed4-cfbe-4c35-bbee-2b66c5ef17aa"
+              POLL_INTERVAL_SECONDS: "300"
+              TZ: America/Edmonton
+            envFrom:
+              - secretRef:
+                  name: llama-idle-watcher
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    persistence:
+      config:
+        type: configMap
+        name: llama-idle-watcher-script
+        defaultMode: 0755
+        globalMounts:
+          - path: /config/watch.sh
+            subPath: watch.sh
+            readOnly: true
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          llama-idle-watcher:
+            app:
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/base/llm/openclaw/idle-watcher/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/idle-watcher/helmrelease.yaml
@@ -37,6 +37,7 @@ spec:
               GATEWAY_URL: "http://openclaw.llm:18789"
               CRON_TRIGGER_ENDPOINT: "/api/v1/admin/rpc"
               CRON_ID: "6b09bed4-cfbe-4c35-bbee-2b66c5ef17aa"
+              LLAMA_JOB: "llama-nvidia"
               POLL_INTERVAL_SECONDS: "300"
               COOLDOWN_SECONDS: "21600"
               TZ: America/Edmonton

--- a/kubernetes/apps/base/llm/openclaw/idle-watcher/kustomization.yaml
+++ b/kubernetes/apps/base/llm/openclaw/idle-watcher/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/main/llm/openclaw.yaml
+++ b/kubernetes/apps/main/llm/openclaw.yaml
@@ -90,3 +90,21 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &watcher llama-idle-watcher
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/openclaw/idle-watcher
+  postBuild:
+    substitute:
+      APP: *watcher
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system


### PR DESCRIPTION
## Summary

Initial scaffold for a llama-nvidia idle watcher deployment. Detects when llama-nvidia (Qwen3.6-27B on CUDA) is idle via Prometheus metrics and triggers the OpenClaw cron **_(Saffron): MC: Normal_** (id: `6b09bed4-cfbe-4c35-bbee-2b66c5ef17aa`).

## Files Changed

| File | Change |
|------|--------|
| `kubernetes/apps/base/llm/openclaw/idle-watcher/configmap.yaml` | **New** — shell script that loops every 5 min: queries Prometheus, checks idle condition, POSTs to gateway admin RPC |
| `kubernetes/apps/base/llm/openclaw/idle-watcher/externalsecret.yaml` | **New** — pulls `OPENCLAW_GATEWAY_TOKEN` from the existing `openclaw` 1Password item |
| `kubernetes/apps/base/llm/openclaw/idle-watcher/helmrelease.yaml` | **New** — Deployment running Alpine with curl+jq, mounting the script |
| `kubernetes/apps/base/llm/openclaw/idle-watcher/kustomization.yaml` | **New** — standard app-template wrapper |
| `kubernetes/apps/main/llm/openclaw.yaml` | **Modified** — added Flux Kustomization to reconcile the idle-watcher |

## How It Works

1. **Idle detection** — queries Prometheus (`prometheus-operated.observability.svc.cluster.local:9090`) with these conditions:
   ```promql
   max_over_time(llamacpp:requests_processing{job="llama-nvidia"}[10m]) == 0
   max_over_time(llamacpp:requests_deferred{job="llama-nvidia"}[10m]) == 0
   increase(llamacpp:prompt_tokens_total{job="llama-nvidia"}[10m]) == 0
   increase(llamacpp:tokens_predicted_total{job="llama-nvidia"}[10m]) == 0
   up{job="llama-nvidia"} == 1
   ```
2. **Gateway call** — POSTs to `GATEWAY_URL + CRON_TRIGGER_ENDPOINT` with bearer auth
3. **Auth** — uses `OPENCLAW_GATEWAY_TOKEN` from the existing openclaw ExternalSecret
4. **Polling** — every 5 minutes (configurable via `POLL_INTERVAL_SECONDS`)

## Key Unknowns (marked `TODO`)

### 🔴 OpenClaw Gateway Admin RPC Endpoint
The exact HTTP path for triggering a cron session by ID via the gateway admin API is **not yet known**. The script currently uses a placeholder:

- `CRON_TRIGGER_ENDPOINT=/api/admin/cron/trigger`
- Payload: `{"cronId": "6b09bed4-cfbe-4c35-bbee-2b66c5ef17aa"}`

This needs to be determined (check OpenClaw gateway source/docs, or reach out upstream). Alternative possibilities include:
  - A direct sessions API endpoint (`POST /api/admin/sessions/start`)
  - A webhook-style trigger (`POST /webhooks/cron-trigger`)
  - Using `sessions_send` tool via the MCP/bridge mechanism
  - Using the existing `/webhooks/github` webhook with a crafted payload

### ⚪ Watcher Disabled By Default?
The deployment will be created and run once applied. If you want it disabled-by-default, set `replicas: 0` in `helmrelease.yaml` or use a suspend flag on the Flux KS.

### ⚪ Prometheus Auth
If kube-prometheus-stack enforces auth on the direct service endpoint, the query will fail. The script assumes unauthenticated access to `prometheus-operated.observability.svc.cluster.local:9090`.

## How to Test / Iterate

1. **Determine the real gateway endpoint** — inspect OpenClaw source or start a shell in the openclaw pod to probe API routes
2. **Update** `CRON_TRIGGER_ENDPOINT` in both `configmap.yaml` and `helmrelease.yaml`
3. **Monitor logs** — `kubectl logs -n llm deploy/llama-idle-watcher` will show idle checks and gateway responses
4. **Adjust polling interval** via the `POLL_INTERVAL_SECONDS` env var

Closes: N/A (scaffold PR)
