### PR TITLE
ci: upgrade pr-reviewer-action to v1.2.0 (routing + escalation)

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Analyze PR with reusable AI reviewer
         id: analyze
-        uses: misospace/pr-reviewer-action@87d01c854d1b385a214ae7d9ede15a077164183f # v1.2.1
+        uses: misospace/pr-reviewer-action@e891235e8e3e75824b88fb696b1f7b4816122737 # v1.2.2
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: "3"

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -37,19 +37,25 @@ jobs:
 
       - name: Analyze PR with reusable AI reviewer
         id: analyze
-        uses: misospace/pr-reviewer-action@ff03870002ecee692bfcfe9ad6e5dd1cb36f3ddd # v1.2.0
+        uses: misospace/pr-reviewer-action@87d01c854d1b385a214ae7d9ede15a077164183f # v1.2.1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
-          ai_primary_retries: "8"
+          ai_primary_retries: "3"
           ai_primary_retry_delay_sec: "15"
           ai_base_url: ${{ vars.LITELLM_URL }}
           ai_api_format: ${{ vars.PRIMARY_FORMAT }}
           ai_model: ${{ vars.PRIMARY_MODEL }}
           ai_api_key: ${{ secrets.LITELLM_API_KEY }}
+          ai_response_format: json_object
           ai_fallback_base_url: ${{ vars.LITELLM_URL }}
           ai_fallback_api_format: ${{ vars.FALLBACK_FORMAT }}
           ai_fallback_model: ${{ vars.FALLBACK_MODEL }}
           ai_fallback_api_key: ${{ secrets.LITELLM_API_KEY }}
+          review_routing_mode: auto
+          ai_smart_base_url: ${{ vars.LITELLM_URL }}
+          ai_smart_api_format: ${{ vars.SMART_FORMAT || vars.FALLBACK_FORMAT }}
+          ai_smart_model: ${{ vars.SMART_MODEL || vars.FALLBACK_MODEL }}
+          ai_smart_api_key: ${{ secrets.LITELLM_API_KEY }}
           allowed_source_hosts: "github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io,minecraft.net,www.minecraft.net,talos.dev,www.talos.dev"
           context_limit_mode: normal
           tool_mode: plan_execute_once
@@ -63,4 +69,6 @@ jobs:
           tool_enable_for_forks: "false"
           system_prompt_file: .agents/instructions/pr-review.instructions.md
           standards_file_candidates: "AGENTS.md"
+          on_model_failure: notice
+          inline_findings: "true"
           publish_mode: review_comment


### PR DESCRIPTION
Upgrades the AI PR review workflow to [pr-reviewer-action v1.2.0](https://github.com/misospace/pr-reviewer-action/releases/tag/v1.2.0) and adopts the new routing/reliability features.

Repo character: Flux/k8s manifests, renovate-heavy — routing is the big win here: the steady stream of renovate bumps classifies low-risk and stays on the fast model, while secret/SOPS/cluster-config changes escalate to the smart model. (Also fixes the stale `# v1.1.1` pin comment.)

## What changed and why

- **Pin bumped** to the v1.2.0 release SHA (`ff03870`). Feature-heavy release: model routing + escalation, structured findings, required-check validation, incremental-review and CI-wait fixes, large context/perf work. All backward-compatible.
- **`review_routing_mode: auto`** — PRs are classified deterministically; low-risk ones (e.g. routine dependency bumps) go to the fast model, risk-flagged ones (auth, secrets, migrations, public routes, linked security issues) go straight to the smart model. Fast stays your current `PRIMARY_MODEL`. Smart is wired as `vars.SMART_MODEL || vars.FALLBACK_MODEL` — **no new vars are required**; it uses your fallback model until you optionally add a `SMART_MODEL` (and `SMART_FORMAT` if it differs) repo variable pointing at a bigger model.
- **Escalation (on by default with routing)** — if the fast review looks insufficient (request_changes, unaddressed required checks, suspiciously short/unsure review, blocker signals), the review automatically re-runs on the smart model and only that result is published.
- **`on_model_failure: notice` + retries 8 → 3** — when the homelab endpoint is down, instead of hammering it (~8 attempts with backoff) and leaving a red check with no explanation, the action now tries 3 times, then posts a visible "review could not run" notice as request_changes. Faster feedback, never silently approves.
- **`inline_findings: "true"`** — findings that anchor to a diff line are posted as native line-anchored review comments (capped at 20) instead of only prose in the review body.

## Now-active defaults worth knowing (no config needed)

- `review_scope: auto` — full review first, then incremental reviews of just the new commits on later pushes. Significant token savings on long-lived PRs.
- `validate_required_checks: auto` (mode `warn`) — risky PRs get classifier-derived required checks; reviews that never address them get a visible "Unaddressed required checks" section.

## Choices for you (left out on purpose — flag if you want any)

1. **`SMART_MODEL` repo variable** — add it to route risky PRs/escalations to a stronger model than your current fallback. Without it, smart = `FALLBACK_MODEL`.
2. **`model_context_tokens`** — if the models behind your LiteLLM endpoint have small context windows (8k–32k local models), set this to the real window and the action right-sizes the corpus instead of using the coarse `context_limit_mode: normal` (~55–70k tokens). I don't know your per-model windows, so I didn't guess.
3. **`ai_response_format: json_object`** — helps small local models emit parseable JSON, but errors on backends that don't support it; only enable if you know the models behind LiteLLM accept it.
4. **`ci_status_check: "true"`** — waits (up to 5 min) for CI before reviewing so the review can see CI state. Adds latency to every review; worth it only if you want the reviewer gating on test results.
5. **`required_check_validation_mode: fail`** — make unaddressed required checks block instead of warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
