### PR TITLE
swap free-game-notifier to upstream image with Deployment

### DIFF
--- a/kubernetes/apps/base/self-hosted/free-game-notifier/externalsecret.yaml
+++ b/kubernetes/apps/base/self-hosted/free-game-notifier/externalsecret.yaml
@@ -12,7 +12,7 @@ spec:
     name: *name
     template:
       data:
-        DISCORD_WEBHOOK: "{{ .DISCORD_WEBHOOK }}"
+        DISCORD_WEBHOOK_URL: "{{ .DISCORD_WEBHOOK }}"
   dataFrom:
     - extract:
         key: free-games

--- a/kubernetes/apps/base/self-hosted/free-game-notifier/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/free-game-notifier/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
           app:
             image:
               repository: ghcr.io/ctrl-research/free-games
-              tag: v0.0.4@sha256:691dd09722c6015af0dadaa7900b09fd5f4c1376cd8804bb998dca3e2efa550b
+              tag: v0.0.5@sha256:346ad591a0abd45cc8722f241d69fa995171483bb45130c44ef26bbdab3380f8
             env:
               TZ: America/Edmonton
               EPIC_INCLUDE_UPCOMING: "false"

--- a/kubernetes/apps/base/self-hosted/free-game-notifier/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/free-game-notifier/helmrelease.yaml
@@ -13,35 +13,16 @@ spec:
   values:
     controllers:
       free-game-notifier:
-        type: cronjob
-        cronjob:
-          schedule: "0 16 * * THU"
-          successfulJobsHistory: 0
         containers:
           app:
             image:
-              repository: ghcr.io/joryirving/free-game-notifier
-              tag: 1.6.0@sha256:b289af63d4fbb1375483d78b01876e75f21525ea3a64c1f696b2de98623543fb
+              repository: ghcr.io/ctrl-research/free-games
+              tag: v0.0.4@sha256:691dd09722c6015af0dadaa7900b09fd5f4c1376cd8804bb998dca3e2efa550b
             env:
               TZ: America/Edmonton
-              SEND_UPCOMING: false
+              EPIC_INCLUDE_UPCOMING: "false"
+              ENABLE_STEAM: "true"
+              ENABLE_TWITCH_DROPS: "true"
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}"
-            resources:
-              requests:
-                cpu: 5m
-              limits:
-                memory: 128M
-      # dec:
-      #   type: cronjob
-      #   cronjob:
-      #     schedule: '0 16 13-31 12 *'
-      #     successfulJobsHistory: 0
-      #   containers: *container
-      # jan:
-      #   type: cronjob
-      #   cronjob:
-      #     schedule: '0 16 1-3 1 *'
-      #     successfulJobsHistory: 0
-      #   containers: *container


### PR DESCRIPTION
## Changes

- Replace \`ghcr.io/joryirving/free-game-notifier\` → \`ghcr.io/ctrl-research/free-games:v0.0.4\` (pinned digest)
- Switch from Kubernetes CronJob to Deployment — upstream app manages its own cron schedules internally
- Enable Steam and Twitch Drops scrapers

### Schedules (upstream defaults, via env vars)
| Provider | Schedule |
|---|---|
| Epic | Thursday midnight (\`0 0 0 * * 4\`) |
| Steam | Daily 9am (\`0 0 9 * * *\`) |
| Twitch Drops | Daily noon (\`0 0 12 * * *\`) |

### Files changed
- \`externalsecret.yaml\` — renamed key \`DISCORD_WEBHOOK\` → \`DISCORD_WEBHOOK_URL\` to match upstream
- \`helmrelease.yaml\` — Deployment, new image + env vars

### ⚠️ Note: Discord webhook URLs

Your 1Password secret stores multiple comma-separated Discord webhook URLs. The upstream app expects \`DISCORD_WEBHOOK_URL\` as a single URL, so it may only use the first one in the list. **Please verify after merge** that notifications are going to all intended servers.

I have filed an upstream issue ([ctrl-research/free-games#16](https://github.com/ctrl-research/free-games/issues/16)) requesting multi-webhook support so we can properly send to all your Discord servers.