### PR TITLE
feat: add drm-exporter for Intel Xe & AMD GPU monitoring

### DIFF
--- a/kubernetes/apps/base/observability/exporters/drm-exporter/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/drm-exporter/helmrelease.yaml
@@ -1,0 +1,64 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: drm-exporter
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.2.0
+  url: oci://ghcr.io/home-operations/charts/drm-exporter
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: drm-exporter
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: drm-exporter
+  interval: 1h
+  values:
+    hostAccess:
+      devCpu: ""
+      devDri: /dev/dri
+    monitoring:
+      dashboards:
+        enabled: true
+      serviceMonitor:
+        enabled: true
+        interval: 30s
+        scrapeTimeout: 10s
+    podSecurityContext:
+      runAsGroup: 0
+      runAsNonRoot: false
+      runAsUser: 0
+      seccompProfile:
+        type: RuntimeDefault
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 256Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+          - PERFMON
+        drop:
+          - ALL
+      privileged: false
+      readOnlyRootFilesystem: true
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: llm-workload
+        operator: Exists
+        effect: NoSchedule

--- a/kubernetes/apps/base/observability/exporters/drm-exporter/kustomization.yaml
+++ b/kubernetes/apps/base/observability/exporters/drm-exporter/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/main/observability/exporters/drm-exporter.yaml
+++ b/kubernetes/apps/main/observability/exporters/drm-exporter.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: drm-exporter
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/observability/exporters/drm-exporter
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/exporters/kustomization.yaml
+++ b/kubernetes/apps/main/observability/exporters/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./blackbox-exporter.yaml
   - ./dcgm-exporter.yaml
+  - ./drm-exporter.yaml
   - ./blackbox-exporter-probes.yaml
   - ./hoymiles-exporter.yaml
   - ./nut-exporter.yaml


### PR DESCRIPTION
## Summary

Adds [drm-exporter](https://github.com/home-operations/drm-exporter) (v0.2.0) as a DaemonSet alongside the existing dcgm-exporter and rocm-smi-exporter.

## What This Covers

| GPU | Node(s) | Before | After |
|---|---|---|---|
| Intel Xe iGPU | MS-01 x3 | ❌ Unmonitored | ✅ Engine util, memory, freq, power |
| AMD Strix Halo iGPU | skirk | ✅ rocm-smi-exporter only | ✅ Augmented with additional metrics (engine util, freq) |
| NVIDIA eGPU | eGPU node | ✅ dcgm-exporter | ✅ dcgm-exporter (unchanged) |

## Talos Compatibility

- Drops `SYS_RAWIO` capability — Talos doesn't ship the `msr` kernel module
- Sets `hostAccess.devCpu: ""` — no MSR path
- Intel iGPU package temperature will be unavailable; all other metrics (engine utilization, memory, frequency, power via perf PMU) work fine
- Perf PMU path is the preferred RAPL power path already

## Chart Details

- Published as Cosign-signed OCI artifact at `oci://ghcr.io/home-operations/charts/drm-exporter`
- Built-in ServiceMonitor and Grafana dashboard enabled
- Tolerates `control-plane` and `llm-workload` taints
- Pods auto-exit on non-GPU nodes

## Status

rocm-smi-exporter is kept running in parallel for now. Once drm-exporter is validated, rocm-smi-exporter can be removed in a follow-up PR.