### PR TITLE
test(llm): 2× 35B-A3B Q5 on Strix (concurrency over the 122B)

### DIFF
--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -8,8 +8,9 @@ data:
     model_list:
       # These aliases keep the client-facing names stable while LiteLLM
       # forwards the upstream model IDs that each llama.cpp server expects.
-      # 122B test (#strix-122b): llama-strix serves Qwen3.5-122B-A10B (262k × 2 slots).
-      # Mac 35B + ROCm review commented out below; review runs on the 3090 Qwen.
+      # 2x 35B-Q5 concurrency test (#strix-2x35b): self-hosted = two Strix instances
+      # (llama-strix-a/b, Qwen3.6-35B-A3B Q5, 262k x 2 slots each); litellm least-busy
+      # load-balances across them = 4 concurrent. Mac 35B + ROCm review still off (3090 Qwen).
       - model_name: self-hosted
         model_info:
           mode: chat
@@ -19,8 +20,22 @@ data:
           supports_vision: true
         litellm_params:
           model: openai/self-hosted
-          api_base: http://llama-strix.llm:8080/v1
-          api_key: llama-strix
+          api_base: http://llama-strix-a.llm:8080/v1
+          api_key: llama-strix-a
+          max_parallel_requests: 2
+          order: 1
+
+      - model_name: self-hosted
+        model_info:
+          mode: chat
+          max_input_tokens: 262144
+          max_output_tokens: 16384
+          supports_function_calling: true
+          supports_vision: true
+        litellm_params:
+          model: openai/self-hosted
+          api_base: http://llama-strix-b.llm:8080/v1
+          api_key: llama-strix-b
           max_parallel_requests: 2
           order: 1
 

--- a/kubernetes/apps/base/llm/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/kustomization.yaml
@@ -6,8 +6,9 @@ resources:
   - ./pvc.yaml
   - ./servicemonitor.yaml
   - ./qwen3.6-27b.yaml
-  # 122B hotswap test (#strix-122b): 35B self-hosted + ROCm review swapped out so
-  # Qwen3.5-122B-A10B owns the Strix; review falls to the 3090 Qwen via least-busy.
+  # 2× 35B-Q5 concurrency test (#strix-2x35b): two llama-strix-a/b instances own the
+  # Strix; litellm least-busy LBs `self-hosted` across them. 122B / 35B-Q8 / ROCm review off.
   # - ./llama-strix.yaml
-  - ./llama-strix-122b.yaml
+  # - ./llama-strix-122b.yaml
+  - ./llama-strix-35b-q5.yaml
   # - ./llama-review.yaml

--- a/kubernetes/apps/base/llm/llmkube/models/llama-strix-35b-q5.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/llama-strix-35b-q5.yaml
@@ -1,0 +1,219 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: qwen3.6-35b-a3b-q5
+spec:
+  source: pvc://llm-models/qwen3.6-35b-a3b-q5/Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf
+  format: gguf
+  quantization: UD-Q5_K_XL
+  hardware:
+    accelerator: rocm
+    gpu:
+      enabled: true
+      vendor: amd
+      count: 1
+      layers: 99
+      resourceName: devic.es/rocm
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: llama-strix-a
+  labels:
+    krr/ignore: "true"
+spec:
+  modelRef: qwen3.6-35b-a3b-q5
+  runtime: llamacpp
+  image: docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:f6f4e29550896c0f810740c0502b1bddf130ccb3412ff347c1e13bce4e753193
+  command:
+    - llama-server
+  replicas: 1
+  priority: high
+  securityContext:
+    privileged: true
+  nodeSelector:
+    topology.kubernetes.io/gpus: amd
+  tolerations:
+    - key: llm-workload
+      operator: Exists
+      effect: NoSchedule
+  contextSize: 262144
+  parallelSlots: 2
+  flashAttention: true
+  jinja: true
+  cacheTypeK: q8_0
+  cacheTypeV: q8_0
+  reasoningBudget: 16384
+  reasoningBudgetMessage: "Stop reasoning and produce the implementation, tool call, or final answer."
+  batchSize: 6144
+  uBatchSize: 2048
+  resources:
+    cpu: "500m"
+    memory: 20Gi
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  extraArgs:
+    - --alias
+    - self-hosted
+    - --mmproj
+    - /model-source/qwen3.6-35b-a3b-q5/mmproj-F16.gguf
+    - --cont-batching
+    - --spec-type
+    - draft-mtp
+    - --spec-draft-p-min
+    - "0.75"
+    - --spec-draft-n-max
+    - "3"
+    - --spec-draft-type-k
+    - q8_0
+    - --spec-draft-type-v
+    - q8_0
+    - -sps
+    - "0.90"
+    - --cache-prompt
+    - --kv-unified
+    - --image-min-tokens
+    - "1024"
+    - --temp
+    - "0.6"
+    - --top-p
+    - "0.95"
+    - --top-k
+    - "20"
+    - --min-p
+    - "0"
+    - --presence-penalty
+    - "0.5"
+    - --repeat-penalty
+    - "1.03"
+    - --threads
+    - "16"
+    - --threads-batch
+    - "21"
+    - --no-mmap
+    - --chat-template-kwargs
+    - '{"preserve_thinking":true}'
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 360
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 6
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 6
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: llama-strix-b
+  labels:
+    krr/ignore: "true"
+spec:
+  modelRef: qwen3.6-35b-a3b-q5
+  runtime: llamacpp
+  image: docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:f6f4e29550896c0f810740c0502b1bddf130ccb3412ff347c1e13bce4e753193
+  command:
+    - llama-server
+  replicas: 1
+  priority: high
+  securityContext:
+    privileged: true
+  nodeSelector:
+    topology.kubernetes.io/gpus: amd
+  tolerations:
+    - key: llm-workload
+      operator: Exists
+      effect: NoSchedule
+  contextSize: 262144
+  parallelSlots: 2
+  flashAttention: true
+  jinja: true
+  cacheTypeK: q8_0
+  cacheTypeV: q8_0
+  reasoningBudget: 16384
+  reasoningBudgetMessage: "Stop reasoning and produce the implementation, tool call, or final answer."
+  batchSize: 6144
+  uBatchSize: 2048
+  resources:
+    cpu: "500m"
+    memory: 20Gi
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  extraArgs:
+    - --alias
+    - self-hosted
+    - --mmproj
+    - /model-source/qwen3.6-35b-a3b-q5/mmproj-F16.gguf
+    - --cont-batching
+    - --spec-type
+    - draft-mtp
+    - --spec-draft-p-min
+    - "0.75"
+    - --spec-draft-n-max
+    - "3"
+    - --spec-draft-type-k
+    - q8_0
+    - --spec-draft-type-v
+    - q8_0
+    - -sps
+    - "0.90"
+    - --cache-prompt
+    - --kv-unified
+    - --image-min-tokens
+    - "1024"
+    - --temp
+    - "0.6"
+    - --top-p
+    - "0.95"
+    - --top-k
+    - "20"
+    - --min-p
+    - "0"
+    - --presence-penalty
+    - "0.5"
+    - --repeat-penalty
+    - "1.03"
+    - --threads
+    - "16"
+    - --threads-batch
+    - "21"
+    - --no-mmap
+    - --chat-template-kwargs
+    - '{"preserve_thinking":true}'
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 360
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 6
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 6

--- a/kubernetes/apps/main/llm/llmkube.yaml
+++ b/kubernetes/apps/main/llm/llmkube.yaml
@@ -142,3 +142,30 @@ spec:
     name: flux-system
     namespace: flux-system
   wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: stage-qwen3-6-35b-q5
+spec:
+  dependsOn:
+    - name: llmkube-models
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/llmkube/stage
+  postBuild:
+    substitute:
+      MODEL_SLUG: qwen3-6-35b-q5
+      MODEL_REPO: unsloth/Qwen3.6-35B-A3B-MTP-GGUF
+      MODEL_FILES: Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf mmproj-F16.gguf
+      MODEL_DIR: qwen3.6-35b-a3b-q5
+      MODEL_CLAIM: llm-models
+      STAGE_NODE_KEY: topology.kubernetes.io/gpus
+      STAGE_NODE_VALUE: amd
+      STAGE_DEADLINE: "10800"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
## What

Swap the single **122B-A10B** on skirk for **two Qwen3.6-35B-A3B UD-Q5_K_XL** instances — trading peak intelligence for concurrency + speed. Rationale: the 3090 dense 27B already out-classes the 122B on most axes, so the 122B's only edge was moot; 35B is ~2× the TG and two of them give real concurrency.

## Shape
- **`llama-strix-35b-q5.yaml`** (new): one `Model` (Q5_K_XL) + two `InferenceService`s `llama-strix-a` / `llama-strix-b`, each **262k ctx × 2 slots, MTP (draft-mtp), ROCm**. Both share the APU via the `devic.es/rocm` count:2 plugin (one claim each).
- **litellm `self-hosted`** = two deployments (`llama-strix-a`/`-b`), `order:1` → **least-busy load-balances across them at the request level** (no nginx) ⇒ 2 instances × 2 slots = **4 concurrent**.
- **stage** `stage-qwen3-6-35b-q5` → Q5 GGUF to `llm-models/qwen3.6-35b-a3b-q5` (skirk-pinned). Q8 stage left intact for revert.
- kustomization toggled: 122B + 35B-Q8 + ROCm review out, 2×35B in. Review stays on the 3090 Qwen.

## To watch
- **RAM is the open question** — 2× Q5 weights (~50GB) + 2 instances × 262k×2-slot KV. Curious where UMA lands; if it's too tight, drop per-slot ctx or slots.
- **Verify llmkube allows 2 InferenceServices sharing one `modelRef`** (1 Model, 2 services) — if it objects, split into two Models.
- This is concurrency/throughput-oriented, not single-stream latency (per-request stays ~35B speed; aggregate is the win for cron/agent fan-out).

## Notes
- Also carries the pending **`nvidia`/`review` → 131072/2-slot** litellm alignment that was in the working tree (correct + wanted, just hadn't been committed).
- Revert: kustomization toggle back to `llama-strix.yaml` (Q8) or `llama-strix-122b.yaml`, and restore the single `self-hosted` litellm deployment.