### PR TITLE
fix(llm): qwen3-embedding 16k/slot context (fixes litellm rotation stall)

### DIFF
--- a/kubernetes/apps/base/llm/llmkube/models/qwen3-embedding-0.6b.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/qwen3-embedding-0.6b.yaml
@@ -24,14 +24,13 @@ spec:
   image: ghcr.io/ggml-org/llama.cpp:server
   replicas: 1
   priority: batch
-  parallelSlots: 8
-  contextSize: 32768
+  parallelSlots: 4
+  contextSize: 65536
   uBatchSize: 2048
   extraArgs:
     - --embeddings
     - --alias
     - qwen3-embedding-0-6b
-    - --metrics
   resources:
     cpu: "500m"
     memory: 1Gi


### PR DESCRIPTION
## What
The litellm rotation was taking ~9 min because the semantic filter's embed calls were 400ing:
```
ContextWindowExceededError: request (4574 tokens) exceeds the available context size (4096 tokens)
```
Pod logs:
```
n_ctx_seq (4096) < n_ctx_train (32768) -- the full capacity of the model will not be utilized
slot load_model: id 0..7 | new slot, n_ctx = 4096
```
llama.cpp **divides** `--ctx-size` across `--parallel` slots: `32768 / 8 = 4096` per slot. So any embed input over 4096 (semantic-filter queries / tool descriptions) failed, litellm retried + fallback-failed, dragging startup out. It recurs on every rotation — not one-time.

It is **not** CPU-bound (the embed pod sits at ~4m CPU) and **not** model-capped (the model's `n_ctx_train` is 32768).

## Fix
`parallelSlots: 4` + `contextSize: 65536` → **16384 tokens per slot** (4× the failing query, well under the 32768 model cap), with the 4-way concurrency requested. Also drops the redundant `--metrics` from extraArgs (the operator already adds it — it was doubled in the live pod).

## Validated
`kustomize build` + `--dry-run=server` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)