### PR TITLE
refactor(llm): let the memini chart define its own image

### DIFF
--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: v0.0.5
+    tag: v0.0.7
   url: oci://registry.erwanleboucher.dev/eleboucher/charts/memini
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
@@ -26,10 +26,9 @@ spec:
   dependsOn: []
   values:
     fullnameOverride: memini
-    image:
-      repository: registry.erwanleboucher.dev/eleboucher/memini
-      tag: 0.0.5
-      digest: sha256:018dddd5bb3a61e6e50058836dd507ca6ba45b60e5e00b76b889f6e2f8cf327e
+    # image intentionally not set: each released chart pins its own matching
+    # image digest, so the OCIRepository tag above is the single version knob
+    # (one Renovate PR per release instead of separate chart + image bumps)
     backend: sqlite
     sqlite:
       persistence:


### PR DESCRIPTION
## Summary

Fixes the double-Renovate-PR situation for memini (e.g. #7436 image + #7437 chart for 0.0.7).

Each released memini chart pins its own matching image digest at release time, so our explicit `image.{repository,tag,digest}` override was redundant — and worse, it made Renovate track two separate deps (the OCIRepository chart tag *and* the helm-values image) that can drift out of sync. This drops the `image:` block and bumps the OCIRepository to **v0.0.7** (which carries the `skip_without_agent` fix). The chart tag is now the single version knob → one Renovate PR per release.

Verified: `helm template` of the v0.0.7 chart renders `registry.erwanleboucher.dev/eleboucher/memini@sha256:61a73cb2…` from the chart's own pinned digest. `flate test ks` 153/153.

**Supersedes #7436 and #7437** (closing those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)