### PR TITLE
fix(ci): stop label events from cancelling net-new PR reviews

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -14,7 +14,10 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}
+  # `labeled` events each get their own group: net-new PRs are auto-labeled
+  # (Renovate adds several at creation), and with a shared group +
+  # cancel-in-progress those label runs would cancel the real opened review.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number || github.ref }}${{ github.event.action == 'labeled' && format('-label-{0}', github.run_id) || '' }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
**Bug:** net-new PRs are not being reviewed. Renovate (and the labeler) apply several labels at PR creation; each is a `labeled` `pull_request` event → a workflow run sharing the concurrency group with `cancel-in-progress: true`. Those label runs **cancel the in-flight `opened` review**, and the last survivor skips because its label isn't `ai-review`. Net result: no review. Seen on [#7507](https://github.com/joryirving/home-ops/pull/7507).

**Fix (workflow-only; no action change — the action's precheck skip is correct):** give `labeled` events their own concurrency group (`…-label-<run_id>`), so they can't cancel a real `opened`/`synchronize` review. opened/synchronize keep the shared group + `cancel-in-progress` (rapid pushes still supersede). A non-`ai-review` label add still spins a run, but the action's precheck no-ops it (no model call) and it reports success — so the only cost is a brief runner run, no review noise and no skipped-check confusion. The `ai-review` re-review path is unchanged.

Verified on this PR: it was reviewed + approved despite carrying `area/github` (the label run no-op'd in its own group instead of cancelling the review). Fleet-wide companion fixes follow for the other repos + the action's README/own workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)