### PR TITLE
feat(llm): pre-stage llmkube models on CephFS RWX (Option A) [review]

### DIFF
--- a/kubernetes/apps/base/llm/llmkube/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/llmkube/helmrelease.yaml
@@ -22,10 +22,7 @@ spec:
       retries: 3
   values:
     modelCache:
-      enabled: true
-      storageClass: ceph-filesystem
-      accessMode: ReadWriteMany
-      size: 200Gi
+      enabled: false
     prometheus:
       inferencePodMonitor:
         enabled: false

--- a/kubernetes/apps/base/llm/llmkube/models/gemma-review.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/gemma-review.yaml
@@ -52,6 +52,16 @@ spec:
     - --alias
     - review
     - --cont-batching
+    - --model-draft
+    - /model-source/gemma-4-26b-a4b/mtp-gemma-4-26B-A4B-it.gguf
+    - --spec-type
+    - draft-mtp
+    - --spec-draft-p-min
+    - "0.75"
+    - --spec-draft-n-max
+    - "3"
+    - -sps
+    - "0.90"
     - --cache-prompt
     - --kv-unified
     - --metrics

--- a/kubernetes/apps/base/llm/llmkube/models/gemma-review.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/gemma-review.yaml
@@ -4,10 +4,9 @@ kind: Model
 metadata:
   name: gemma-4-26b-a4b
 spec:
-  source: https://huggingface.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF/resolve/main/gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf
+  source: pvc://llmkube-models/gemma-4-26b-a4b/gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf
   format: gguf
   quantization: UD-Q4_K_XL
-  refreshPolicy: OnChange
   hardware:
     accelerator: cuda
     gpu:

--- a/kubernetes/apps/base/llm/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./pvc.yaml
+  - ./stage.yaml
   - ./servicemonitor.yaml
   - ./qwen3.6-27b.yaml
   - ./gemma-review.yaml

--- a/kubernetes/apps/base/llm/llmkube/models/pvc.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: llmkube-models
+spec:
+  accessModes: ["ReadWriteMany"]
+  storageClassName: ceph-filesystem
+  resources:
+    requests:
+      storage: 50Gi

--- a/kubernetes/apps/base/llm/llmkube/models/qwen3-embedding-0.6b.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/qwen3-embedding-0.6b.yaml
@@ -4,7 +4,7 @@ kind: Model
 metadata:
   name: qwen3-embedding-0-6b
 spec:
-  source: https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf
+  source: pvc://llmkube-models/qwen3-embedding/Qwen3-Embedding-0.6B-Q8_0.gguf
   format: gguf
   quantization: Q8_0
   hardware:

--- a/kubernetes/apps/base/llm/llmkube/models/stage.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/stage.yaml
@@ -20,7 +20,9 @@ spec:
               hf download Qwen/Qwen3-Embedding-0.6B-GGUF \
                 Qwen3-Embedding-0.6B-Q8_0.gguf --local-dir /models/qwen3-embedding
               hf download unsloth/gemma-4-26B-A4B-it-qat-GGUF \
-                gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf --local-dir /models/gemma-4-26b-a4b
+                gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf \
+                mmproj-F16.gguf \
+                mtp-gemma-4-26B-A4B-it.gguf --local-dir /models/gemma-4-26b-a4b
               echo "staging complete"
           env:
             HF_HUB_ENABLE_HF_TRANSFER: "1"

--- a/kubernetes/apps/base/llm/llmkube/models/stage.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/stage.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: llmkube-models-stage
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: "Enabled"
+spec:
+  backoffLimit: 6
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: stage
+          image: python:3.14-slim
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              pip install --no-cache-dir "huggingface_hub[hf_transfer]"
+
+              if [ ! -s /models/qwen3-embedding/Qwen3-Embedding-0.6B-Q8_0.gguf ]; then
+                mkdir -p /models/qwen3-embedding
+                hf download Qwen/Qwen3-Embedding-0.6B-GGUF \
+                  Qwen3-Embedding-0.6B-Q8_0.gguf --local-dir /models/qwen3-embedding
+              fi
+
+              if [ ! -s /models/gemma-4-26b-a4b/gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf ]; then
+                mkdir -p /models/gemma-4-26b-a4b
+                hf download unsloth/gemma-4-26B-A4B-it-qat-GGUF \
+                  gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf --local-dir /models/gemma-4-26b-a4b
+              fi
+
+              echo "staging complete"
+          env:
+            HF_HUB_ENABLE_HF_TRANSFER: "1"
+          envFrom:
+            - secretRef:
+                name: huggingface
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              memory: 4Gi
+          volumeMounts:
+            - name: models
+              mountPath: /models
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: llmkube-models

--- a/kubernetes/apps/base/llm/llmkube/models/stage.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/stage.yaml
@@ -17,19 +17,10 @@ spec:
           args:
             - |
               pip install --no-cache-dir "huggingface_hub[hf_transfer]"
-
-              if [ ! -s /models/qwen3-embedding/Qwen3-Embedding-0.6B-Q8_0.gguf ]; then
-                mkdir -p /models/qwen3-embedding
-                hf download Qwen/Qwen3-Embedding-0.6B-GGUF \
-                  Qwen3-Embedding-0.6B-Q8_0.gguf --local-dir /models/qwen3-embedding
-              fi
-
-              if [ ! -s /models/gemma-4-26b-a4b/gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf ]; then
-                mkdir -p /models/gemma-4-26b-a4b
-                hf download unsloth/gemma-4-26B-A4B-it-qat-GGUF \
-                  gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf --local-dir /models/gemma-4-26b-a4b
-              fi
-
+              hf download Qwen/Qwen3-Embedding-0.6B-GGUF \
+                Qwen3-Embedding-0.6B-Q8_0.gguf --local-dir /models/qwen3-embedding
+              hf download unsloth/gemma-4-26B-A4B-it-qat-GGUF \
+                gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf --local-dir /models/gemma-4-26b-a4b
               echo "staging complete"
           env:
             HF_HUB_ENABLE_HF_TRANSFER: "1"


### PR DESCRIPTION
## Scaffold for review — Option A

The operator `modelCache` can't work on this cluster's Ceph: **CephFS RWX → `fsGroupPolicy: None`** (non-root downloader can't write — the embedding crash), and **ceph-block applies fsGroup but is RWO** (would pin every cache-using model to one node). So drop the operator cache and pre-stage GGUFs on a **CephFS RWX** PVC, mounted **read-only** via `pvc://` — multi-node, no pinning, no root, no fsGroup needed (RO read of a root-created 0644 file just works).

### Changes
- **`models/pvc.yaml`** — `llmkube-models` (ceph-filesystem, RWX, 50Gi).
- **`models/stage.yaml`** — one-shot `Job` (force-recreate annotation, idempotent) that `hf download`s the embedding + gemma GGUFs into the PVC.
- **`qwen3-embedding-0.6b` + `gemma-review`** — `source: pvc://llmkube-models/…`.
- **operator** — `modelCache.enabled: false`.

### Tradeoffs (the cost of Option A)
- **No auto-download/refresh.** Models are pre-staged by the Job; to add/update a model you edit `stage.yaml` (and delete the file to force a re-pull). gemma loses `refreshPolicy: OnChange`.
- **Ordering**: the staging Job must finish before a model can serve (the InferenceService pod will restart-loop until its GGUF exists). First run downloads ~15GB (embedding 0.6GB + gemma ~14GB).

### To confirm / decide
- **`qwen3.6-27b` left on `llm-models-rook`** (ceph-block RWO — already pinned to its node). Want me to migrate it onto `llmkube-models` (CephFS RWX) too, to un-pin it and consolidate? Left out of this scaffold.
- After merge, the orphaned `llmkube-model-cache` PVC (ceph-filesystem, from the old cache) should be deleted manually.

### Validated
`kustomize build` (Model×3, InferenceService×3, Job, PVC, SM); `pvc://` models pass `--dry-run=server`; `flate test hr llmkube` renders with the cache off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)