### PR TITLE
test(llm): hotswap Strix to Qwen3.5-122B-A10B (MTP)

### DIFF
--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -8,10 +8,12 @@ data:
     model_list:
       # These aliases keep the client-facing names stable while LiteLLM
       # forwards the upstream model IDs that each llama.cpp server expects.
+      # 122B hotswap test (#strix-122b): llama-strix now serves Qwen3.5-122B-A10B
+      # (ctx 150k, 1 slot). Mac 35B + ROCm review commented out below for the test.
       - model_name: self-hosted
         model_info:
           mode: chat
-          max_input_tokens: 262144
+          max_input_tokens: 150000
           max_output_tokens: 16384
           supports_function_calling: true
           supports_vision: true
@@ -19,36 +21,36 @@ data:
           model: openai/self-hosted
           api_base: http://llama-strix.llm:8080/v1
           api_key: llama-strix
-          max_parallel_requests: 2
+          max_parallel_requests: 1
           order: 1
 
-      - model_name: self-hosted
-        model_info:
-          mode: chat
-          max_input_tokens: 262144
-          max_output_tokens: 16384
-          supports_function_calling: true
-          supports_vision: true
-        litellm_params:
-          model: openai/qwen3.6-35b-a3b@q5_k_xl
-          api_base: http://mac.internal:1234/v1
-          api_key: lm-studio
-          max_parallel_requests: 2
-          order: 1
+      # - model_name: self-hosted
+      #   model_info:
+      #     mode: chat
+      #     max_input_tokens: 262144
+      #     max_output_tokens: 16384
+      #     supports_function_calling: true
+      #     supports_vision: true
+      #   litellm_params:
+      #     model: openai/qwen3.6-35b-a3b@q5_k_xl
+      #     api_base: http://mac.internal:1234/v1
+      #     api_key: lm-studio
+      #     max_parallel_requests: 2
+      #     order: 1
 
-      - model_name: review
-        model_info:
-          mode: chat
-          max_input_tokens: 204800
-          max_output_tokens: 16384
-          supports_function_calling: true
-          supports_vision: false
-        litellm_params:
-          model: openai/review
-          api_base: http://llama-review.llm:8080/v1
-          api_key: llama-review
-          max_parallel_requests: 2
-          order: 1
+      # - model_name: review          # ROCm GLM-4.7-Flash off the Strix during 122B test
+      #   model_info:
+      #     mode: chat
+      #     max_input_tokens: 204800
+      #     max_output_tokens: 16384
+      #     supports_function_calling: true
+      #     supports_vision: false
+      #   litellm_params:
+      #     model: openai/review
+      #     api_base: http://llama-review.llm:8080/v1
+      #     api_key: llama-review
+      #     max_parallel_requests: 2
+      #     order: 1
 
       - model_name: review
         model_info:

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -38,7 +38,7 @@ data:
       #     max_parallel_requests: 2
       #     order: 1
 
-      # - model_name: review          # ROCm GLM-4.7-Flash off the Strix during 122B test
+      # - model_name: review          # ROCm Gemma-4-26B-A4B off the Strix during 122B test
       #   model_info:
       #     mode: chat
       #     max_input_tokens: 204800

--- a/kubernetes/apps/base/llm/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/kustomization.yaml
@@ -6,5 +6,8 @@ resources:
   - ./pvc.yaml
   - ./servicemonitor.yaml
   - ./qwen3.6-27b.yaml
-  - ./llama-strix.yaml
-  - ./llama-review.yaml
+  # 122B hotswap test (#strix-122b): 35B self-hosted + ROCm review swapped out so
+  # Qwen3.5-122B-A10B owns the Strix; review falls to the 3090 Qwen via least-busy.
+  # - ./llama-strix.yaml
+  - ./llama-strix-122b.yaml
+  # - ./llama-review.yaml

--- a/kubernetes/apps/base/llm/llmkube/models/llama-strix-122b.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/llama-strix-122b.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen3.5-122b-a10b
+spec:
+  source: pvc://llmkube-models/qwen3.5-122b-a10b/Qwen3.5-122B-A10B-UD-Q4_K_XL-00001-of-00003.gguf
+  format: gguf
+  quantization: UD-Q4_K_XL
+  hardware:
+    accelerator: rocm
+    gpu:
+      enabled: true
+      vendor: amd
+      count: 1
+      layers: 99
+      resourceName: devic.es/rocm
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: llama-strix
+  labels:
+    krr/ignore: "true"
+spec:
+  modelRef: qwen3.5-122b-a10b
+  runtime: llamacpp
+  image: docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:f6f4e29550896c0f810740c0502b1bddf130ccb3412ff347c1e13bce4e753193
+  command:
+    - llama-server
+  replicas: 1
+  priority: high
+  securityContext:
+    privileged: true
+  nodeSelector:
+    topology.kubernetes.io/gpus: amd
+  tolerations:
+    - key: llm-workload
+      operator: Exists
+      effect: NoSchedule
+  contextSize: 150000
+  parallelSlots: 1
+  flashAttention: true
+  jinja: true
+  cacheTypeK: q8_0
+  cacheTypeV: q8_0
+  reasoningBudget: 16384
+  reasoningBudgetMessage: "Stop reasoning and produce the implementation, tool call, or final answer."
+  batchSize: 4096
+  uBatchSize: 2048
+  resources:
+    cpu: "500m"
+    memory: 20Gi
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  extraArgs:
+    - --alias
+    - self-hosted
+    - --mmproj
+    - /model-source/qwen3.5-122b-a10b/mmproj-F16.gguf
+    - --cont-batching
+    - --spec-type
+    - draft-mtp
+    - --spec-draft-p-min
+    - "0.75"
+    - --spec-draft-n-max
+    - "3"
+    - --spec-draft-type-k
+    - q8_0
+    - --spec-draft-type-v
+    - q8_0
+    - -sps
+    - "0.90"
+    - --cache-prompt
+    - --kv-unified
+    - --no-context-shift
+    - --ctx-checkpoints
+    - "4"
+    - --checkpoint-every-n-tokens
+    - "16384"
+    - --image-min-tokens
+    - "1024"
+    - --temp
+    - "0.6"
+    - --top-p
+    - "0.95"
+    - --top-k
+    - "20"
+    - --min-p
+    - "0"
+    - --presence-penalty
+    - "0.5"
+    - --repeat-penalty
+    - "1.03"
+    - --threads
+    - "16"
+    - --threads-batch
+    - "21"
+    - --no-mmap
+    - --chat-template-kwargs
+    - '{"preserve_thinking":true}'
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 360
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 6
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 6

--- a/kubernetes/apps/base/llm/llmkube/models/llama-strix-122b.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/llama-strix-122b.yaml
@@ -4,7 +4,7 @@ kind: Model
 metadata:
   name: qwen3.5-122b-a10b
 spec:
-  source: pvc://llmkube-models/qwen3.5-122b-a10b/Qwen3.5-122B-A10B-UD-Q4_K_XL-00001-of-00003.gguf
+  source: pvc://llm-models/qwen3.5-122b-a10b/Qwen3.5-122B-A10B-UD-Q4_K_XL-00001-of-00003.gguf
   format: gguf
   quantization: UD-Q4_K_XL
   hardware:

--- a/kubernetes/apps/base/llm/llmkube/stage/stage.yaml
+++ b/kubernetes/apps/base/llm/llmkube/stage/stage.yaml
@@ -5,10 +5,16 @@ metadata:
   name: stage-${MODEL_SLUG}
 spec:
   backoffLimit: 6
-  activeDeadlineSeconds: 3600
+  activeDeadlineSeconds: ${STAGE_DEADLINE:=3600}
   template:
     spec:
       restartPolicy: OnFailure
+      nodeSelector:
+        ${STAGE_NODE_KEY:=kubernetes.io/os}: "${STAGE_NODE_VALUE:=linux}"
+      tolerations:
+        - key: llm-workload
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: stage
           image: python:3.14-slim
@@ -36,4 +42,4 @@ spec:
       volumes:
         - name: models
           persistentVolumeClaim:
-            claimName: llmkube-models
+            claimName: ${MODEL_CLAIM:=llmkube-models}

--- a/kubernetes/apps/main/llm/llmkube.yaml
+++ b/kubernetes/apps/main/llm/llmkube.yaml
@@ -61,3 +61,26 @@ spec:
     name: flux-system
     namespace: flux-system
   wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: stage-qwen3-5-122b
+spec:
+  dependsOn:
+    - name: llmkube-models
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/llmkube/stage
+  postBuild:
+    substitute:
+      MODEL_SLUG: qwen3-5-122b
+      MODEL_REPO: unsloth/Qwen3.5-122B-A10B-MTP-GGUF
+      MODEL_FILES: Qwen3.5-122B-A10B-UD-Q4_K_XL-00001-of-00003.gguf Qwen3.5-122B-A10B-UD-Q4_K_XL-00002-of-00003.gguf Qwen3.5-122B-A10B-UD-Q4_K_XL-00003-of-00003.gguf mmproj-F16.gguf
+      MODEL_DIR: qwen3.5-122b-a10b
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/main/llm/llmkube.yaml
+++ b/kubernetes/apps/main/llm/llmkube.yaml
@@ -61,26 +61,3 @@ spec:
     name: flux-system
     namespace: flux-system
   wait: false
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: stage-qwen3-5-122b
-spec:
-  dependsOn:
-    - name: llmkube-models
-  interval: 1h
-  path: ./kubernetes/apps/base/llm/llmkube/stage
-  postBuild:
-    substitute:
-      MODEL_SLUG: qwen3-5-122b
-      MODEL_REPO: unsloth/Qwen3.5-122B-A10B-MTP-GGUF
-      MODEL_FILES: Qwen3.5-122B-A10B-UD-Q4_K_XL-00001-of-00003.gguf Qwen3.5-122B-A10B-UD-Q4_K_XL-00002-of-00003.gguf Qwen3.5-122B-A10B-UD-Q4_K_XL-00003-of-00003.gguf mmproj-F16.gguf
-      MODEL_DIR: qwen3.5-122b-a10b
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  wait: false

--- a/kubernetes/apps/main/llm/llmkube.yaml
+++ b/kubernetes/apps/main/llm/llmkube.yaml
@@ -61,3 +61,30 @@ spec:
     name: flux-system
     namespace: flux-system
   wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: stage-qwen3-5-122b
+spec:
+  dependsOn:
+    - name: llmkube-models
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/llmkube/stage
+  postBuild:
+    substitute:
+      MODEL_SLUG: qwen3-5-122b
+      MODEL_REPO: unsloth/Qwen3.5-122B-A10B-MTP-GGUF
+      MODEL_FILES: Qwen3.5-122B-A10B-UD-Q4_K_XL-00001-of-00003.gguf Qwen3.5-122B-A10B-UD-Q4_K_XL-00002-of-00003.gguf Qwen3.5-122B-A10B-UD-Q4_K_XL-00003-of-00003.gguf mmproj-F16.gguf
+      MODEL_DIR: qwen3.5-122b-a10b
+      MODEL_CLAIM: llm-models
+      STAGE_NODE_KEY: topology.kubernetes.io/gpus
+      STAGE_NODE_VALUE: amd
+      STAGE_DEADLINE: "14400"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/main/llm/llmkube.yaml
+++ b/kubernetes/apps/main/llm/llmkube.yaml
@@ -88,3 +88,57 @@ spec:
     name: flux-system
     namespace: flux-system
   wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: stage-qwen3-6-35b
+spec:
+  dependsOn:
+    - name: llmkube-models
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/llmkube/stage
+  postBuild:
+    substitute:
+      MODEL_SLUG: qwen3-6-35b
+      MODEL_REPO: unsloth/Qwen3.6-35B-A3B-MTP-GGUF
+      MODEL_FILES: Qwen3.6-35B-A3B-UD-Q8_K_XL.gguf mmproj-F16.gguf
+      MODEL_DIR: qwen3.6-35b-a3b
+      MODEL_CLAIM: llm-models
+      STAGE_NODE_KEY: topology.kubernetes.io/gpus
+      STAGE_NODE_VALUE: amd
+      STAGE_DEADLINE: "10800"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: stage-gemma-4-26b-a4b
+spec:
+  dependsOn:
+    - name: llmkube-models
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/llmkube/stage
+  postBuild:
+    substitute:
+      MODEL_SLUG: gemma-4-26b-a4b
+      MODEL_REPO: unsloth/gemma-4-26B-A4B-it-qat-GGUF
+      MODEL_FILES: gemma-4-26B-A4B-it-qat-UD-Q4_K_XL.gguf mmproj-F16.gguf mtp-gemma-4-26B-A4B-it.gguf
+      MODEL_DIR: gemma4-26b-a4b
+      MODEL_CLAIM: llm-models
+      STAGE_NODE_KEY: topology.kubernetes.io/gpus
+      STAGE_NODE_VALUE: amd
+      STAGE_DEADLINE: "7200"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
## What

Test running **Qwen3.5-122B-A10B** (UD-Q4_K_XL, MTP) as the *single* tenant on the Strix Halo, in place of the 35B-A3B + Gemma review co-tenancy. Goal: see if the larger active-param count (10B vs 3B) is worth the ~2× slower generation and Q8→Q4 drop.

## How it's wired (hotswap-friendly)

- **New file** `models/llama-strix-122b.yaml` — separate manifest, InferenceService still named `llama-strix` so the `self-hosted` endpoint (`llama-strix.llm:8080`) is unchanged. The 35B `llama-strix.yaml` is left intact, just toggled out of the kustomization.
- **`models/kustomization.yaml`** — commented out `llama-strix.yaml` (35B) + `llama-review.yaml` (Gemma review) so the 122B owns the card; added `llama-strix-122b.yaml`.
- **Stage job** `stage-qwen3-5-122b` — downloads the 4 GGUFs (`unsloth/Qwen3.5-122B-A10B-MTP-GGUF`) to the **skirk-local `llm-models` PVC** at `qwen3.5-122b-a10b/` (same claim the other Strix models use). The shared `stage/` template is now parameterized (`MODEL_CLAIM`, `STAGE_NODE_KEY/VALUE`, `STAGE_DEADLINE`); this job is **pinned to skirk** (`topology.kubernetes.io/gpus: amd`) with a 4h deadline for the ~70GB pull. The 27b stage keeps its CephFS defaults.
- **litellm** — `self-hosted` now points at the 122B (ctx 150k, 1 slot, `max_parallel 1`); Mac 35B `self-hosted` + ROCm `review` commented out. **Review now serves from the 3090 Qwen + Mac** via least-busy.

## Model config (122B + current MTP setup)
- UD-Q4_K_XL (Q8 won't fit 128GB), `contextSize 150000`, `parallelSlots 1`
- `draft-mtp` speculative decoding (why the MTP GGUF) to offset the slower big model
- `--no-context-shift`, `--ctx-checkpoints 4`, kv q8_0, sampling temp 0.6 / top-p 0.95 / top-k 20 / presence 0.5 / repeat 1.03

## Expect / caveats
- First spin-up is slow: ~70GB download (skirk-pinned stage Job → `llm-models`), then load.
- ~2× slower generation than 35B-A3B; single slot = 1 concurrent self-hosted request.
- Skirk is single-tenant now (review/35B off it) — frees UMA for the 122B.

## Revert / hotswap back
Toggle `models/kustomization.yaml` (uncomment `llama-strix.yaml` + `llama-review.yaml`, comment `llama-strix-122b.yaml`) and uncomment the litellm Mac `self-hosted` + ROCm `review` blocks (restore `self-hosted` max_input 262144 / parallel 2). Or just close this PR.