### PR TITLE
fix(openclaw): persist Saffron heartbeat config

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -141,6 +141,15 @@ data:
             identity: {
               name: "Saffron",
               avatar: "avatars/saffron_avatar.png",
+            },
+            heartbeat: {
+              every: "60m",
+              model: "litellm/dsv4f",
+              directPolicy: "allow",
+              lightContext: false,
+              isolatedSession: true,
+              includeReasoning: false,
+              timeoutSeconds: 600,
             }
           },
         ],


### PR DESCRIPTION
$## Summary\n- add a per-agent Saffron heartbeat block to the GitOps-managed OpenClaw config\n- use `litellm/dsv4f` instead of `litellm/review` for Saffron heartbeat work\n- disable light context and isolate heartbeat sessions so backlog grooming sees the Saffron workspace contract\n\n## Why\nThe live pod config was changed locally with `openclaw config set`, but `openclaw.json` is generated from this ConfigMap on pod start. Without this PR the heartbeat fix disappears on restart.\n\n## Validation\n- `git diff --check`\n