### PR TITLE
feat(ci): konflate evidence provider + reviewer token-budget fix

### DIFF
--- a/.github/konflate-evidence-providers.json
+++ b/.github/konflate-evidence-providers.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "konflate-rendered-diff",
+    "command": "python3 \"$GITHUB_WORKSPACE/.github/scripts/konflate_evidence.py\"",
+    "timeout_sec": 45
+  }
+]

--- a/.github/scripts/konflate_evidence.py
+++ b/.github/scripts/konflate_evidence.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Evidence provider: konflate rendered-diff for the PR under review.
+
+Emits the action's evidence-provider JSON contract on stdout:
+  {"severity": "info", "findings": [{"severity","message","source"}]}
+
+Reads PR_NUMBER from the environment (set by the action). Targets konflate's
+read-only MCP endpoint (KONFLATE_MCP_URL). Read-only, advisory, never a gate:
+on any failure or an untracked PR it emits an empty findings list and exits 0
+so it can never block a review.
+"""
+import json, os, sys, urllib.request
+
+URL = os.environ.get("KONFLATE_MCP_URL", "https://konflate.jory.dev/mcp")
+PR = os.environ.get("PR_NUMBER", "").strip()
+SID = None
+
+def _emit(findings, severity="info"):
+    print(json.dumps({"severity": severity, "findings": findings}))
+    sys.exit(0)
+
+def call(method, params=None, notif=False):
+    global SID
+    body = {"jsonrpc": "2.0", "method": method}
+    if not notif:
+        body["id"] = 1
+    if params is not None:
+        body["params"] = params
+    req = urllib.request.Request(URL, data=json.dumps(body).encode(), method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json, text/event-stream")
+    tok = os.environ.get("KONFLATE_MCP_TOKEN", "").strip()
+    if tok:
+        req.add_header("Authorization", f"Bearer {tok}")
+    if SID:
+        req.add_header("Mcp-Session-Id", SID)
+    with urllib.request.urlopen(req, timeout=20) as r:
+        sid = r.headers.get("Mcp-Session-Id")
+        if sid:
+            SID = sid
+        raw = r.read().decode()
+    if notif:
+        return None
+    for line in raw.splitlines():
+        if line.startswith("data:"):
+            return json.loads(line[5:].strip())
+    return None
+
+def _text(resp):
+    out = []
+    for c in (resp or {}).get("result", {}).get("content", []):
+        if c.get("type") == "text":
+            out.append(c["text"])
+    return "\n".join(out).strip()
+
+def main():
+    if not PR.isdigit():
+        _emit([])  # no PR context — nothing to add
+    try:
+        call("initialize", {"protocolVersion": "2025-06-18", "capabilities": {},
+                            "clientInfo": {"name": "konflate-evidence", "version": "0"}})
+        call("notifications/initialized", notif=True)
+        summary = _text(call("tools/call", {"name": "get_pr_summary", "arguments": {"number": int(PR)}}))
+        diff = _text(call("tools/call", {"name": "get_pr_diff", "arguments": {"number": int(PR)}}))
+    except Exception as exc:  # advisory: never fail the review
+        print(f"konflate evidence provider: {exc}", file=sys.stderr)
+        _emit([])
+
+    findings = []
+    src = f"https://konflate.jory.dev/#/pr/{PR}"
+
+    # konflate returns a plain sentinel when there's no usable diff yet —
+    # PR not tracked ("No pull request #N is tracked.") or render still pending
+    # ("has no rendered diff yet", "Still rendering"). Emit nothing in those
+    # cases rather than presenting a placeholder as evidence.
+    _SKIP = ("no pull request", "is tracked", "no rendered diff",
+             "still rendering", "has no rendered")
+
+    def _no_evidence(t):
+        low = (t or "").lower()
+        return (not t) or any(s in low for s in _SKIP)
+
+    if _no_evidence(diff):
+        _emit([])
+    findings.append({
+        "severity": "info",
+        "message": "konflate rendered Flux diff (post-kustomize/Helm Kubernetes YAML — "
+                   "the resources Flux will actually apply, not the raw template diff):\n\n"
+                   f"{diff}",
+        "source": src,
+    })
+    if summary and not _no_evidence(summary):
+        findings.append({"severity": "info", "message": summary, "source": src})
+    _emit(findings)
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/konflate_evidence.py
+++ b/.github/scripts/konflate_evidence.py
@@ -9,7 +9,7 @@ read-only MCP endpoint (KONFLATE_MCP_URL). Read-only, advisory, never a gate:
 on any failure or an untracked PR it emits an empty findings list and exits 0
 so it can never block a review.
 """
-import json, os, sys, urllib.request
+import json, os, sys, urllib.error, urllib.request
 
 URL = os.environ.get("KONFLATE_MCP_URL", "https://konflate.jory.dev/mcp")
 PR = os.environ.get("PR_NUMBER", "").strip()
@@ -29,16 +29,26 @@ def call(method, params=None, notif=False):
     req = urllib.request.Request(URL, data=json.dumps(body).encode(), method="POST")
     req.add_header("Content-Type", "application/json")
     req.add_header("Accept", "application/json, text/event-stream")
+    # An explicit User-Agent is required: urllib's default ("Python-urllib/x")
+    # trips Cloudflare's Browser Integrity Check (Error 1010, HTTP 403) at the
+    # edge, even when the hostname is WAF-allowlisted. Any real UA passes.
+    req.add_header("User-Agent", "ai-pr-reviewer-konflate/1.0")
     tok = os.environ.get("KONFLATE_MCP_TOKEN", "").strip()
     if tok:
         req.add_header("Authorization", f"Bearer {tok}")
     if SID:
         req.add_header("Mcp-Session-Id", SID)
-    with urllib.request.urlopen(req, timeout=20) as r:
-        sid = r.headers.get("Mcp-Session-Id")
-        if sid:
-            SID = sid
-        raw = r.read().decode()
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            sid = r.headers.get("Mcp-Session-Id")
+            if sid:
+                SID = sid
+            raw = r.read().decode()
+    except urllib.error.HTTPError as e:
+        # Surface the edge/app body (e.g. a Cloudflare error page) so a future
+        # block explains itself instead of a bare "HTTP Error 403".
+        detail = e.read().decode("utf-8", "replace")[:200].replace("\n", " ")
+        raise RuntimeError(f"HTTP {e.code} from {URL}: {detail}") from None
     if notif:
         return None
     for line in raw.splitlines():

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -61,6 +61,10 @@ jobs:
       - name: Analyze PR with reusable AI reviewer
         id: analyze
         uses: misospace/pr-reviewer-action@4126a2701a5e9adcf7c48ac6eb678e2e3a2bb2a0 # v1.2.9
+        env:
+          # konflate's read-only MCP endpoint — the konflate evidence provider
+          # fetches the rendered (post-kustomize/Helm) Flux diff for this PR.
+          KONFLATE_MCP_URL: https://konflate.jory.dev/mcp
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
@@ -97,6 +101,11 @@ jobs:
           tool_enable_for_forks: "false"
           system_prompt_file: .agents/instructions/pr-review.instructions.md
           standards_file_candidates: "AGENTS.md"
+          # Read-only konflate MCP: injects the rendered Flux YAML diff (the
+          # resources Flux will actually apply) as advisory evidence. Never
+          # gates — the provider exits clean with no findings on any failure
+          # or for PRs konflate isn't tracking.
+          evidence_providers_file: .github/konflate-evidence-providers.json
           on_model_failure: notice
           inline_findings: "true"
           publish_mode: review_comment

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -76,6 +76,11 @@ jobs:
           ai_model: ${{ vars.PRIMARY_MODEL }}
           ai_api_key: ${{ secrets.LITELLM_API_KEY }}
           ai_response_format: json_object
+          # The primary model (Gemma) is a thinking model: the default 4096
+          # token budget is consumed entirely by reasoning, leaving empty
+          # content (finish_reason=length) and a failed JSON parse. Give the
+          # reasoning + JSON verdict room.
+          ai_max_tokens: "16000"
           ai_fallback_base_url: ${{ vars.LITELLM_URL }}
           ai_fallback_api_format: ${{ vars.FALLBACK_FORMAT }}
           ai_fallback_model: ${{ vars.FALLBACK_MODEL }}


### PR DESCRIPTION
## What

Two changes to the AI PR review workflow:

1. **konflate rendered-diff evidence provider** (advisory)
   - `.github/scripts/konflate_evidence.py` — calls konflate's read-only MCP endpoint (`get_pr_summary` + `get_pr_diff`) and emits the action's evidence-provider JSON contract.
   - `.github/konflate-evidence-providers.json` — provider definition (45s timeout).
   - `ai-pr-review.yaml` — sets `evidence_providers_file` + `KONFLATE_MCP_URL`.
2. **Reviewer token-budget fix** — `ai_max_tokens: "16000"`. The primary model (Gemma) is a *thinking* model; the action's default 4096 budget is consumed by reasoning, so the completion ends `finish_reason=length` with empty content, fails the JSON parse, and forces a smart-tier escalation on **every** review. (Surfaced while testing this PR.)

## Why konflate

The reviewer currently sees only the raw template/Renovate diff. konflate renders the **post-kustomize/Helm Kubernetes YAML** — the resources Flux will actually apply. Example on #7462:

```diff
   kubernetes:
-    version: v1.36.1
+    version: v1.36.2
```

## Reachability note

konflate's MCP (`konflate.jory.dev`) is behind the external Cloudflare edge, which 403s unauthenticated GitHub-hosted runners. **Requires a hostname WAF-bypass for `konflate.jory.dev`** (same pattern already used for `flux-webhook`). Until that's in place the provider simply emits zero findings and never blocks (advisory by design).

## Safety

- **Advisory, never gates.** Any failure (unreachable, 403, untracked PR, render pending) → zero findings, exit 0.
- **Read-only.** konflate's MCP only lists/summarizes/diffs PRs.
- Forks skip evidence providers by default.

## Validation

konflate provider tested against live MCP through the action's own `run_evidence_providers.py`: #7462/#7433 → 2 findings; #7508 (pending) / #99999 (untracked) → 0 findings (skipped cleanly).

Related: misospace/pr-reviewer-action#245 (loop-native MCP tools, the eventual successor to this deterministic fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
