### PR TITLE
fix(llm): LLMKube Model accelerator gpu → cuda

### DIFF
--- a/kubernetes/apps/base/llm/llmkube/models/qwen3.6-27b.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/qwen3.6-27b.yaml
@@ -8,7 +8,7 @@ spec:
   format: gguf
   quantization: UD-Q4_K_XL
   hardware:
-    accelerator: gpu
+    accelerator: cuda
     gpu:
       enabled: true
       vendor: nvidia


### PR DESCRIPTION
## What
`spec.hardware.accelerator: gpu` is invalid — the CRD enum is `cpu|metal|cuda|rocm|intel`. For NVIDIA it must be **`cuda`**.

## Why
After #7537 merged, `llmkube-models` was stuck failing its server-side dry-run:
```
Model "qwen3.6-27b" is invalid: spec.hardware.accelerator: Unsupported value: "gpu"
```
So the `qwen3.6-27b` Model and `llama-nvidia` InferenceService never reconciled — `nvidia` isn't running. flate didn't catch it (the enum is enforced by the live CRD, not in flate's schema set).

## Verified
`kubectl apply --dry-run=server` on the corrected file creates both the Model and InferenceService cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)