### PR TITLE
fix(terraform): use in-cluster 1Password Connect for plan auth

### DIFF
--- a/.github/workflows/terraform-diff.yaml
+++ b/.github/workflows/terraform-diff.yaml
@@ -91,7 +91,8 @@ jobs:
       - name: Tofu Plan
         working-directory: ${{ matrix.paths }}
         env:
-          TF_VAR_OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OP_CONNECT_HOST: http://onepassword-connect.external-secrets.svc.cluster.local
+          OP_CONNECT_TOKEN: ${{ secrets.OP_CONNECT_TOKEN }}
         run: tofu plan -lock=false -input=false -out .planfile | grep -v "Refreshing state...\|Reading...\|Read complete after"
 
       - name: Post PR comment

--- a/terraform/authentik/main.tofu
+++ b/terraform/authentik/main.tofu
@@ -13,9 +13,7 @@ terraform {
 }
 
 # 1Password provider for secure credential retrieval
-provider "onepassword" {
-  service_account_token = var.OP_SERVICE_ACCOUNT_TOKEN
-}
+provider "onepassword" {}
 
 # Module to retrieve authentik credentials from 1Password
 module "onepassword_authentik" {

--- a/terraform/authentik/variables.tofu
+++ b/terraform/authentik/variables.tofu
@@ -1,9 +1,3 @@
-variable "OP_SERVICE_ACCOUNT_TOKEN" {
-  type        = string
-  description = "1Password Service Account token"
-  sensitive   = true
-}
-
 variable "CLUSTER_DOMAIN" {
   type        = string
   description = "Domain for Authentik"

--- a/terraform/garage/main.tofu
+++ b/terraform/garage/main.tofu
@@ -13,9 +13,7 @@ terraform {
 }
 
 # 1Password provider for secure credential retrieval
-provider "onepassword" {
-  service_account_token = var.OP_SERVICE_ACCOUNT_TOKEN
-}
+provider "onepassword" {}
 
 # Data source to reference the Kubernetes vault
 data "onepassword_vault" "kubernetes" {

--- a/terraform/garage/variables.tofu
+++ b/terraform/garage/variables.tofu
@@ -1,9 +1,3 @@
-variable "OP_SERVICE_ACCOUNT_TOKEN" {
-  type        = string
-  description = "1Password Service Account token"
-  sensitive   = true
-}
-
 variable "GARAGE_URL" {
   type        = string
   description = "Garage Server URL"

--- a/terraform/uptimerobot/main.tofu
+++ b/terraform/uptimerobot/main.tofu
@@ -13,9 +13,7 @@ terraform {
 }
 
 # 1Password provider for secure credential retrieval
-provider "onepassword" {
-  service_account_token = var.OP_SERVICE_ACCOUNT_TOKEN
-}
+provider "onepassword" {}
 
 # Data source to reference the Kubernetes vault
 data "onepassword_vault" "kubernetes" {

--- a/terraform/uptimerobot/variables.tofu
+++ b/terraform/uptimerobot/variables.tofu
@@ -1,5 +1,0 @@
-variable "OP_SERVICE_ACCOUNT_TOKEN" {
-  type        = string
-  description = "1Password Service Account token"
-  sensitive   = true
-}


### PR DESCRIPTION
Plans were hitting `1Password: rate limit exceeded` because the four `max-parallel` jobs each read the vault through the cloud service-account SDK at once.

Reverts the auth half of `9b1e0d8d8` back to in-cluster **Connect**, which is self-hosted and not rate-limited. The utility runner already reaches it.

- provider blocks → env-configured (`OP_CONNECT_HOST`/`OP_CONNECT_TOKEN`), drop the `OP_SERVICE_ACCOUNT_TOKEN` var
- workflow Plan step → Connect env; host hardcoded to the in-cluster service URL

`schemas.yaml` left on the service-account token — single secret fetch, not part of the rate-limit issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)