### PR TITLE
Harden konflate cluster refresh

### DIFF
--- a/.github/workflows/konflate.yaml
+++ b/.github/workflows/konflate.yaml
@@ -4,7 +4,7 @@ name: Konflate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: ["main"]
 
 concurrency:
@@ -29,27 +29,34 @@ jobs:
         with:
           script: |
             const clusters = ["main", "test", "utility"];
+            const labels = context.payload.pull_request.labels?.map((label) => label.name) ?? [];
             const files = await github.paginate(github.rest.pulls.listFiles, {
               ...context.repo,
               pull_number: context.payload.pull_request.number,
               per_page: 100,
             });
 
-            const selected = new Set();
+            const selected = new Set(
+              labels
+                .map((label) => label.match(/^cluster\/(main|test|utility)$/)?.[1])
+                .filter(Boolean)
+            );
             let shared = false;
 
-            for (const { filename } of files) {
-              const match = filename.match(/^kubernetes\/(?:apps|clusters)\/(main|test|utility)(?:\/|$)/);
-              if (match) {
-                selected.add(match[1]);
-                continue;
-              }
+            if (selected.size === 0) {
+              for (const { filename } of files) {
+                const match = filename.match(/^kubernetes\/(?:apps|clusters)\/(main|test|utility)(?:\/|$)/);
+                if (match) {
+                  selected.add(match[1]);
+                  continue;
+                }
 
-              if (
-                filename.startsWith("kubernetes/apps/base/") ||
-                filename.startsWith("kubernetes/components/")
-              ) {
-                shared = true;
+                if (
+                  filename.startsWith("kubernetes/apps/base/") ||
+                  filename.startsWith("kubernetes/components/")
+                ) {
+                  shared = true;
+                }
               }
             }
 
@@ -64,6 +71,7 @@ jobs:
         id: fetch
         env:
           KONFLATE_CLUSTERS: ${{ steps.clusters.outputs.clusters }}
+          KONFLATE_WEBHOOK_SECRET: ${{ secrets.KONFLATE_WEBHOOK_SECRET }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           ready=false
@@ -81,7 +89,15 @@ jobs:
               main) host="konflate.${KONFLATE_DOMAIN}" ;;
               *) host="konflate-${cluster}.${KONFLATE_DOMAIN}" ;;
             esac
+            refresh_url="https://${host}/api/prs/${PR}/refresh"
             url="https://${host}/api/prs/${PR}/summary"
+
+            if ! curl -fsS -o /dev/null \
+              -X POST \
+              -H "Authorization: Bearer ${KONFLATE_WEBHOOK_SECRET}" \
+              "${refresh_url}" 2>/dev/null; then
+              echo "::notice::konflate refresh unavailable for ${cluster}; polling existing state."
+            fi
 
             if status="$(curl -fsS --retry 10 --retry-delay 3 --retry-all-errors \
                  -H 'Accept: text/markdown' \
@@ -97,7 +113,7 @@ jobs:
                 cat "${summary}"
               } >> summary.md
             else
-              echo "konflate summary unavailable or empty for ${cluster} - skipping; next push retries."
+              echo "::notice::konflate summary unavailable or empty for ${cluster}; skipping."
             fi
           done
 

--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -24,20 +24,6 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Configure 1password
-        uses: 1password/load-secrets-action/configure@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
-        with:
-          service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-
-      - name: Get Secrets
-        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
-        with:
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          CLOUDFLARE_API_TOKEN: op://Kubernetes/cloudflare/CLOUDFLARE_API_TOKEN_GHA
-          CLOUDFLARE_ACCOUNT_ID: op://Kubernetes/cloudflare/CLOUDFLARE_ACCOUNT_TAG
-
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -70,7 +56,7 @@ jobs:
       - name: Publish Schemas
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
-          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: /home/runner/.datree/crdSchemas
           command: pages deploy --project-name=kube-schemas --branch main .

--- a/.github/workflows/terraform-diff.yaml
+++ b/.github/workflows/terraform-diff.yaml
@@ -66,20 +66,6 @@ jobs:
         with:
           tofu_wrapper: false
 
-      - name: Install 1Password CLI
-        uses: 1password/install-cli-action@8d006a0d0a4fd505af7f7ce589e7f768385ff5e4 # v3.0.0
-
-      - name: Load Secrets
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-        run: |
-          ACCESS_KEY=$(op read 'op://Kubernetes/garage/TERRAFORM_STATE_KEY_ID')
-          SECRET_KEY=$(op read 'op://Kubernetes/garage/TERRAFORM_STATE_SECRET_KEY')
-          echo "::add-mask::$ACCESS_KEY"
-          echo "::add-mask::$SECRET_KEY"
-          echo "AWS_ACCESS_KEY_ID=$ACCESS_KEY" >> "$GITHUB_ENV"
-          echo "AWS_SECRET_ACCESS_KEY=$SECRET_KEY" >> "$GITHUB_ENV"
-
       - name: Tofu fmt
         id: fmt
         working-directory: ${{ matrix.paths }}
@@ -89,6 +75,9 @@ jobs:
       - name: Tofu Init
         id: init
         working-directory: ${{ matrix.paths }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TERRAFORM_STATE_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_SECRET_KEY }}
         run: |
           tofu init \
             -backend-config="access_key=$AWS_ACCESS_KEY_ID" \

--- a/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml
+++ b/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml
@@ -26,13 +26,16 @@ spec:
   dependsOn: []
   values:
     config:
-      repo: github://joryirving/home-ops
       clusterPath: ./kubernetes/clusters/${CLUSTER}
+      prFilterExpr: pr.labels.exists(l, l.name == "cluster/${CLUSTER}")
+      repo: github://joryirving/home-ops
     persistence:
       enabled: true
       size: 5Gi
     secret:
       existingSecret: konflate
+    podAnnotations:
+      reloader.stakater.com/auto: "true"
     httpRoute:
       enabled: true
       annotations:


### PR DESCRIPTION
## Summary

- prefer `cluster/*` PR labels when deciding which Konflate summaries to fetch, with path detection kept as fallback
- configure Konflate instances to filter PRs by their cluster label
- refresh selected Konflate PR state before fetching summaries as a best-effort step, using `KONFLATE_WEBHOOK_SECRET`
- skip unavailable per-cluster summaries gracefully while still failing on rendered Konflate `failures` or `error` statuses
- remove runtime 1Password reads from workflows and use GitHub Actions secrets for stable CI credentials

## Secrets

Set these GitHub Actions secrets from the existing 1Password values:

- `KONFLATE_WEBHOOK_SECRET`
- `CLOUDFLARE_API_TOKEN`
- `CLOUDFLARE_ACCOUNT_ID`
- `TERRAFORM_STATE_KEY_ID`
- `TERRAFORM_STATE_SECRET_KEY`

Updated all three Konflate GitHub webhooks with the current `op://Kubernetes/konflate/KONFLATE_WEBHOOK_SECRET`. Validated `main` and `utility` webhook pings return `202 OK`; `test` was updated but not validated.

## Validation

- parsed every `.github/workflows/*.yaml` / `.github/workflows/*.yml` with `yq eval`
- `git diff --check`
- confirmed workflows no longer reference `op://`, `1password/load-secrets-action`, or `1password/install-cli-action`
- confirmed the new GitHub Actions secrets exist with fresh update timestamps

`actionlint` is not installed locally, so I could not run it.
