### PR TITLE
feat(llm): switch openclaw and hermes memory to memini

### DIFF
--- a/kubernetes/apps/base/llm/hermes/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/hermes/helmrelease.yaml
@@ -39,8 +39,13 @@ spec:
               tag: v2026.6.5@sha256:9ad3b04ec916ea2c2da22358fd43b024c788d74073210695af88bfc2e63869b4
             args: ["gateway", "run", "--no-supervise"]
             env:
-              AGENTMEMORY_PROJECT: hermes
-              AGENTMEMORY_URL: http://agentmemory.llm:3111
+              MEMINI_URL: http://memini.llm:8080
+              MEMINI_NAMESPACE: sake
+              MEMINI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: memini
+                    key: api-key
               HERMES_HOME: /opt/data
               HOME: /opt/data
               TZ: America/Edmonton
@@ -146,12 +151,12 @@ spec:
         globalMounts:
           - path: /tmp/config.yaml
             subPath: config.yaml
-      agentmemory-plugin:
+      memini-plugin:
         type: configMap
-        name: hermes-agentmemory-plugin
+        name: hermes-memini-plugin
         defaultMode: 0755
         globalMounts:
-          - path: /opt/data/plugins/agentmemory
+          - path: /opt/data/plugins/memini
       gallery:
         type: nfs
         server: voyager.internal

--- a/kubernetes/apps/base/llm/hermes/kustomization.yaml
+++ b/kubernetes/apps/base/llm/hermes/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./agentmemory-plugin.yaml
+  - ./memini-plugin.yaml
   - ./configmap.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/base/llm/hermes/memini-plugin.yaml
+++ b/kubernetes/apps/base/llm/hermes/memini-plugin.yaml
@@ -1,0 +1,281 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-memini-plugin
+data:
+  # vendored from eleboucher/memini v0.0.5 integrations/hermes/plugin/memini/
+  plugin.yaml: |
+    name: memini
+    version: 0.1.0
+    description: "Persistent cross-session memory for Hermes Agent via memini. Native MemoryProvider — no MCP server required."
+    homepage: "https://github.com/eleboucher/memini"
+    # Memory providers are single-select; only one may be active at a time.
+    hooks:
+      - prefetch
+      - sync_turn
+      - on_pre_compress
+      - on_memory_write
+  __init__.py: |
+    """memini memory provider for Hermes Agent.
+
+    Native MemoryProvider: Hermes drives it directly, no MCP server.
+
+        prefetch         recall relevant memories before each turn
+        sync_turn        capture each exchange (episodic)
+        on_pre_compress  re-inject recalled context before compaction
+        on_memory_write  mirror MEMORY.md/USER.md edits into memini (semantic)
+        tools            memory_recall / memory_remember
+
+    Install: copy this directory to ~/.hermes/plugins/memini and add `memini` to
+    `plugins.enabled` in ~/.hermes/config.yaml.
+
+    Environment:
+        MEMINI_URL            base URL (default http://localhost:8080)
+        MEMINI_NAMESPACE      tenant to scope memory to (default: cwd basename, else "hermes")
+        MEMINI_API_KEY        bearer token, if memini requires auth
+        MEMINI_REQUIRE_HTTPS  =1 to refuse sending a token over plaintext HTTP
+
+    Network errors are swallowed.
+    """
+
+    from __future__ import annotations
+
+    import json
+    import os
+    import sys
+    import threading
+    from pathlib import Path
+    from typing import Any, Callable
+    from urllib.error import URLError
+    from urllib.parse import urlparse
+    from urllib.request import Request, urlopen
+
+    try:
+        from agent.memory_provider import MemoryProvider
+    except ImportError:  # allow import/testing outside a Hermes install
+        from abc import ABC, abstractmethod
+
+        class MemoryProvider(ABC):
+            @property
+            @abstractmethod
+            def name(self) -> str: ...
+            @abstractmethod
+            def is_available(self) -> bool: ...
+            @abstractmethod
+            def initialize(self, session_id: str, **kwargs: Any) -> None: ...
+            @abstractmethod
+            def get_tool_schemas(self) -> list[dict]: ...
+            @abstractmethod
+            def handle_tool_call(self, name: str, args: dict) -> str: ...
+            def get_config_schema(self) -> list[dict]: return []
+            def save_config(self, values: dict, hermes_home: str) -> None: pass
+            def prefetch(self, query: str, **kwargs: Any) -> str: return ""
+            def sync_turn(self, user: str, assistant: str, **kwargs: Any) -> None: pass
+            def on_pre_compress(self, messages: list, **kwargs: Any) -> None: pass
+            def on_memory_write(self, action: str, target: str, content: str, **kwargs: Any) -> None: pass
+
+
+    DEFAULT_BASE_URL = "http://localhost:8080"
+    TIMEOUT = 5
+    LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
+    VALID_TIERS = ("working", "episodic", "semantic", "procedural")
+    _plaintext_bearer_warned = False
+
+
+    def _env(name: str, default: str = "") -> str:
+        return os.environ.get(name, default).strip()
+
+
+    def _uses_plaintext_bearer_auth(base: str, secret: str) -> bool:
+        if not secret:
+            return False
+        parsed = urlparse(base)
+        host = (parsed.hostname or "").lower()
+        return parsed.scheme == "http" and host not in LOOPBACK_HOSTS
+
+
+    def _check_plaintext_bearer_guard(base: str, secret: str, warn: Callable[[str], None] | None = None) -> None:
+        global _plaintext_bearer_warned
+        if not _uses_plaintext_bearer_auth(base, secret):
+            return
+        msg = (
+            f"memini: MEMINI_API_KEY is configured for plaintext HTTP to {base}. "
+            "Bearer tokens and memory payloads can be observed on the network; "
+            "use HTTPS or an SSH tunnel."
+        )
+        if _env("MEMINI_REQUIRE_HTTPS") == "1":
+            raise RuntimeError(msg)
+        if not _plaintext_bearer_warned:
+            _plaintext_bearer_warned = True
+            (warn or (lambda m: print(m, file=sys.stderr)))(msg)
+
+
+    def _valid_url(base: str) -> bool:
+        try:
+            parsed = urlparse(base)
+            _ = parsed.port
+        except ValueError:
+            return False
+        return parsed.scheme in ("http", "https") and bool(parsed.hostname)
+
+
+    def _api(base: str, path: str, body: dict | None, namespace: str, secret: str,
+             method: str = "POST") -> dict | None:
+        if not _valid_url(base):
+            return None
+        headers = {"Content-Type": "application/json", "X-Memini-Namespace": namespace}
+        _check_plaintext_bearer_guard(base, secret)
+        if secret:
+            headers["Authorization"] = f"Bearer {secret}"
+        data = json.dumps(body).encode() if body is not None else None
+        req = Request(f"{base}{path}", data=data, headers=headers, method=method)
+        try:
+            with urlopen(req, timeout=TIMEOUT) as resp:
+                raw = resp.read()
+                return json.loads(raw) if raw else {}
+        except (URLError, TimeoutError, ValueError):
+            return None
+
+
+    class MeminiMemoryProvider(MemoryProvider):
+        """Cross-session memory backed by a memini service."""
+
+        @property
+        def name(self) -> str:
+            return "memini"
+
+        def is_available(self) -> bool:
+            return _valid_url(_env("MEMINI_URL", DEFAULT_BASE_URL))
+
+        def initialize(self, session_id: str, **kwargs: Any) -> None:
+            self._base = _env("MEMINI_URL", DEFAULT_BASE_URL).rstrip("/")
+            self._secret = _env("MEMINI_API_KEY")
+            self._session_id = session_id
+            cwd = kwargs.get("cwd") or os.getcwd()
+            self._namespace = _env("MEMINI_NAMESPACE") or os.path.basename(cwd.rstrip("/")) or "hermes"
+            if _env("MEMINI_REQUIRE_HTTPS") == "1":
+                _check_plaintext_bearer_guard(self._base, self._secret)
+
+        def _call(self, path: str, body: dict | None, method: str = "POST") -> dict | None:
+            return _api(self._base, path, body, self._namespace, self._secret, method)
+
+        def _call_bg(self, path: str, body: dict) -> None:
+            threading.Thread(target=self._call, args=(path, body), daemon=True).start()
+
+        def get_config_schema(self) -> list[dict]:
+            return [
+                {"key": "url", "description": "memini server URL",
+                 "default": DEFAULT_BASE_URL, "env_var": "MEMINI_URL"},
+                {"key": "namespace", "description": "memory namespace (tenant)",
+                 "required": False, "env_var": "MEMINI_NAMESPACE"},
+                {"key": "secret", "description": "memini bearer token (optional)",
+                 "secret": True, "required": False, "env_var": "MEMINI_API_KEY"},
+            ]
+
+        def save_config(self, values: dict, hermes_home: str) -> None:
+            (Path(hermes_home) / "memini.json").write_text(json.dumps(values, indent=2))
+
+        def _format(self, result: dict | None, limit: int) -> str:
+            if not result:
+                return ""
+            lines = []
+            for r in (result.get("results") or [])[:limit]:
+                mem = r.get("memory") or {}
+                text = (mem.get("summary") or mem.get("content") or "").strip()
+                if text:
+                    lines.append(f"- {text[:300]}")
+            return "\n".join(lines)
+
+        def prefetch(self, query: str, **kwargs: Any) -> str:
+            if not query.strip():
+                return ""
+            block = self._format(self._call("/v1/search", {"query": query, "limit": 5}), 5)
+            return f"Relevant memories (from memini):\n{block}" if block else ""
+
+        def on_pre_compress(self, messages: list, **kwargs: Any) -> None:
+            query = ""
+            for m in reversed(messages):
+                if isinstance(m, dict) and m.get("role") == "user" and isinstance(m.get("content"), str):
+                    query = m["content"]
+                    break
+            block = self._format(self._call("/v1/search", {"query": query, "limit": 5}), 5) if query else ""
+            if block:
+                messages.insert(0, {"role": "user",
+                                    "content": f"[memini context before compaction]\n{block}"})
+
+        def sync_turn(self, user: str, assistant: str, **kwargs: Any) -> None:
+            user, assistant = (user or "").strip(), (assistant or "").strip()
+            if not user and not assistant:
+                return
+            self._call_bg("/v1/memories", {
+                "content": f"User: {user}\nAssistant: {assistant}"[:4000],
+                "tier": "episodic",
+                "metadata": {"source": "hermes", "session_id": kwargs.get("session_id", self._session_id)},
+            })
+
+        def on_memory_write(self, action: str, target: str, content: str, **kwargs: Any) -> None:
+            if action in ("add", "update") and content.strip():
+                self._call_bg("/v1/memories", {"content": content.strip()[:4000], "tier": "semantic"})
+
+        def get_tool_schemas(self) -> list[dict]:
+            return [
+                {
+                    "name": "memory_recall",
+                    "description": "Search long-term memory (memini) for relevant past facts and context.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string", "description": "What to search for"},
+                            "limit": {"type": "integer", "description": "Max results", "default": 5},
+                        },
+                        "required": ["query"],
+                    },
+                },
+                {
+                    "name": "memory_remember",
+                    "description": "Store a durable fact, decision, or preference in long-term memory (memini).",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "content": {"type": "string", "description": "The fact to remember"},
+                            "tier": {
+                                "type": "string",
+                                "enum": list(VALID_TIERS),
+                                "description": "semantic=durable knowledge, procedural=how-to, "
+                                               "episodic=what happened, working=transient",
+                                "default": "semantic",
+                            },
+                        },
+                        "required": ["content"],
+                    },
+                },
+            ]
+
+        def handle_tool_call(self, name: str, args: dict) -> str:
+            if name == "memory_recall":
+                limit = args.get("limit", 5)
+                result = self._call("/v1/search", {"query": args["query"], "limit": limit})
+                items = []
+                for r in (result or {}).get("results", []):
+                    mem = r.get("memory") or {}
+                    items.append({
+                        "content": mem.get("content", ""),
+                        "summary": mem.get("summary", ""),
+                        "tier": mem.get("tier", ""),
+                        "score": r.get("score", 0),
+                    })
+                return json.dumps({"results": items})
+
+            if name == "memory_remember":
+                tier = args.get("tier", "semantic")
+                if tier not in VALID_TIERS:
+                    tier = "semantic"
+                result = self._call("/v1/memories", {"content": args["content"], "tier": tier})
+                return json.dumps({"id": (result or {}).get("id"), "success": result is not None})
+
+            return json.dumps({"error": f"Unknown tool: {name}"})
+
+
+    def register(ctx: Any) -> None:
+        ctx.register_memory_provider(MeminiMemoryProvider())

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -355,9 +355,18 @@ data:
               project_prefix: "openclaw",
             },
           },
+          memini: {
+            enabled: true,
+            config: {
+              base_url: "http://memini.llm:8080",
+              namespace_per_agent: true,
+              fallback_on_error: true,
+              timeout_ms: 5000,
+            },
+          },
         },
         slots: {
-          memory: "agentmemory",
+          memory: "memini",
           contextEngine: "lossless-claw"
         },
       },

--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -47,6 +47,18 @@ spec:
                 chmod 400 /home/node/.openclaw/openclaw.json
                 chmod 500 /home/node/.openclaw/extensions/agentmemory
                 chmod 400 /home/node/.openclaw/extensions/agentmemory/*
+
+                mkdir -p /home/node/.openclaw/extensions/memini
+                chmod u+w /home/node/.openclaw/extensions/memini || true
+                rm -f /home/node/.openclaw/extensions/memini/openclaw.plugin.json
+                rm -f /home/node/.openclaw/extensions/memini/package.json
+                rm -f /home/node/.openclaw/extensions/memini/plugin.mjs
+                cp /tmp/memini-plugin/openclaw.plugin.json /home/node/.openclaw/extensions/memini/openclaw.plugin.json
+                cp /tmp/memini-plugin/package.json /home/node/.openclaw/extensions/memini/package.json
+                cp /tmp/memini-plugin/plugin.mjs /home/node/.openclaw/extensions/memini/plugin.mjs
+                chown -R 1000:100 /home/node/.openclaw/extensions/memini
+                chmod 500 /home/node/.openclaw/extensions/memini
+                chmod 400 /home/node/.openclaw/extensions/memini/*
         containers:
           app:
             image:
@@ -71,6 +83,11 @@ spec:
               PIP_BREAK_SYSTEM_PACKAGES: "1"
               TERM: xterm-256color
               TZ: &tz America/Edmonton
+              MEMINI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: memini
+                    key: api-key
             envFrom:
               - secretRef:
                   name: openclaw
@@ -147,6 +164,17 @@ spec:
           - path: /tmp/agentmemory-plugin/package.json
             subPath: package.json
           - path: /tmp/agentmemory-plugin/plugin.mjs
+            subPath: plugin.mjs
+      memini-plugin:
+        type: configMap
+        name: openclaw-memini-plugin
+        defaultMode: 0755
+        globalMounts:
+          - path: /tmp/memini-plugin/openclaw.plugin.json
+            subPath: openclaw.plugin.json
+          - path: /tmp/memini-plugin/package.json
+            subPath: package.json
+          - path: /tmp/memini-plugin/plugin.mjs
             subPath: plugin.mjs
     rbac:
       roles:

--- a/kubernetes/apps/base/llm/openclaw/app/kustomization.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./agentmemory-plugin.yaml
+  - ./memini-plugin.yaml
   - ./configmap.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/base/llm/openclaw/app/memini-plugin.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/memini-plugin.yaml
@@ -1,0 +1,290 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-memini-plugin
+data:
+  # vendored from eleboucher/memini v0.0.5 integrations/openclaw/plugin/
+  openclaw.plugin.json: |
+    {
+      "id": "memini",
+      "kind": "memory",
+      "name": "memini",
+      "description": "Persistent cross-session memory for OpenClaw via memini.",
+      "version": "0.1.0",
+      "configSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": { "type": "boolean" },
+          "base_url": { "type": "string" },
+          "namespace": { "type": "string" },
+          "namespace_per_agent": { "type": "boolean" },
+          "namespace_template": { "type": "string" },
+          "fallback_on_error": { "type": "boolean" },
+          "timeout_ms": { "type": "number" }
+        }
+      },
+      "uiHints": {
+        "enabled": { "label": "Enabled" },
+        "base_url": { "label": "Base URL", "help": "memini REST server base URL" },
+        "namespace": {
+          "label": "Namespace",
+          "help": "Tenant the memory is scoped to (X-Memini-Namespace)"
+        },
+        "namespace_per_agent": {
+          "label": "Per-Agent Namespaces",
+          "help": "Scope memory per agent instead of sharing one namespace"
+        },
+        "namespace_template": {
+          "label": "Namespace Template",
+          "help": "Per-agent namespace, e.g. \"{agent}\" or \"openclaw-{agent}\" ({namespace} also substituted)"
+        },
+        "fallback_on_error": { "label": "Fallback On Error" },
+        "timeout_ms": { "label": "Timeout (ms)" }
+      }
+    }
+  package.json: |
+    {
+      "name": "memini-openclaw",
+      "version": "0.1.0",
+      "type": "module",
+      "openclaw": {
+        "extensions": [
+          "./plugin.mjs"
+        ]
+      }
+    }
+  plugin.mjs: |
+    /**
+     * memini memory-slot plugin for OpenClaw.
+     *
+     * Claims plugins.slots.memory via api.registerMemoryCapability, plus:
+     *   - before_agent_start: recall relevant memories, prepend as context
+     *   - agent_end: capture the completed turn into memini
+     *
+     * Talks to memini over REST (/v1/search, /v1/memories), scoped by the
+     * X-Memini-Namespace header. Default endpoint http://localhost:8080.
+     */
+
+    const DEFAULT_BASE_URL = "http://localhost:8080";
+    const DEFAULT_TIMEOUT_MS = 5000;
+    const DEFAULT_NAMESPACE = "openclaw";
+    const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
+    const configSchema = {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        enabled: { type: "boolean" },
+        base_url: { type: "string" },
+        namespace: { type: "string" },
+        namespace_per_agent: { type: "boolean" },
+        namespace_template: { type: "string" },
+        fallback_on_error: { type: "boolean" },
+        timeout_ms: { type: "number" },
+      },
+    };
+
+    const DEFAULT_NAMESPACE_TEMPLATE = "{agent}";
+
+    // sanitizeNsSegment keeps a namespace segment header-safe (the server sanitizes
+    // too, but the X-Memini-Namespace value should be clean): alnum, dot, dash,
+    // underscore; collapse the rest to dashes and trim.
+    function sanitizeNsSegment(s) {
+      return String(s).trim().replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+    }
+
+    // agentIdentity pulls a stable per-agent id from an OpenClaw hook event,
+    // tolerating the field names different OpenClaw versions use. Returns "" when
+    // the event doesn't identify an agent.
+    function agentIdentity(event) {
+      if (!event || typeof event !== "object") return "";
+      const candidates = [
+        event.agentId,
+        event.agentName,
+        event.agent?.id,
+        event.agent?.name,
+        event.agent?.slug,
+        event.sessionId,
+        event.session?.id,
+        event.session?.agentId,
+      ];
+      for (const c of candidates) {
+        if (typeof c === "string" && c.trim()) return c.trim();
+      }
+      return "";
+    }
+
+    // effectiveNamespace returns the configured namespace, or a per-agent namespace
+    // when namespace_per_agent is enabled and the event identifies an agent. The
+    // per-agent name comes from namespace_template (default "{agent}"), with
+    // {agent} and {namespace} substituted — e.g. "{agent}" -> "miso",
+    // "openclaw-{agent}" -> "openclaw-miso". Falls back to the base namespace when
+    // no agent id is present, preserving the shared-memory behavior.
+    export function effectiveNamespace(cfg, event) {
+      if (!cfg.namespace_per_agent) return cfg.namespace;
+      const id = sanitizeNsSegment(agentIdentity(event));
+      if (!id) return cfg.namespace;
+      const tmpl = cfg.namespace_template || DEFAULT_NAMESPACE_TEMPLATE;
+      return tmpl.replaceAll("{agent}", id).replaceAll("{namespace}", cfg.namespace);
+    }
+
+    function extractText(content) {
+      if (typeof content === "string") return content;
+      if (!Array.isArray(content)) return "";
+      return content
+        .flatMap((block) => {
+          if (!block || typeof block !== "object") return [];
+          if (block.type === "text" && typeof block.text === "string") return [block.text];
+          return [];
+        })
+        .join("\n")
+        .trim();
+    }
+
+    function lastTextByRole(messages, role) {
+      for (const message of [...messages].reverse()) {
+        if (!message || typeof message !== "object" || message.role !== role) continue;
+        const text = extractText(message.content);
+        if (text) return text;
+      }
+      return "";
+    }
+
+    function formatResults(results) {
+      if (!Array.isArray(results) || results.length === 0) return "";
+      return results
+        .slice(0, 5)
+        .map((result, index) => {
+          const mem = result?.memory ?? {};
+          const text = (mem.summary || mem.content || `Memory $${index + 1}`).trim();
+          const tier = (mem.tier || "memory").trim();
+          return `- ($${tier}) $${text.slice(0, 300)}`;
+        })
+        .filter(Boolean)
+        .join("\n");
+    }
+
+    function normalizedHostname(hostname) {
+      return hostname.replace(/^\[|\]$/g, "").toLowerCase();
+    }
+
+    function usesPlaintextBearerAuth(baseUrl, secret) {
+      if (!secret) return false;
+      try {
+        const parsed = new URL(baseUrl);
+        return parsed.protocol === "http:" && !LOOPBACK_HOSTS.has(normalizedHostname(parsed.hostname));
+      } catch {
+        return false;
+      }
+    }
+
+    function plaintextBearerAuthMessage(baseUrl) {
+      return `memini: MEMINI_API_KEY is configured for plaintext HTTP to $${baseUrl}. Bearer tokens and memory payloads can be observed on the network; use HTTPS or an SSH tunnel.`;
+    }
+
+    export function createPlaintextBearerAuthGuard(warn, env) {
+      let warned = false;
+      return function guardPlaintextBearerAuth(baseUrl, secret) {
+        if (!usesPlaintextBearerAuth(baseUrl, secret)) return;
+        const message = plaintextBearerAuthMessage(baseUrl);
+        if ((env || process.env).MEMINI_REQUIRE_HTTPS === "1") throw new Error(message);
+        if (!warned) {
+          warned = true;
+          warn(message);
+        }
+      };
+    }
+
+    function createClient(cfg, api) {
+      const baseUrl = String(cfg.base_url || DEFAULT_BASE_URL).replace(/\/+$/, "");
+      const namespace = String(cfg.namespace || DEFAULT_NAMESPACE);
+      const timeoutMs = Number(cfg.timeout_ms || DEFAULT_TIMEOUT_MS);
+      const fallbackOnError = cfg.fallback_on_error !== false;
+      const secret = process.env.MEMINI_API_KEY;
+      const guardPlaintextBearerAuth = createPlaintextBearerAuthGuard((m) => api.logger.warn?.(m));
+      if (process.env.MEMINI_REQUIRE_HTTPS === "1") {
+        guardPlaintextBearerAuth(baseUrl, secret);
+      }
+
+      async function postJson(path, payload, ns) {
+        guardPlaintextBearerAuth(baseUrl, secret);
+        const headers = { "Content-Type": "application/json", "X-Memini-Namespace": ns || namespace };
+        if (secret) headers.Authorization = `Bearer $${secret}`;
+        try {
+          const res = await fetch(`$${baseUrl}$${path}`, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(payload),
+            signal: AbortSignal.timeout(timeoutMs),
+          });
+          if (!res.ok) {
+            if (fallbackOnError) return null;
+            const body = await res.text().catch(() => "");
+            throw new Error(`memini $${path} failed: $${res.status} $${body}`);
+          }
+          return await res.json();
+        } catch (error) {
+          if (!fallbackOnError) throw error;
+          api.logger.warn?.(`memini: $${String(error)}`);
+          return null;
+        }
+      }
+
+      return { postJson, baseUrl, namespace };
+    }
+
+    const plugin = {
+      id: "memini",
+      name: "memini",
+      description: "Shared cross-session memory via a memini service.",
+      configSchema,
+      register(api) {
+        const cfg = {
+          enabled: api.pluginConfig?.enabled !== false,
+          base_url: api.pluginConfig?.base_url || DEFAULT_BASE_URL,
+          namespace: api.pluginConfig?.namespace || DEFAULT_NAMESPACE,
+          namespace_per_agent: api.pluginConfig?.namespace_per_agent === true,
+          namespace_template: api.pluginConfig?.namespace_template || DEFAULT_NAMESPACE_TEMPLATE,
+          fallback_on_error: api.pluginConfig?.fallback_on_error !== false,
+          timeout_ms: api.pluginConfig?.timeout_ms || DEFAULT_TIMEOUT_MS,
+        };
+        const client = createClient(cfg, api);
+
+        if (typeof api.registerMemoryCapability === "function") {
+          api.registerMemoryCapability({
+            promptBuilder: () => [
+              cfg.namespace_per_agent
+                ? `Long-term memory: memini at $${client.baseUrl}, per-agent namespace from "$${cfg.namespace_template}".`
+                : `Long-term memory: memini at $${client.baseUrl}, namespace "$${client.namespace}".`,
+              "Relevant memories are recalled before each turn and turns are captured after. Treat recalled context as background; prefer current workspace state and user instructions.",
+            ],
+          });
+        }
+
+        api.on("before_agent_start", async (event) => {
+          if (!cfg.enabled) return;
+          const prompt = typeof event?.prompt === "string" ? event.prompt.trim() : "";
+          if (!prompt) return;
+          const result = await client.postJson("/v1/search", { query: prompt, limit: 5 }, effectiveNamespace(cfg, event));
+          const block = formatResults(result?.results || []);
+          if (!block) return;
+          return { prependContext: `Relevant long-term memory from memini:\n$${block}` };
+        });
+
+        api.on("agent_end", async (event) => {
+          if (!cfg.enabled || !event?.success || !Array.isArray(event.messages)) return;
+          const userText = lastTextByRole(event.messages, "user");
+          const assistantText = lastTextByRole(event.messages, "assistant");
+          if (!userText || !assistantText) return;
+          await client.postJson("/v1/memories", {
+            content: `User: $${userText.slice(0, 1000)}\nAssistant: $${assistantText.slice(0, 3000)}`,
+            tier: "episodic",
+            metadata: { source: "openclaw" },
+          }, effectiveNamespace(cfg, event));
+        });
+      },
+    };
+
+    export default plugin;


### PR DESCRIPTION
## Summary

Phase 3 of the agentmemory → memini migration: flip both consumers to memini. agentmemory stays deployed and untouched — rollback is reverting the memory slot (OpenClaw) / env+mount (Hermes).

- **OpenClaw**: memini's extension (v0.0.5) vendored as `openclaw-memini-plugin` ConfigMap, installed by the init container alongside the existing agentmemory extension; `plugins.slots.memory` flipped to `memini` with `namespace_per_agent: true` (per-agent namespaces: `main`/`saffron`/`matcha`); `MEMINI_API_KEY` env from the memini secret. `plugin.mjs` is `$$`-escaped for Flux postBuild substitution, same as the agentmemory plugin.
- **Hermes**: plugin mount swapped to `hermes-memini-plugin` at `/opt/data/plugins/memini`; env swapped to `MEMINI_URL` / `MEMINI_NAMESPACE: sake` / `MEMINI_API_KEY`.

## Data (already migrated, server-side)

All four namespaces are seeded and search-verified: `main` 198 / `saffron` 200 / `matcha` 1 / `sake` 3. Note the OpenClaw default agent's **id** is `main` (display name Miso), so its namespace is `main` — the `miso` namespace from the original import also exists and can be dropped (or adopted by renaming the agent id) later.

## Validation

- `flate test ks`: 153 passed, 0 failed
- memini end-to-end already verified live (embed + Qwen3 rerank + volsync PVC)

## Post-merge verification

1. `kubectl -n llm logs deploy/openclaw | grep -i memini` — plugin registered, no auth errors
2. After first agent activity: `/v1/namespaces` must NOT grow new namespaces (would mean the events carry a different agent identity and the sessionId fallback is fragmenting)
3. Hermes: provider availability log line, then a recall round-trip in `sake`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
