### PR TITLE
feat(pr-review): /ai-review comment command to force a re-review

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -5,9 +5,11 @@ on:
   pull_request:
     branches: ["main"]
     types: [opened, reopened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -17,16 +19,26 @@ permissions:
 jobs:
   review-pr:
     name: AI PR Review
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.draft) || github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '/ai-review')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
 
     steps:
+      - name: Resolve PR head for comment trigger
+        id: prctx
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          echo "head_sha=$sha" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || steps.prctx.outputs.head_sha }}
 
       - name: Generate bot token
         id: app-token
@@ -35,11 +47,43 @@ jobs:
           client-id: ${{ secrets.SAFFRON_CLIENT_ID }}
           private-key: ${{ secrets.SAFFRON_APP_PRIVATE_KEY }}
 
+      # The gate script ships with the action; the authorization decision
+      # (commenter must hold write/admin) must run before any review work.
+      - name: Check out re-review command gate
+        if: github.event_name == 'issue_comment'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          repository: misospace/pr-reviewer-action
+          ref: bfe54bcac9959ca258da86482caa0f7b16d681c3 # v1.2.8
+          path: .ai-review-gate
+          persist-credentials: false
+
+      - name: Authorize re-review command
+        id: cmd
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENTER_LOGIN: ${{ github.event.comment.user.login }}
+          IS_PR_COMMENT: ${{ github.event.issue.pull_request != null }}
+        run: bash .ai-review-gate/scripts/parse_review_command.sh
+
+      - name: Acknowledge authorized re-review
+        if: github.event_name == 'issue_comment' && steps.cmd.outputs.should_review == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" -f content=rocket --silent || true
+
       - name: Analyze PR with reusable AI reviewer
+        if: github.event_name == 'pull_request' || steps.cmd.outputs.should_review == 'true'
         id: analyze
-        uses: misospace/pr-reviewer-action@0ee2d97090496aafb1b53a1226f75de4af7177c8 # v1.2.7
+        uses: misospace/pr-reviewer-action@bfe54bcac9959ca258da86482caa0f7b16d681c3 # v1.2.8
         with:
           github_token: ${{ steps.app-token.outputs.token }}
+          pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
+          force_review: ${{ github.event_name == 'issue_comment' && 'true' || 'false' }}
           ai_primary_retries: "3"
           ai_primary_retry_delay_sec: "15"
           ai_base_url: ${{ vars.LITELLM_URL }}

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -24,22 +24,6 @@ jobs:
     timeout-minutes: 35
 
     steps:
-      - name: Resolve PR head for comment trigger
-        id: prctx
-        if: github.event_name == 'issue_comment'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-        run: |
-          sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
-          echo "head_sha=$sha" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || steps.prctx.outputs.head_sha }}
-
       - name: Generate bot token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -75,6 +59,27 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}/reactions" -f content=rocket --silent || true
+
+      # Only after authorization do we place the (untrusted) PR head on
+      # this secret-bearing runner: on issue_comment the checkout is gated
+      # on the write/admin authorization above, so an unauthorized comment
+      # never checks out attacker-controllable code (CodeQL js/actions/...).
+      - name: Resolve PR head for comment trigger
+        id: prctx
+        if: github.event_name == 'issue_comment' && steps.cmd.outputs.should_review == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          echo "head_sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: github.event_name != 'issue_comment' || steps.cmd.outputs.should_review == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || steps.prctx.outputs.head_sha || github.sha }}
 
       - name: Analyze PR with reusable AI reviewer
         if: github.event_name == 'pull_request' || steps.cmd.outputs.should_review == 'true'


### PR DESCRIPTION
Wires the `/ai-review` re-review command into this repo, completing [pr-reviewer-action#231](https://github.com/misospace/pr-reviewer-action/issues/231).

**What it does:** commenting `/ai-review` on a PR forces a fresh AI review even when nothing changed (`force_review` bypasses the diff-unchanged guard) — for when the model behind the LiteLLM alias changed, standards were updated, or the first review was flaky. An authorized command gets a 🚀 reaction; the review runs against the PR head.

**Authorization (the important part):** `issue_comment` workflows run with base-repo secrets, so the command is gated by the action's tested `parse_review_command.sh`: the commenter must hold **write/admin** via the collaborators API (`author_association` is never trusted), the command must be its own line, and non-PR issues are ignored. Unauthorized comments are a silent no-op. All event data reaches scripts via `env`, never inline interpolation; the gate checkout uses `persist-credentials: false`.

Also bumps the action pin to [v1.2.8](https://github.com/misospace/pr-reviewer-action/releases/tag/v1.2.8) (ships `force_review` + the gate script; otherwise byte-identical default behavior), making the PR self-contained instead of racing the Renovate bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)