### PR TITLE
fix(litellm): register MCP servers directly, drop toolhive gateway

### DIFF
--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -305,8 +305,29 @@ data:
           api_key: os.environ/OPENCODE_API_KEY
 
     mcp_servers:
-      toolhive:
-        url: http://vmcp-mcp-gateway-internal.llm:4483/mcp
+      arr:
+        url: http://mcp-arr-proxy.llm:8080/mcp
+      comfyui:
+        url: http://mcp-comfyui-mcp-proxy.llm:8080/mcp
+      flux:
+        url: http://mcp-flux.llm:8000/mcp
+      garmin-connect:
+        url: http://mcp-garmin-connect-proxy.llm:8080/mcp
+      github:
+        url: http://mcp-github-proxy.llm:8080/mcp
+      grafana:
+        url: http://mcp-grafana.observability:8000/sse
+        transport: sse
+      ha:
+        url: http://mcp-ha-mcp.llm:8080/mcp
+      kubectl:
+        url: http://mcp-kubectl.llm:8000/mcp
+      memory:
+        url: http://mcp-memory-mcp-proxy.llm:8080/mcp
+      seerr:
+        url: http://mcp-seerr-mcp-proxy.llm:8080/mcp
+      talos:
+        url: http://mcp-talos-mcp.llm:8080/mcp
 
     general_settings:
       health_check_endpoint: /v1/health

--- a/kubernetes/apps/base/llm/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/helmrelease.yaml
@@ -60,6 +60,16 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                   failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 4000
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  failureThreshold: 30
     persistence:
       config:
         type: configMap


### PR DESCRIPTION
## What
LiteLLM was wired at the toolhive **vmcp aggregation gateway** (`#7541`). Its startup tool-listing against the gateway times out, so the pod never binds `:4000` before the liveness probe kills it → **CrashLoop** (the new ReplicaSet is stuck; old pods still serve). Register the 11 MCP servers **directly** so LiteLLM aggregates them with its own `mcp_semantic_tool_filter`, and drop the gateway.

## Routing
- **Native (bypass the proxy entirely):** flux, ha, kubectl, talos → their own streamable-http services; grafana → its external `…/sse`.
- **stdio (no HTTP of their own):** arr, comfyui, garmin-connect, github, memory, seerr → via their toolhive per-server `-proxy` (the only HTTP shim). Fully cutting these = replacing each `MCPServer` with a raw stdio→HTTP deployment (follow-up).

All paths verified in-cluster (`/mcp` for streamable-http, `/sse` for grafana).

## Startup probe
Added a 300s startup probe so MCP discovery on boot isn't killed by the 35s liveness window (this is what's CrashLooping it today).

## Validated
`flate test hr litellm` passes (renders HR + embedded configmap); no `vmcp-mcp-gateway` refs remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)