### PR TITLE
refactor(llm): hf-xet for model downloads (drop deprecated hf_transfer)

### DIFF
--- a/kubernetes/apps/base/llm/litellm/GLM-4.7-Flash/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/GLM-4.7-Flash/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
                 set -euo pipefail
 
                 if [ ! -s /models/glm-4.7-flash/GLM-4.7-Flash-REAP-23B-A3B-UD-Q4_K_XL.gguf ] || [ ! -s /models/glm-4.7-flash/mmproj-F16.gguf ]; then
-                  pip install --no-cache-dir "huggingface_hub[hf_transfer]"
+                  pip install --no-cache-dir "huggingface_hub[hf_xet]"
                   mkdir -p /models/glm-4.7-flash
                   rm -rf /models/glm-4.7-flash/.cache/huggingface/download/GLM-4.7-Flash-REAP-23B-A3B-UD-Q4_K_XL.gguf.lock
                   hf download \
@@ -47,8 +47,6 @@ spec:
                 else
                   echo "GLM-4.7-Flash-REAP-23B-A3B-UD-Q4_K_XL already downloaded, skipping"
                 fi
-            env:
-              HF_HUB_ENABLE_HF_TRANSFER: "1"
             envFrom:
               - secretRef:
                   name: huggingface

--- a/kubernetes/apps/base/llm/litellm/Gemma4-26B-A4B/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/Gemma4-26B-A4B/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
                 set -euo pipefail
 
                 if [ ! -s /models/gemma4-26b-a4b/gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf ] || [ ! -s /models/gemma4-26b-a4b/mmproj-F16.gguf ] || [ ! -s /models/gemma4-26b-a4b/mtp-gemma-4-26B-A4B-it.gguf ]; then
-                  pip install --no-cache-dir "huggingface_hub[hf_transfer]"
+                  pip install --no-cache-dir "huggingface_hub[hf_xet]"
                   mkdir -p /models/gemma4-26b-a4b
                   rm -rf /models/gemma4-26b-a4b/.cache/huggingface/download/gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf.lock
                   hf download \
@@ -48,8 +48,6 @@ spec:
                 else
                   echo "Gemma-4-26B-A4B-it-qat-UD-Q4_K_XL already downloaded, skipping"
                 fi
-            env:
-              HF_HUB_ENABLE_HF_TRANSFER: "1"
             envFrom:
               - secretRef:
                   name: huggingface

--- a/kubernetes/apps/base/llm/litellm/Qwen3.6-35B-A3B/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/Qwen3.6-35B-A3B/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
                 set -euo pipefail
 
                 if [ ! -s /models/qwen3.6-35b-a3b/Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf ] || [ ! -s /models/qwen3.6-35b-a3b/mmproj-F16.gguf ]; then
-                  pip install --no-cache-dir "huggingface_hub[hf_transfer]"
+                  pip install --no-cache-dir "huggingface_hub[hf_xet]"
                   mkdir -p /models/qwen3.6-35b-a3b
                   rm -rf /models/qwen3.6-35b-a3b/.cache/huggingface/download/Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf.lock
                   hf download \
@@ -48,8 +48,6 @@ spec:
                 else
                   echo "Qwen3.6-35B-A3B already downloaded, skipping"
                 fi
-            env:
-              HF_HUB_ENABLE_HF_TRANSFER: "1"
             envFrom:
               - secretRef:
                   name: huggingface

--- a/kubernetes/apps/base/llm/litellm/llama-ryzen/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-ryzen/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
                 set -euo pipefail
 
                 if [ ! -s /models/qwen3.5-9b/Qwen3.5-9B-heretic.Q4_K_M.gguf ] || [ ! -s /models/qwen3.5-9b/mmproj-F16.gguf ]; then
-                  pip install --no-cache-dir "huggingface_hub[hf_transfer]"
+                  pip install --no-cache-dir "huggingface_hub[hf_xet]"
                   mkdir -p /models/qwen3.5-9b
                   rm -rf /models/qwen3.5-9b/.cache/huggingface/download/Qwen3.5-9B-heretic.Q4_K_M.gguf.lock
                   hf download \
@@ -44,8 +44,6 @@ spec:
                 else
                   echo "Qwen3.5-9B already downloaded, skipping"
                 fi
-            env:
-              HF_HUB_ENABLE_HF_TRANSFER: "1"
             envFrom:
               - secretRef:
                   name: huggingface

--- a/kubernetes/apps/base/llm/llmkube/README.md
+++ b/kubernetes/apps/base/llm/llmkube/README.md
@@ -122,9 +122,8 @@ spec:
           command: ["/bin/sh", "-ec"]
           args:
             - |
-              pip install --no-cache-dir "huggingface_hub[hf_transfer]"
+              pip install --no-cache-dir "huggingface_hub[hf_xet]"
               hf download <org>/<repo> <File>.gguf --local-dir /models/<dir>
-          env: { HF_HUB_ENABLE_HF_TRANSFER: "1" }
           envFrom: [{ secretRef: { name: huggingface } }]  # for gated repos
           volumeMounts: [{ name: models, mountPath: /models }]
       volumes:

--- a/kubernetes/apps/base/llm/llmkube/models/stage.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/stage.yaml
@@ -14,7 +14,7 @@ spec:
           command: ["/bin/sh", "-ec"]
           args:
             - |
-              pip install --no-cache-dir "huggingface_hub[hf_transfer]"
+              pip install --no-cache-dir "huggingface_hub[hf_xet]"
               hf download Qwen/Qwen3-Embedding-0.6B-GGUF \
                 Qwen3-Embedding-0.6B-Q8_0.gguf --local-dir /models/qwen3-embedding
               hf download unsloth/gemma-4-26B-A4B-it-qat-GGUF \
@@ -25,9 +25,6 @@ spec:
                 Qwen3.6-27B-UD-Q4_K_XL.gguf \
                 mmproj-F16.gguf --local-dir /models/qwen3.6-27b
               echo "staging complete"
-          env:
-            - name: HF_HUB_ENABLE_HF_TRANSFER
-              value: "1"
           envFrom:
             - secretRef:
                 name: huggingface

--- a/kubernetes/apps/base/llm/memini/llama-embed/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/llama-embed/helmrelease.yaml
@@ -41,7 +41,7 @@ spec:
                 set -euo pipefail
 
                 if [ ! -s /models/all-MiniLM-L6-v2/all-MiniLM-L6-v2-Q8_0.gguf ]; then
-                  pip install --no-cache-dir "huggingface_hub[hf_transfer]"
+                  pip install --no-cache-dir "huggingface_hub[hf_xet]"
                   mkdir -p /models/all-MiniLM-L6-v2
                   rm -rf /models/all-MiniLM-L6-v2/.cache/huggingface/download/all-MiniLM-L6-v2-Q8_0.ggufflock
                   hf download \
@@ -52,8 +52,6 @@ spec:
                 else
                   echo "all-MiniLM-L6-v2 already downloaded, skipping"
                 fi
-            env:
-              HF_HUB_ENABLE_HF_TRANSFER: "1"
             envFrom:
               - secretRef:
                   name: huggingface

--- a/kubernetes/apps/base/llm/memini/llama-rerank/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/llama-rerank/helmrelease.yaml
@@ -41,7 +41,7 @@ spec:
                 set -euo pipefail
 
                 if [ ! -s /models/Qwen3-Reranker-0.6B/qwen3-reranker-0.6b-q8_0.gguf ]; then
-                  pip install --no-cache-dir "huggingface_hub[hf_transfer]"
+                  pip install --no-cache-dir "huggingface_hub[hf_xet]"
                   mkdir -p /models/Qwen3-Reranker-0.6B
                   rm -rf /models/Qwen3-Reranker-0.6B/.cache/huggingface/download/qwen3-reranker-0.6b-q8_0.ggufflock
                   hf download \
@@ -52,8 +52,6 @@ spec:
                 else
                   echo "Qwen3-Reranker-0.6B already downloaded, skipping"
                 fi
-            env:
-              HF_HUB_ENABLE_HF_TRANSFER: "1"
             envFrom:
               - secretRef:
                   name: huggingface


### PR DESCRIPTION
## What
`huggingface_hub` now emits a `FutureWarning` for `HF_HUB_ENABLE_HF_TRANSFER` — the `hf_transfer` Rust accelerator is superseded by the **hf-xet** backend. Switch every model-download container to `huggingface_hub[hf_xet]` and drop the env (xet auto-engages for Xet-backed repos, falls back to plain HTTP otherwise):

- llmkube staging Job (`models/stage.yaml`)
- app-template initContainers: `llama-ryzen`, `GLM-4.7-Flash`, `Qwen3.6-35B-A3B`, `Gemma4-26B-A4B`, memini `llama-embed` / `llama-rerank`
- the README example

## ⚠️ Post-merge step for the staging Job (no `force`)
The 6 HelmReleases are Deployments (mutable) — they roll normally. But `models/stage.yaml` is a raw **Job**, and it now exists on-cluster, so its spec change can't be patched in place. Per your call we're **not** using `spec.force`, so after merge delete it once and Flux recreates it with the new spec (idempotent — re-verifies the already-staged files, no re-download):
```
kubectl delete job llmkube-models-stage -n llm
```
(If skipped, the `llmkube-models` ks will wedge on the immutable Job, same failure mode as before.) Future Job-spec changes need the same one-time delete — the alternative is `spec.force: true` on the ks if you'd rather not.

## Validated
`flate test hr` passes for all 7 (main + utility); no `hf_transfer`/`HF_HUB_ENABLE_HF_TRANSFER` left; staging Job's new spec is valid (dry-run's "immutable" is just the existing-object conflict, which the delete resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)