### PR TITLE
feat(llm): qwen3-embedding-0.6b under llmkube for MCP semantic filter

### DIFF
--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -126,6 +126,14 @@ data:
           api_base: http://llama-embed.llm:8080/v1
           api_key: llama-embed
 
+      - model_name: qwen3-embedding-0-6b
+        model_info:
+          mode: embedding
+        litellm_params:
+          model: openai/qwen3-embedding-0-6b
+          api_base: http://qwen3-embedding-0-6b.llm:8080/v1
+          api_key: qwen3-embedding-0-6b
+
       # ChatGPT subscription (OAuth device flow, no API key — token cached in CHATGPT_TOKEN_DIR).
       # reasoning_effort is left to the caller (none|low|medium|high|xhigh per request).
       # Only models the Codex/ChatGPT backend serves work here: 5.5, 5.4 and 5.4-mini.
@@ -361,7 +369,7 @@ data:
       set_verbose: false
       mcp_semantic_tool_filter:
         enabled: true
-        embedding_model: sentence-transformers/all-MiniLM-L6-v2
+        embedding_model: qwen3-embedding-0-6b
         top_k: 6
         similarity_threshold: 0.3
 

--- a/kubernetes/apps/base/llm/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./servicemonitor.yaml
   - ./qwen3.6-27b.yaml
   - ./gemma-review.yaml
+  - ./qwen3-embedding-0.6b.yaml

--- a/kubernetes/apps/base/llm/llmkube/models/qwen3-embedding-0.6b.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/qwen3-embedding-0.6b.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen3-embedding-0-6b
+spec:
+  source: https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf
+  format: gguf
+  quantization: Q8_0
+  hardware:
+    accelerator: cpu
+    gpu:
+      enabled: false
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: qwen3-embedding-0-6b
+  labels:
+    krr/ignore: "true"
+spec:
+  modelRef: qwen3-embedding-0-6b
+  runtime: llamacpp
+  image: ghcr.io/ggml-org/llama.cpp:server
+  replicas: 1
+  priority: batch
+  parallelSlots: 8
+  contextSize: 32768
+  uBatchSize: 2048
+  extraArgs:
+    - --embeddings
+    - --alias
+    - qwen3-embedding-0-6b
+    - --metrics
+  resources:
+    cpu: "500m"
+    memory: 1Gi
+  endpoint:
+    port: 8080
+    type: ClusterIP


### PR DESCRIPTION
## What
The `mcp_semantic_tool_filter` was 400ing because it embeds MCP tool descriptions via memini's all-MiniLM (`n_ctx` hard-capped at **512** — BERT absolute positions, can't be raised) and some tool descriptions are 638 tokens. Add a long-context embedding model and point the filter at it.

- **`llmkube/models/qwen3-embedding-0.6b.yaml`** — `Model` + `InferenceService` (Qwen3-Embedding-0.6B, CPU, 32k context, `--embeddings`), mirroring the upstream mirceanton example, consolidated under llmkube like the other models. Downloads via the operator's CephFS cache.
- **litellm** — new `qwen3-embedding-0-6b` embedding model entry; `mcp_semantic_tool_filter.embedding_model` repointed to it. all-MiniLM stays as-is for memini (it's memini's 384-dim model, and it's on the Vulkan iGPU which LLMKube can't host anyway).

CR name is `qwen3-embedding-0-6b` (no dot) so the derived Service name is DNS-valid → `qwen3-embedding-0-6b.llm:8080`.

## Validated
`kubectl apply --dry-run=server` creates both CRs cleanly; `flate test hr litellm` passes; models dir + litellm app build.

## Note
The semantic filter builds at LiteLLM startup, so the embed `InferenceService` should be Ready first. On first rollout the Model downloads ~639MB to the cache; if LiteLLM restarts before the embed is up, the filter just logs an error and serves unfiltered until the next restart (non-fatal). One LiteLLM restart after the embed is Ready guarantees the filter builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)