### PR TITLE
ci: validate /ai-review split design against CodeQL

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 name: AI PR Review
 
 on:

--- a/.github/workflows/ai-rereview-command.yaml
+++ b/.github/workflows/ai-rereview-command.yaml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 name: AI Re-review Command
 
 # Privileged comment handler. It ONLY authorizes the commenter and relays to a


### PR DESCRIPTION
No functional change — touches both workflow files so CodeQL analyzes the split /ai-review design (relay in its own file, no PR-head checkout under issue_comment) in PR context. If CodeQL passes here, the design is validated and alert #19 should resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)