### PR TITLE
[codex] add flate diff previews and dufs hosting

### DIFF
--- a/.agents/instructions/pr-review.instructions.md
+++ b/.agents/instructions/pr-review.instructions.md
@@ -25,6 +25,7 @@ If a pattern is explicitly documented as intentional in `AGENTS.md` (or in the c
 For Renovate digest-only container image updates where the repository and tag are unchanged and the diff only changes `@sha256:` values, keep `review_markdown` compact.
 
 Prefer:
+
 - short recommendation
 - changed files summary
 - non-blocking caveats, if any

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -4,6 +4,7 @@ name: Flate
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, closed]
     branches: ["main"]
 
 concurrency:
@@ -12,6 +13,11 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: write
+
+env:
+  DUFS_DOMAIN: dufs.jory.dev
+  DUFS_USERNAME: flate
 
 jobs:
   filter:
@@ -27,7 +33,7 @@ jobs:
           patterns: kubernetes/**/*
 
   flate:
-    if: ${{ needs.filter.outputs.changed-files != '[]' }}
+    if: ${{ needs.filter.outputs.changed-files != '[]' && github.event.action != 'closed' }}
     needs: filter
     name: Flate - ${{ matrix.cluster }} - ${{ matrix.resource }}
     runs-on: ubuntu-latest
@@ -47,15 +53,192 @@ jobs:
         uses: home-operations/flate/action@39f44bd8bc9f11ba5321cecbdfc04398a568f4d0 # v0.3.3
 
       - name: Run Flate
-        id: flate
         env:
           FLATE_PATH: ./kubernetes/clusters/${{ matrix.cluster }}
           KIND: ${{ matrix.resource }}
         run: flate test $KIND
 
+  flatten-diff:
+    if: ${{ needs.filter.outputs.changed-files != '[]' && github.event.action != 'closed' }}
+    needs: filter
+    name: Flate - Diff
+    runs-on: ubuntu-latest
+    outputs:
+      diff: ${{ steps.check.outputs.diff }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Flate
+        uses: home-operations/flate/action@39f44bd8bc9f11ba5321cecbdfc04398a568f4d0 # v0.3.3
+
+      - name: Run flate diff per cluster
+        run: |
+          for cluster in main test utility; do
+            flate diff all -p ./kubernetes/clusters/$cluster -o html > $cluster.html || true
+          done
+
+      - name: Check if any diffs exist
+        id: check
+        run: |
+          for cluster in main test utility; do
+            if [ -s $cluster.html ]; then
+              echo "diff=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "diff=false" >> "$GITHUB_OUTPUT"
+
+      - name: Configure 1Password
+        if: ${{ steps.check.outputs.diff == 'true' }}
+        uses: 1password/load-secrets-action/configure@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          connect-host: ${{ secrets.OP_CONNECT_HOST }}
+          connect-token: ${{ secrets.OP_CONNECT_TOKEN }}
+
+      - name: Load Secrets
+        if: ${{ steps.check.outputs.diff == 'true' }}
+        id: load-secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        env:
+          DUFS_PASSWORD: op://Kubernetes/dufs/DUFS_PASSWORD
+
+      - name: Upload diffs to dufs
+        if: ${{ steps.check.outputs.diff == 'true' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DUFS_PASSWORD: ${{ steps.load-secrets.outputs.DUFS_PASSWORD }}
+        with:
+          script: |
+            const fs = require("fs");
+            const crypto = require("crypto");
+            const pr = context.issue.number;
+            const clusters = ["main", "test", "utility"];
+
+            const auth = "Basic " + Buffer.from(`${process.env.DUFS_USERNAME}:${process.env.DUFS_PASSWORD}`).toString("base64");
+
+            for (const cluster of clusters) {
+              if (!fs.existsSync(`${cluster}.html`) || fs.statSync(`${cluster}.html`).size === 0) continue;
+
+              const dir = `https://${process.env.DUFS_DOMAIN}/flate/${cluster}/`;
+              const url = `${dir}${pr}.html`;
+              const body = fs.readFileSync(`${cluster}.html`);
+              const localHash = crypto.createHash("sha256").update(body).digest("hex");
+
+              const head = await fetch(`${url}?hash`, { headers: { Authorization: auth } });
+              const remoteHash = head.ok ? (await head.text()).trim() : "";
+              if (remoteHash === localHash) {
+                core.info(`Diff unchanged (sha256 ${localHash}) — skipping upload.`);
+                continue;
+              }
+
+              await fetch(dir, { method: "MKCOL", headers: { Authorization: auth } });
+              const res = await fetch(url, { method: "PUT", headers: { Authorization: auth }, body });
+              if (!res.ok) throw new Error(`PUT ${url} returned HTTP ${res.status}`);
+              core.info(`📄 Rendered diff (${cluster}): ${url}`);
+            }
+
+  comment:
+    if: ${{ needs.flatten-diff.outputs.diff == 'true' }}
+    needs: flatten-diff
+    name: Flate - Comment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      - name: Add or Update Comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const marker = `<!-- flate -->`;
+            const sha = context.payload.pull_request.head.sha;
+            const shortSha = sha.slice(0, 7);
+            const commitUrl = `${context.serverUrl}/${owner}/${repo}/commit/${sha}`;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const diffUrl = `https://${process.env.DUFS_DOMAIN}/flate`;
+            const clusters = ["main", "test", "utility"];
+
+            const body = [
+              marker,
+              `### 📄 Flux Diff Preview`,
+              ``,
+              `**[View the rendered diff ➔](${diffUrl})** for commit [\`${shortSha}\`](${commitUrl})`,
+              ``,
+              clusters.map(c => `- [${c} →](${diffUrl}/${c}/${issue_number}.html)`).join("\n"),
+              ``,
+              `> [!WARNING]`,
+              `> 🔥 This diff will
+ self destruct after merge.`,
+              ``,
+              `<sub>Rendered by [flate](https://github.com/home-operations/flate) · [Workflow run](${runUrl})</sub>`,
+            ].join("\n");
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number, per_page: 100,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+  prune:
+    if: ${{ github.event.action == 'closed' }}
+    name: Flate - Prune
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure 1Password
+        uses: 1password/load-secrets-action/configure@92467eb28f72e8255933372f1e0
+707c567ce2259 # v4.0.0
+        with:
+          connect-host: ${{ secrets.OP_CONNECT_HOST }}
+          connect-token: ${{ secrets.OP_CONNECT_TOKEN }}
+
+      - name: Load Secrets
+        id: load-secrets
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        env:
+          DUFS_PASSWORD: op://Kubernetes/dufs/DUFS_PASSWORD
+
+      - name: Delete diffs for closed PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          DUFS_PASSWORD: ${{ steps.load-secrets.outputs.DUFS_PASSWORD }}
+        with:
+          script: |
+            const pr = context.issue.number;
+            const clusters = ["main", "test", "utility"];
+            const auth = "Basic " + Buffer.from(`${process.env.DUFS_USERNAME}:${process.env.DUFS_PASSWORD}`).toString("base64");
+
+            for (const cluster of clusters) {
+              const url = `https://${process.env.DUFS_DOMAIN}/flate/${cluster}/${pr}.html`;
+              const res = await fetch(url, { method: "DELETE", headers: { Authorization: auth } });
+              if (res.ok) core.info(`Deleted ${url}`);
+              else if (res.status === 404) core.info(`No diff for PR #${pr} (${cluster}) — nothing to delete.`);
+              else core.setFailed(`DELETE ${url} returned HTTP ${res.status}`);
+            }
+
   success:
     if: ${{ !cancelled() }}
-    needs: flate
+    needs:
+      - flate
+      - flatten-diff
+      - comment
+      - prune
     name: Flate - Success
     runs-on: ubuntu-latest
     steps:
@@ -65,4 +248,6 @@ jobs:
 
       - name: All jobs passed or skipped?
         if: ${{ !(contains(needs.*.result, 'failure')) }}
-        run: echo "All jobs passed or skipped" && echo "${{ toJSON(needs.*.result) }}"
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: echo "All jobs passed or skipped" && echo "$RESULTS"

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -183,8 +183,7 @@ jobs:
               clusters.map(c => `- [${c} →](${diffUrl}/${c}/${issue_number}.html)`).join("\n"),
               ``,
               `> [!WARNING]`,
-              `> 🔥 This diff will
- self destruct after merge.`,
+              `> 🔥 This diff will self destruct after merge.`,
               ``,
               `<sub>Rendered by [flate](https://github.com/home-operations/flate) · [Workflow run](${runUrl})</sub>`,
             ].join("\n");
@@ -206,8 +205,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure 1Password
-        uses: 1password/load-secrets-action/configure@92467eb28f72e8255933372f1e0
-707c567ce2259 # v4.0.0
+        uses: 1password/load-secrets-action/configure@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -104,18 +104,11 @@ jobs:
             echo "clusters=" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Configure 1Password
-        if: ${{ steps.check.outputs.diff == 'true' }}
-        uses: 1password/load-secrets-action/configure@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
-        with:
-          connect-host: ${{ secrets.OP_CONNECT_HOST }}
-          connect-token: ${{ secrets.OP_CONNECT_TOKEN }}
-
       - name: Load Secrets
-        if: ${{ steps.check.outputs.diff == 'true' }}
         id: load-secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
         env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           DUFS_PASSWORD: op://Kubernetes/dufs/FLATE_PASSWORD
 
       - name: Upload diffs to dufs

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -67,6 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       diff: ${{ steps.check.outputs.diff }}
+      clusters: ${{ steps.check.outputs.clusters }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -82,19 +83,26 @@ jobs:
       - name: Run flate diff per cluster
         run: |
           for cluster in main test utility; do
-            flate diff all -p ./kubernetes/clusters/$cluster -o html > $cluster.html || true
+            flate diff all -p ./kubernetes/clusters/$cluster -o html > "$cluster.html"
           done
 
       - name: Check if any diffs exist
         id: check
         run: |
+          clusters=()
           for cluster in main test utility; do
-            if [ -s $cluster.html ]; then
-              echo "diff=true" >> "$GITHUB_OUTPUT"
-              exit 0
+            if [ -s "$cluster.html" ]; then
+              clusters+=("$cluster")
             fi
           done
-          echo "diff=false" >> "$GITHUB_OUTPUT"
+
+          if [ "${#clusters[@]}" -gt 0 ]; then
+            echo "diff=true" >> "$GITHUB_OUTPUT"
+            printf 'clusters=%s\n' "$(IFS=,; echo "${clusters[*]}")" >> "$GITHUB_OUTPUT"
+          else
+            echo "diff=false" >> "$GITHUB_OUTPUT"
+            echo "clusters=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Configure 1Password
         if: ${{ steps.check.outputs.diff == 'true' }}
@@ -108,7 +116,7 @@ jobs:
         id: load-secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
         env:
-          DUFS_PASSWORD: op://Kubernetes/dufs/DUFS_PASSWORD
+          DUFS_PASSWORD: op://Kubernetes/dufs/FLATE_PASSWORD
 
       - name: Upload diffs to dufs
         if: ${{ steps.check.outputs.diff == 'true' }}
@@ -161,6 +169,8 @@ jobs:
 
       - name: Add or Update Comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PREVIEW_CLUSTERS: ${{ needs.flatten-diff.outputs.clusters }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -172,7 +182,7 @@ jobs:
             const commitUrl = `${context.serverUrl}/${owner}/${repo}/commit/${sha}`;
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
             const diffUrl = `https://${process.env.DUFS_DOMAIN}/flate`;
-            const clusters = ["main", "test", "utility"];
+            const clusters = (process.env.PREVIEW_CLUSTERS || "").split(",").filter(Boolean);
 
             const body = [
               marker,
@@ -204,17 +214,12 @@ jobs:
     name: Flate - Prune
     runs-on: ubuntu-latest
     steps:
-      - name: Configure 1Password
-        uses: 1password/load-secrets-action/configure@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
-        with:
-          connect-host: ${{ secrets.OP_CONNECT_HOST }}
-          connect-token: ${{ secrets.OP_CONNECT_TOKEN }}
-
       - name: Load Secrets
         id: load-secrets
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
         env:
-          DUFS_PASSWORD: op://Kubernetes/dufs/DUFS_PASSWORD
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          DUFS_PASSWORD: op://Kubernetes/dufs/FLATE_PASSWORD
 
       - name: Delete diffs for closed PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Install Flate
         uses: home-operations/flate/action@39f44bd8bc9f11ba5321cecbdfc04398a568f4d0 # v0.3.3
+        with:
+          cache: true
 
       - name: Run Flate
         env:
@@ -74,6 +76,8 @@ jobs:
 
       - name: Install Flate
         uses: home-operations/flate/action@39f44bd8bc9f11ba5321cecbdfc04398a568f4d0 # v0.3.3
+        with:
+          cache: true
 
       - name: Run flate diff per cluster
         run: |

--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -345,7 +345,7 @@ tasks:
             && echo true || echo false
       MACHINE_TYPE:
         sh: basename "$(find "${TALOS_DIR}" -name "${NODE}.yaml" -exec dirname {} \;)"
-      SCHEMATIC_FILE: "{{.TALOS_DIR}}/{{.MACHINE_TYPE}}/{{if eq .EGPU_EFFECTIVE \"true\"}}eGPU-schematic.yaml{{else}}schematic.yaml{{end}}"
+      SCHEMATIC_FILE: '{{.TALOS_DIR}}/{{.MACHINE_TYPE}}/{{if eq .EGPU_EFFECTIVE "true"}}eGPU-schematic.yaml{{else}}schematic.yaml{{end}}'
     requires:
       vars: [CLUSTER, NODE]
     preconditions:

--- a/kubernetes/apps/base/self-hosted/dufs/externalsecret.yaml
+++ b/kubernetes/apps/base/self-hosted/dufs/externalsecret.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dufs
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: dufs
+  dataFrom:
+    - extract:
+        key: Kubernetes/dufs

--- a/kubernetes/apps/base/self-hosted/dufs/externalsecret.yaml
+++ b/kubernetes/apps/base/self-hosted/dufs/externalsecret.yaml
@@ -3,14 +3,16 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: dufs
+  name: &name dufs
 spec:
-  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword
   target:
-    name: dufs
+    name: *name
+    template:
+      data:
+        DUFS_AUTH: admin:{{ .ADMIN_PASSWORD }}@/:rw|flate:{{ .FLATE_PASSWORD }}@/flate:rw|@/flate
   dataFrom:
     - extract:
-        key: Kubernetes/dufs
+        key: dufs

--- a/kubernetes/apps/base/self-hosted/dufs/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/dufs/helmrelease.yaml
@@ -25,28 +25,59 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/sigoden/dufs
-              tag: v0.46.0
-            command: ["/bin/sh", "-c"]
-            args: ["dufs /data -a flate:${DUFS_PASSWORD}@/:rw -b 0.0.0.0:8000"]
+              repository: mirror.gcr.io/sigoden/dufs
+              tag: v0.46.0@sha256:8dd3b750015734703e64b55641fb7d2254c112e0ff3967074766177dc15dc982
+            args:
+              - /config
+              - --allow-upload
+              - --allow-delete
+              - --allow-hash
+            env:
+              DUFS_PORT: &port 80
+              TZ: America/Edmonton
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}"
             probes:
               liveness:
                 enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
               readiness:
                 enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /__dufs__/health
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
             resources:
               requests:
                 cpu: 10m
-                memory: 64Mi
               limits:
                 memory: 256Mi
     persistence:
       data:
         type: emptyDir
-
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.jory.dev"]
+        parentRefs:
+          - name: envoy-external
+            namespace: network
     service:
       app:
         ports:

--- a/kubernetes/apps/base/self-hosted/dufs/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/dufs/helmrelease.yaml
@@ -70,7 +70,7 @@ spec:
               limits:
                 memory: 256Mi
     persistence:
-      data:
+      config:
         type: emptyDir
     route:
       app:
@@ -82,4 +82,4 @@ spec:
       app:
         ports:
           http:
-            port: 8000
+            port: *port

--- a/kubernetes/apps/base/self-hosted/dufs/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/dufs/helmrelease.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dufs
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 15m
+  dependsOn: []
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 100
+        fsGroup: 100
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      dufs:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/sigoden/dufs
+              tag: v0.46.0
+            command: ["/bin/sh", "-c"]
+            args: ["dufs /data -a flate:${DUFS_PASSWORD}@/:rw -b 0.0.0.0:8000"]
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}"
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+    persistence:
+      data:
+        type: emptyDir
+
+    service:
+      app:
+        ports:
+          http:
+            port: 8000

--- a/kubernetes/apps/base/self-hosted/dufs/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/dufs/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/main/self-hosted/dufs.yaml
+++ b/kubernetes/apps/main/self-hosted/dufs.yaml
@@ -7,10 +7,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/dufs
-  postBuild:
-    substitute:
-      APP: *app
-      CLUSTER: ${CLUSTER}
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/main/self-hosted/dufs.yaml
+++ b/kubernetes/apps/main/self-hosted/dufs.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dufs
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/self-hosted/dufs
+  postBuild:
+    substitute:
+      APP: *app
+      CLUSTER: ${CLUSTER}
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/main/self-hosted/kustomization.yaml
+++ b/kubernetes/apps/main/self-hosted/kustomization.yaml
@@ -10,6 +10,7 @@ replacements:
 resources:
   - ./actual.yaml
   - ./archiveteam.yaml
+  - ./dufs.yaml
   - ./atuin.yaml
   - ./bentopdf.yaml
   - ./manyfold.yaml


### PR DESCRIPTION
## Summary
- add a multi-cluster `flate` diff workflow that renders HTML previews, uploads them to `dufs`, comments the preview links on PRs, and prunes them when the PR closes
- add a `dufs` app in `self-hosted` to host the rendered diff artifacts
- align the `dufs` chart wiring with the upstream pattern so `/config` is writable and the rendered Service, probes, and route all use the same port
- make the workflow fail on real `flate diff` errors and only advertise clusters that actually produced preview HTML

## Why
This adapts the upstream `onedr0p/home-ops` flate preview flow to this repo while preserving the existing `home-operations/flate/action` install step and the repo's multi-cluster layout.

The follow-up fix addresses two issues introduced during the adaptation:
- `dufs` was serving `/config` but the chart mounted the `emptyDir` at `/data`
- the rendered `dufs` Service and startup/liveness probes targeted `8000` while the container listened on `80`

## Impact
- PRs that touch `kubernetes/**/*` should get rendered diff previews for any cluster that produces a diff
- the preview comment will only list clusters with an uploaded HTML artifact
- the `dufs` workload should now be reachable and writable for diff uploads

## Validation
- `flate test ks --path ./kubernetes/clusters/main`
- rendered `dufs` manifests verified via `flate build hr --path ./kubernetes/clusters/main` to confirm `/config` is mounted and port `80` is used end to end