### PR TITLE
feat(echo): migrate to home-operations/echo chart

### DIFF
--- a/kubernetes/apps/base/network/echo/helmrelease.yaml
+++ b/kubernetes/apps/base/network/echo/helmrelease.yaml
@@ -1,5 +1,19 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: echo
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.0
+  url: oci://ghcr.io/home-operations/charts/echo
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -7,77 +21,28 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
-  interval: 15m
-  dependsOn: []
+    name: echo
+  interval: 1h
   values:
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 100
-        fsGroupChangePolicy: OnRootMismatch
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: "{{ .Release.Name }}"
-    controllers:
-      echo:
-        strategy: RollingUpdate
-        containers:
-          app:
-            image:
-              repository: ghcr.io/mendhak/http-https-echo
-              tag: 41
-            env:
-              HTTP_PORT: &port 80
-              LOG_WITHOUT_NEWLINE: true
-              LOG_IGNORE_PATH: /healthz
-              PROMETHEUS_ENABLED: true
-            probes:
-              liveness: &probes
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /healthz
-                    port: *port
-                  initialDelaySeconds: 0
-                  periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
-              readiness: *probes
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
-              seccompProfile:
-                type: RuntimeDefault
-            resources:
-              requests:
-                cpu: 10m
-              limits:
-                memory: 64Mi
-    route:
-      app:
-        hostnames: ["${SUBDOMAIN}.jory.dev"]
-        parentRefs:
-          - name: envoy-external
-            namespace: network
-    service:
-      app:
-        ports:
-          http:
-            port: *port
-    serviceMonitor:
-      app:
-        serviceName: "{{ .Release.Name }}"
-        endpoints:
-          - port: http
-            scheme: http
-            path: /metrics
-            interval: 1m
-            scrapeTimeout: 10s
+    replicaCount: 1
+    config:
+      kubernetes: true
+    httpRoute:
+      enabled: true
+      annotations:
+        gatus.home-operations.com/endpoint: |-
+          conditions: ["[STATUS] == 200"]
+      hostnames:
+        - "${SUBDOMAIN}.jory.dev"
+      parentRefs:
+        - name: envoy-external
+          namespace: network
+    monitoring:
+      serviceMonitor:
+        enabled: true
+        interval: 1m
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 64Mi


### PR DESCRIPTION
## Overview

Switch the `echo` deployment from the bjw-s `app-template` (running `ghcr.io/mendhak/http-https-echo`) to the first-party [home-operations/echo](https://github.com/home-operations/echo) OCI chart `0.1.0` (`oci://ghcr.io/home-operations/charts/echo`).

- **Chart + image change**: Swaps to home-operations' own `ghcr.io/home-operations/echo` binary
- **Kubernetes feature enabled**: `config.kubernetes: true` adds a `kubernetes` object (pod name, namespace, pod IP, node) to echo responses via the Downward API
- **Preserved**: HTTPRoute on `${SUBDOMAIN}.jory.dev` via `envoy-external`, ServiceMonitor, and resource requests/limits (10m CPU / 64Mi memory)
- **Metrics**: Now served on dedicated `metrics` port (9090) instead of the HTTP port
- **Gatus**: Added health check annotation to the HTTPRoute

The HelmRelease drops from ~83 lines of app-template scaffolding to chart-specific values (~30 lines). Cluster overlays (`main`, `utility`, `test`) are unchanged.