### PR TITLE
ci(pr-review): enable ci_status_check to feed CI results into review

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -58,6 +58,8 @@ jobs:
           ai_smart_api_key: ${{ secrets.LITELLM_API_KEY }}
           allowed_source_hosts: "github.com,api.github.com,gitlab.com,registry.terraform.io,artifacthub.io,minecraft.net,www.minecraft.net,talos.dev,www.talos.dev"
           context_limit_mode: normal
+          ci_status_check: "true"
+          ci_timeout_sec: "600"
           tool_mode: plan_execute_loop
           tool_max_rounds: "2"
           tool_max_requests: "4"


### PR DESCRIPTION
Enables `ci_status_check: "true"` so the AI reviewer waits for CI to reach a terminal state and folds the per-check results (test/lint pass-fail) into its review corpus, instead of reporting them as "not verifiable".

This is the v1.2.7 feature from [pr-reviewer-action#230](https://github.com/misospace/pr-reviewer-action/pull/230). The reviewer never runs the suite itself — it consumes the results CI already produced. `ci_skip_on_timeout` defaults to true, so a slow pipeline degrades gracefully (review proceeds with partial CI info rather than blocking).

The action pin bump to v1.2.7 is handled separately by Renovate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)