### PR TITLE
feat(llm): pressure-driven 3090 burst (review) + self-hosted backfill

### DIFF
--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -34,7 +34,7 @@ data:
           api_base: http://mac.internal:1234/v1
           api_key: lm-studio
           max_parallel_requests: 1
-          order: 2
+          order: 3
 
       - model_name: self-hosted
         model_info:
@@ -48,7 +48,7 @@ data:
           api_base: http://llama-nvidia.llm:8080/v1
           api_key: llama-nvidia
           max_parallel_requests: 1
-          order: 3
+          order: 2
 
       - model_name: review
         model_info:
@@ -76,7 +76,7 @@ data:
           api_base: http://mac.internal:1234/v1
           api_key: lm-studio
           max_parallel_requests: 1
-          order: 1
+          order: 3
 
       - model_name: review
         model_info:
@@ -90,7 +90,7 @@ data:
           api_base: http://gemma-review.llm:8080/v1
           api_key: gemma-review
           max_parallel_requests: 1
-          order: 3
+          order: 2
 
       - model_name: ryzen
         model_info:

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -34,7 +34,7 @@ data:
           api_base: http://mac.internal:1234/v1
           api_key: lm-studio
           max_parallel_requests: 1
-          order: 3
+          order: 2
 
       - model_name: self-hosted
         model_info:
@@ -48,7 +48,7 @@ data:
           api_base: http://llama-nvidia.llm:8080/v1
           api_key: llama-nvidia
           max_parallel_requests: 1
-          order: 2
+          order: 3
 
       - model_name: review
         model_info:
@@ -76,7 +76,7 @@ data:
           api_base: http://mac.internal:1234/v1
           api_key: lm-studio
           max_parallel_requests: 1
-          order: 3
+          order: 2
 
       - model_name: review
         model_info:
@@ -90,7 +90,7 @@ data:
           api_base: http://gemma-review.llm:8080/v1
           api_key: gemma-review
           max_parallel_requests: 1
-          order: 2
+          order: 3
 
       - model_name: ryzen
         model_info:

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -36,6 +36,20 @@ data:
           max_parallel_requests: 1
           order: 2
 
+      - model_name: self-hosted
+        model_info:
+          mode: chat
+          max_input_tokens: 131072
+          max_output_tokens: 16384
+          supports_function_calling: true
+          supports_vision: false
+        litellm_params:
+          model: openai/nvidia
+          api_base: http://llama-nvidia.llm:8080/v1
+          api_key: llama-nvidia
+          max_parallel_requests: 1
+          order: 3
+
       - model_name: review
         model_info:
           mode: chat
@@ -63,6 +77,20 @@ data:
           api_key: lm-studio
           max_parallel_requests: 1
           order: 1
+
+      - model_name: review
+        model_info:
+          mode: chat
+          max_input_tokens: 131072
+          max_output_tokens: 16384
+          supports_function_calling: true
+          supports_vision: false
+        litellm_params:
+          model: openai/review
+          api_base: http://gemma-review.llm:8080/v1
+          api_key: gemma-review
+          max_parallel_requests: 1
+          order: 3
 
       - model_name: ryzen
         model_info:

--- a/kubernetes/apps/base/llm/llmkube/README.md
+++ b/kubernetes/apps/base/llm/llmkube/README.md
@@ -42,16 +42,25 @@ Drop one file in `models/` (a `Model` + `InferenceService`, mirror
 folder, no Flux Kustomization — the operator and the existing `llmkube-models`
 Kustomization pick it up.
 
-## Swapping the nvidia slot
+## The 3090: default tenant + pressure burst
 
-`qwen3.6-27b.yaml` and `gemma-4-26b-a4b.yaml` both define an `InferenceService`
-named `llama-nvidia` (alias `nvidia`) for the single egpu / RTX 3090. They can't
-coexist, so exactly one is listed in `models/kustomization.yaml` — swap by moving
-the comment. LiteLLM routing and the idle-watcher (`job="llama-nvidia"`) are
-unaffected since the Service name is identical either way.
+The single egpu / RTX 3090 has two `InferenceService`s, distinguished by
+`priority` so the scheduler arbitrates the one card:
 
-A model that runs *concurrently* (different node) instead of swapping just needs
-a distinct `InferenceService` name; list it alongside the others.
+- `llama-nvidia` (Qwen3.6-27B) — `replicas: 1`, priority `normal`. Default
+  tenant: the `nvidia` coding model, also a LiteLLM backfill for `self-hosted`.
+- `gemma-review` (Gemma-4-26B-A4B) — `replicas: 0`, priority `high`. The review
+  burst capacity, downloaded on demand (`refreshPolicy: OnChange`).
+
+`burst-watcher/` polls `llamacpp:requests_deferred{job="llama-review"}`. When the
+ROCm review model stays backed up, it scales `gemma-review` `0→1`; being higher
+priority it **preempts** Qwen off the 3090 (Qwen → `WaitingForGPU`). When the
+queue drains (after `MIN_UP_SECONDS`), it scales back to `0` and Qwen
+reschedules. LiteLLM has `gemma-review` as an `order: 3` backfill in the `review`
+group, so traffic spreads to it once it's up.
+
+While a review burst is active the 3090's coding (`nvidia`) and the `self-hosted`
+backfill are unavailable — that's the cost of one card serving review instead.
 
 ### Option A — let the operator download it (preferred for new models)
 

--- a/kubernetes/apps/base/llm/llmkube/README.md
+++ b/kubernetes/apps/base/llm/llmkube/README.md
@@ -53,11 +53,12 @@ The single egpu / RTX 3090 has two `InferenceService`s, distinguished by
   burst capacity, downloaded on demand (`refreshPolicy: OnChange`).
 
 `burst-watcher/` polls `llamacpp:requests_deferred{job="llama-review"}`. When the
-ROCm review model stays backed up, it scales `gemma-review` `0→1`; being higher
-priority it **preempts** Qwen off the 3090 (Qwen → `WaitingForGPU`). When the
-queue drains (after `MIN_UP_SECONDS`), it scales back to `0` and Qwen
-reschedules. LiteLLM has `gemma-review` as an `order: 3` backfill in the `review`
-group, so traffic spreads to it once it's up.
+ROCm review model stays backed up, it scales `gemma-review` `0→1` only after
+`llama-nvidia` is idle, avoiding interruption of in-flight Qwen work. When the
+queue drains (after `MIN_UP_SECONDS`), it scales back to `0` only after
+`gemma-review` is idle, then Qwen can continue as the default 3090 tenant.
+LiteLLM has `gemma-review` as an `order: 3` backfill in the `review` group, so
+traffic spreads to it once it's up.
 
 While a review burst is active the 3090's coding (`nvidia`) and the `self-hosted`
 backfill are unavailable — that's the cost of one card serving review instead.

--- a/kubernetes/apps/base/llm/llmkube/burst-watcher/configmap.yaml
+++ b/kubernetes/apps/base/llm/llmkube/burst-watcher/configmap.yaml
@@ -13,11 +13,21 @@ data:
 
     log() { echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] $*"; }
 
+    as_int() {
+      value=$${1%%.*}
+      : "$${value:=0}"
+      printf '%s' "$${value}"
+    }
+
     prom() {
       curl -sfG --max-time 10 \
         --data-urlencode "query=$1" \
         "$${PROMETHEUS_URL}/api/v1/query" \
         | jq -r '.data.result[0].value[1] // "0"'
+    }
+
+    metric_max() {
+      prom "max_over_time(llamacpp:$1{job=\"$2\"}[$${PRESSURE_WINDOW}])"
     }
 
     current_replicas() {
@@ -31,32 +41,55 @@ data:
         && log "scaled $${ISVC} -> replicas=$1"
     }
 
-    log "burst-watcher started: review_job=$${REVIEW_JOB} target=$${NS}/$${ISVC} poll=$${POLL_INTERVAL_SECONDS}s"
+    log "burst-watcher started: review_job=$${REVIEW_JOB} nvidia_job=$${NVIDIA_JOB} burst_job=$${BURST_JOB} target=$${NS}/$${ISVC} poll=$${POLL_INTERVAL_SECONDS}s"
 
     up_streak=0
     down_streak=0
     last_up_epoch=0
 
     while true; do
-      deferred=$(prom "max_over_time(llamacpp:requests_deferred{job=\"$${REVIEW_JOB}\"}[$${PRESSURE_WINDOW}])")
-      up=$(prom "up{job=\"$${REVIEW_JOB}\"}")
+      review_deferred=$(metric_max requests_deferred "$${REVIEW_JOB}")
+      review_up=$(prom "up{job=\"$${REVIEW_JOB}\"}")
+      nvidia_processing=$(metric_max requests_processing "$${NVIDIA_JOB}")
+      nvidia_deferred=$(metric_max requests_deferred "$${NVIDIA_JOB}")
+      nvidia_up=$(prom "up{job=\"$${NVIDIA_JOB}\"}")
+      burst_processing=$(metric_max requests_processing "$${BURST_JOB}")
+      burst_deferred=$(metric_max requests_deferred "$${BURST_JOB}")
+      burst_up=$(prom "up{job=\"$${BURST_JOB}\"}")
       replicas=$(current_replicas)
-      deferred_int=$${deferred%%.*}
-      : "$${deferred_int:=0}"
-      log "review deferred=$${deferred} up=$${up} gemma_replicas=$${replicas:-?} up_streak=$${up_streak} down_streak=$${down_streak}"
+      review_deferred_int=$(as_int "$${review_deferred}")
+      nvidia_processing_int=$(as_int "$${nvidia_processing}")
+      nvidia_deferred_int=$(as_int "$${nvidia_deferred}")
+      burst_processing_int=$(as_int "$${burst_processing}")
+      burst_deferred_int=$(as_int "$${burst_deferred}")
+      nvidia_idle=false
+      burst_idle=false
+      if [ "$${nvidia_up}" = "1" ] && [ "$${nvidia_processing_int}" -eq 0 ] && [ "$${nvidia_deferred_int}" -eq 0 ]; then
+        nvidia_idle=true
+      fi
+      if [ "$${burst_processing_int}" -eq 0 ] && [ "$${burst_deferred_int}" -eq 0 ]; then
+        burst_idle=true
+      fi
+      log "review deferred=$${review_deferred} up=$${review_up} nvidia processing=$${nvidia_processing} deferred=$${nvidia_deferred} up=$${nvidia_up} idle=$${nvidia_idle} burst processing=$${burst_processing} deferred=$${burst_deferred} up=$${burst_up} idle=$${burst_idle} replicas=$${replicas:-?} up_streak=$${up_streak} down_streak=$${down_streak}"
 
-      if [ "$${up}" = "1" ] && [ "$${deferred_int}" -ge "$${SCALE_UP_DEFERRED}" ]; then
+      if [ "$${review_up}" = "1" ] && [ "$${review_deferred_int}" -ge "$${SCALE_UP_DEFERRED}" ]; then
         up_streak=$((up_streak + 1)); down_streak=0
       else
         down_streak=$((down_streak + 1)); up_streak=0
       fi
 
       if [ "$${replicas:-0}" = "0" ] && [ "$${up_streak}" -ge "$${SCALE_UP_HOLD}" ]; then
-        scale 1
-        last_up_epoch=$(date +%s)
+        if [ "$${nvidia_idle}" = "true" ]; then
+          scale 1
+          last_up_epoch=$(date +%s)
+        else
+          log "review pressure held but $${NVIDIA_JOB} is not idle, waiting to avoid preempting in-flight work"
+        fi
       elif [ "$${replicas:-0}" != "0" ] && [ "$${down_streak}" -ge "$${SCALE_DOWN_HOLD}" ]; then
         held=$(( $(date +%s) - last_up_epoch ))
-        if [ "$${held}" -ge "$${MIN_UP_SECONDS}" ]; then
+        if [ "$${burst_idle}" != "true" ]; then
+          log "pressure cleared but $${BURST_JOB} is not idle, holding gemma"
+        elif [ "$${held}" -ge "$${MIN_UP_SECONDS}" ]; then
           scale 0
         else
           log "pressure cleared but min-up not met ($${held}s/$${MIN_UP_SECONDS}s), holding gemma"

--- a/kubernetes/apps/base/llm/llmkube/burst-watcher/configmap.yaml
+++ b/kubernetes/apps/base/llm/llmkube/burst-watcher/configmap.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llama-burst-watcher-script
+data:
+  watch.sh: |
+    #!/bin/sh
+    set -eu
+
+    NS="$${TARGET_NS:-llm}"
+    ISVC="$${TARGET_ISVC:-gemma-review}"
+
+    log() { echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] $*"; }
+
+    prom() {
+      curl -sfG --max-time 10 \
+        --data-urlencode "query=$1" \
+        "$${PROMETHEUS_URL}/api/v1/query" \
+        | jq -r '.data.result[0].value[1] // "0"'
+    }
+
+    current_replicas() {
+      kubectl -n "$${NS}" get inferenceservice "$${ISVC}" \
+        -o jsonpath='{.spec.replicas}' 2>/dev/null || echo ""
+    }
+
+    scale() {
+      kubectl -n "$${NS}" patch inferenceservice "$${ISVC}" \
+        --type merge -p "{\"spec\":{\"replicas\":$1}}" >/dev/null \
+        && log "scaled $${ISVC} -> replicas=$1"
+    }
+
+    log "burst-watcher started: review_job=$${REVIEW_JOB} target=$${NS}/$${ISVC} poll=$${POLL_INTERVAL_SECONDS}s"
+
+    up_streak=0
+    down_streak=0
+    last_up_epoch=0
+
+    while true; do
+      deferred=$(prom "max_over_time(llamacpp:requests_deferred{job=\"$${REVIEW_JOB}\"}[$${PRESSURE_WINDOW}])")
+      up=$(prom "up{job=\"$${REVIEW_JOB}\"}")
+      replicas=$(current_replicas)
+      deferred_int=$${deferred%%.*}
+      : "$${deferred_int:=0}"
+      log "review deferred=$${deferred} up=$${up} gemma_replicas=$${replicas:-?} up_streak=$${up_streak} down_streak=$${down_streak}"
+
+      if [ "$${up}" = "1" ] && [ "$${deferred_int}" -ge "$${SCALE_UP_DEFERRED}" ]; then
+        up_streak=$((up_streak + 1)); down_streak=0
+      else
+        down_streak=$((down_streak + 1)); up_streak=0
+      fi
+
+      if [ "$${replicas:-0}" = "0" ] && [ "$${up_streak}" -ge "$${SCALE_UP_HOLD}" ]; then
+        scale 1
+        last_up_epoch=$(date +%s)
+      elif [ "$${replicas:-0}" != "0" ] && [ "$${down_streak}" -ge "$${SCALE_DOWN_HOLD}" ]; then
+        held=$(( $(date +%s) - last_up_epoch ))
+        if [ "$${held}" -ge "$${MIN_UP_SECONDS}" ]; then
+          scale 0
+        else
+          log "pressure cleared but min-up not met ($${held}s/$${MIN_UP_SECONDS}s), holding gemma"
+        fi
+      fi
+
+      sleep "$${POLL_INTERVAL_SECONDS}"
+    done

--- a/kubernetes/apps/base/llm/llmkube/burst-watcher/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/llmkube/burst-watcher/helmrelease.yaml
@@ -1,0 +1,91 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: llama-burst-watcher
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  interval: 15m
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      llama-burst-watcher:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/alpine/k8s
+              tag: "1.34.9"
+            command:
+              - /bin/sh
+              - -c
+              - exec /bin/sh /config/watch.sh
+            env:
+              HOME: /tmp
+              PROMETHEUS_URL: "http://prometheus-operated.observability.svc.cluster.local:9090"
+              REVIEW_JOB: "llama-review"
+              TARGET_NS: "llm"
+              TARGET_ISVC: "gemma-review"
+              POLL_INTERVAL_SECONDS: "30"
+              PRESSURE_WINDOW: "2m"
+              SCALE_UP_DEFERRED: "1"
+              SCALE_UP_HOLD: "3"
+              SCALE_DOWN_HOLD: "10"
+              MIN_UP_SECONDS: "600"
+              TZ: America/Edmonton
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    serviceAccount:
+      llama-burst-watcher: {}
+    rbac:
+      roles:
+        llama-burst-watcher:
+          type: Role
+          rules:
+            - apiGroups: ["inference.llmkube.dev"]
+              resources: ["inferenceservices"]
+              verbs: ["get", "list", "patch"]
+      bindings:
+        llama-burst-watcher:
+          type: RoleBinding
+          roleRef:
+            identifier: llama-burst-watcher
+          subjects:
+            - identifier: llama-burst-watcher
+              serviceAccount: llama-burst-watcher
+    persistence:
+      config:
+        type: configMap
+        name: llama-burst-watcher-script
+        defaultMode: 0755
+        globalMounts:
+          - path: /config/watch.sh
+            subPath: watch.sh
+            readOnly: true
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          llama-burst-watcher:
+            app:
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/base/llm/llmkube/burst-watcher/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/llmkube/burst-watcher/helmrelease.yaml
@@ -34,6 +34,8 @@ spec:
               HOME: /tmp
               PROMETHEUS_URL: "http://prometheus-operated.observability.svc.cluster.local:9090"
               REVIEW_JOB: "llama-review"
+              NVIDIA_JOB: "llama-nvidia"
+              BURST_JOB: "gemma-review"
               TARGET_NS: "llm"
               TARGET_ISVC: "gemma-review"
               POLL_INTERVAL_SECONDS: "30"

--- a/kubernetes/apps/base/llm/llmkube/burst-watcher/kustomization.yaml
+++ b/kubernetes/apps/base/llm/llmkube/burst-watcher/kustomization.yaml
@@ -3,6 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./servicemonitor.yaml
-  - ./qwen3.6-27b.yaml
-  - ./gemma-review.yaml
+  - ./configmap.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/llm/llmkube/models/gemma-review.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/gemma-review.yaml
@@ -9,7 +9,7 @@ spec:
   quantization: UD-Q4_K_XL
   refreshPolicy: OnChange
   hardware:
-    accelerator: gpu
+    accelerator: cuda
     gpu:
       enabled: true
       vendor: nvidia
@@ -73,7 +73,7 @@ spec:
     - --threads-batch
     - "12"
     - --reasoning
-    - on
+    - "on"
     - --chat-template-kwargs
     - '{"enable_thinking":true}'
   endpoint:

--- a/kubernetes/apps/base/llm/llmkube/models/gemma-review.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/gemma-review.yaml
@@ -19,14 +19,15 @@ spec:
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
 metadata:
-  name: llama-nvidia
+  name: gemma-review
   labels:
     krr/ignore: "true"
 spec:
   modelRef: gemma-4-26b-a4b
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:841b199aed2649a748875b043b32fed2e8c2d4d87e1d563556817fb7fa44b72b
-  replicas: 1
+  replicas: 0
+  priority: high
   runtimeClassName: nvidia
   nodeSelector:
     topology.kubernetes.io: egpu
@@ -50,7 +51,7 @@ spec:
     memory: 16Gi
   extraArgs:
     - --alias
-    - nvidia
+    - review
     - --cont-batching
     - --cache-prompt
     - --kv-unified

--- a/kubernetes/apps/base/llm/llmkube/models/qwen3.6-27b.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/qwen3.6-27b.yaml
@@ -26,6 +26,7 @@ spec:
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:841b199aed2649a748875b043b32fed2e8c2d4d87e1d563556817fb7fa44b72b
   replicas: 1
+  priority: normal
   runtimeClassName: nvidia
   nodeSelector:
     topology.kubernetes.io: egpu

--- a/kubernetes/apps/base/llm/llmkube/models/qwen3.6-27b.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/qwen3.6-27b.yaml
@@ -8,7 +8,7 @@ spec:
   format: gguf
   quantization: UD-Q4_K_XL
   hardware:
-    accelerator: gpu
+    accelerator: cuda
     gpu:
       enabled: true
       vendor: nvidia

--- a/kubernetes/apps/main/llm/llmkube.yaml
+++ b/kubernetes/apps/main/llm/llmkube.yaml
@@ -38,3 +38,24 @@ spec:
     name: flux-system
     namespace: flux-system
   wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app llama-burst-watcher
+spec:
+  dependsOn:
+    - name: llmkube-models
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/llmkube/burst-watcher
+  postBuild:
+    substitute:
+      APP: *app
+      CLUSTER: ${CLUSTER}
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
Stacked on #7537 (base = `feat/llmkube-eval-qwen3-27b`). Implements the design we landed on: use the mostly-idle 3090 to relieve the ROCm models.

## Two mechanisms

**1. `self-hosted` backfill — static, LiteLLM only.** `nvidia` (Qwen3.6-27B, always loaded) added as an `order: 3` backend in the `self-hosted` group. Overflow spills to it once `llama-strix` (order 1) + mac (order 2) are at `max_parallel_requests`. No swap, always available.

**2. `review` burst — dynamic, pressure-driven.** The 3090 is now two `InferenceService`s arbitrated by `priority`:
| service | model | replicas | priority | role |
|---|---|---|---|---|
| `llama-nvidia` | Qwen3.6-27B | 1 | `normal` | coding (`nvidia`) + self-hosted backfill |
| `gemma-review` | Gemma-4-26B-A4B | 0 | `high` | review burst (downloaded, `refreshPolicy: OnChange`) |

`burst-watcher` (app-template, `alpine/k8s` = kubectl+jq+curl) polls `llamacpp:requests_deferred{job="llama-review"}`. Sustained pressure → scale `gemma-review` `0→1` → it **preempts** Qwen off the card (Qwen → `WaitingForGPU`). Queue clears + `MIN_UP_SECONDS` → scale `0`, Qwen reschedules. `gemma-review` is an `order: 3` backfill in the `review` group.

Hysteresis: `SCALE_UP_HOLD=3` polls (~90s), `SCALE_DOWN_HOLD=10` (~300s), `MIN_UP_SECONDS=600` — avoids thrashing (each swap is two cold loads).

## Accepted tradeoff
During a review burst the 3090's coding (`nvidia`) **and** the self-hosted backfill go away — one card can't do both. Low-cost right now since `nvidia` is mostly idle.

## Notes / to verify
- ✅ Validated: `flate test ks` (155/0) and `flate test hr` (130/0) both pass — incl. `llama-burst-watcher` (app-template `rbac:`/`serviceAccount:` renders) and `llmkube`.
- Watcher patches `InferenceService.spec.replicas` via a namespaced Role (get/list/patch). The operator owns the Deployment replicas, so patching the CR is the correct lever (no HPA/KEDA fight).
- Gemma weights download to the CephFS cache when the `Model` is applied (replicas 0), so the first burst is load+prefill, not a download.
- LiteLLM picks up `model_list` changes on configmap reload/restart — confirm the litellm HR's reload behavior.
- `gemma-review` serves `--alias review`; while at replicas 0 LiteLLM cooldowns it (a few failed probes), routing to ROCm meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)