### PR TITLE
feat(observability): add drm-exporter-amd for skirk

### DIFF
--- a/kubernetes/apps/base/kube-system/generic-device-plugin/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/generic-device-plugin/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
               tag: latest@sha256:dc192e164c69b03f156765793a1be62ca437709ae477b27ca7d8f3dcf5021576
             args:
               - --device
-              - '{"name":"rocm","groups":[{"count":2,"paths":[{"path":"/dev/kfd"},{"path":"/dev/dri/renderD128"}]}]}'
+              - '{"name":"rocm","groups":[{"count":3,"paths":[{"path":"/dev/kfd"},{"path":"/dev/dri/renderD128"}]}]}'
             securityContext:
               privileged: true
             resources:

--- a/kubernetes/apps/base/observability/exporters/drm-exporter-amd/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/drm-exporter-amd/helmrelease.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: drm-exporter-amd
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: drm-exporter
+  interval: 15m
+  dependsOn:
+    - name: generic-device-plugin
+      namespace: kube-system
+  values:
+    fullnameOverride: drm-exporter-amd
+    config:
+      logLevel: info
+    securityContext:
+      privileged: false
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: [ALL]
+        add: []
+    monitoring:
+      serviceMonitor:
+        enabled: true
+        relabelings:
+          - sourceLabels: [__meta_kubernetes_endpoint_node_name]
+            targetLabel: nodename
+      dashboards:
+        enabled: false
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 64Mi
+        devic.es/rocm: 1
+    nodeSelector:
+      topology.kubernetes.io/gpus: amd
+    tolerations:
+      - key: llm-workload
+        operator: Exists
+        effect: NoSchedule

--- a/kubernetes/apps/base/observability/exporters/drm-exporter-amd/kustomization.yaml
+++ b/kubernetes/apps/base/observability/exporters/drm-exporter-amd/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/main/observability/exporters/drm-exporter-amd.yaml
+++ b/kubernetes/apps/main/observability/exporters/drm-exporter-amd.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: drm-exporter-amd
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/observability/exporters/drm-exporter-amd
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/exporters/kustomization.yaml
+++ b/kubernetes/apps/main/observability/exporters/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./blackbox-exporter.yaml
   - ./dcgm-exporter.yaml
   - ./drm-exporter.yaml
+  - ./drm-exporter-amd.yaml
   - ./blackbox-exporter-probes.yaml
   - ./hoymiles-exporter.yaml
   - ./nut-exporter.yaml


### PR DESCRIPTION
`drm-exporter` reaches Intel iGPUs through a `gpu.intel.com` DRA claim, which skirk's AMD APU can't satisfy (it's exposed via the squat generic-device-plugin, not DRA) — and the DaemonSet only tolerates the control-plane taint, so it never lands on skirk anyway. A single release can't do both: the per-node access paths (DRA claim + `PERFMON` vs. device-plugin request) are mutually exclusive in one pod template.

So this adds a second, skirk-scoped release alongside the existing one, mirroring how `rocm-smi-exporter` is deployed.

- **`drm-exporter-amd`** — reuses the existing `drm-exporter` OCIRepository; `nodeSelector: topology.kubernetes.io/gpus=amd` + `llm-workload` toleration. Gets `/dev/dri` via `devic.es/rocm: 1` (device plugin injects `renderD128`+`kfd` with a cgroup grant) — no DRA, no privileged, no hostPath. Runs root with `drop: [ALL]` (Intel's `PERFMON`/`SYS_RAWIO` caps are unneeded on AMD). Dashboard render disabled (the Intel release already ships the shared one, grouped by node).
- **generic-device-plugin** — `rocm` group count `2 → 3` so the exporter slot doesn't starve llama-strix/llama-review.

Verified `kustomize build` + a `helm template` render: no `resourceClaims`, no `dev-dri` hostPath, device request present, `/sys` mounted.

Follow-up (separate PR, once metrics are confirmed flowing): migrate `llm-rocm-node.json` off `rocm_smi_*` to `drm_*` and retire `rocm-smi-exporter`.