### PR TITLE
feat(llm): disable memini API auth

### DIFF
--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -52,10 +52,6 @@ spec:
     rerank:
       mode: http://llama-rerank.llm:8080/v1
       model: qwen3-reranker
-    auth:
-      apiKeySecret:
-        name: memini
-        key: api-key
     httpRoute:
       enabled: true
       hostnames: ["memini.jory.dev"]


### PR DESCRIPTION
## Summary

Drops `auth.apiKeySecret` from the memini HelmRelease — no `MEMINI_API_KEY` means /v1, /mcp, /metrics, and therefore the embedded dashboard are open, but only behind envoy-internal + in-cluster.

Motivation:
- The embedded admin UI has no token support (filed upstream: eleboucher/memini#11) — with auth on, every dashboard pane 401s.
- Same for the chart's ServiceMonitor: `/metrics` is bearer-gated when a key is set and the scrape config sends no token, so Prometheus has been getting 401s.

The `memini` 1Password item / ExternalSecret stays (still feeds `llm-api-key`, and the api-key field is ready for re-enabling auth once the UI supports tokens). Consumer plugins sending `Authorization` anyway is harmless — the server ignores it with no key configured.

Validation: `flate test ks` 153/153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)