### PR TITLE
fix(llm): allow conversation access for openclaw memini plugin

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -357,6 +357,9 @@ data:
           },
           memini: {
             enabled: true,
+            hooks: {
+              allowConversationAccess: true,
+            },
             config: {
               base_url: "http://memini.llm:8080",
               namespace_per_agent: true,


### PR DESCRIPTION
## Summary

The gateway log shows OpenClaw blocking memini's write path:

```
[plugins] typed hook "agent_end" blocked because non-bundled plugins must set plugins.entries.memini.hooks.allowConversationAccess=true
```

`agent_end` is how the memini extension stores each turn as an episodic memory — without it, recall works but nothing new is ever written (all namespaces would stay frozen at the imported semantic facts). The agentmemory entry already carried `hooks.allowConversationAccess: true`; this adds the same to the memini entry.

Validation: `flate test ks` 153/153. After merge, per-namespace `/v1/stats` should start showing `episodic` counts as agents converse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)