### PR TITLE
fix(dispatch): use main tag to pick up PR#370 queue fix

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/dispatch/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/dispatch/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
           app:
             image:
               repository: ghcr.io/misospace/dispatch
-              tag: 0.4.5@sha256:8b3baf78a246dbf6e97191ccee84cec17e8d42c673ccf61f912e215ba8308851
+              tag: main
             env:
               DATABASE_URL:
                 valueFrom:


### PR DESCRIPTION
Pin image tag to `main` instead of `0.4.5@sha256:8b3baf...` to pick up the queue claimable-filter fix (PR #370, merged into dispatch main). The `main` tag was pushed by the successful CI build for commit `4f8f307`.

This gets the Dispatch queue fix deployed immediately. Once the next version tag is cut, we can pin back to a versioned digest.