### PR TITLE
chore(renovate): config hygiene — manager scoping, operator changelog, fileMatch migration

### DIFF
--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -10,7 +10,7 @@
         // foobar_version: v1.0.0
         // # renovate: datasource=docker depName=ghcr.io/foo/bar
         // FOOBAR_VERSION=v1.0.0
-        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n.+(:\\s|=)(&\\S+\\s)?(?<currentValue>\\S+)",
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n.+(:\\s|=)(&\\S+\\s)?[\"']?(?<currentValue>[^\"'\\s]+)[\"']?",
       ],
       datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
     },

--- a/.renovate/minecraft.json5
+++ b/.renovate/minecraft.json5
@@ -4,7 +4,7 @@
     {
       customType: "regex",
       description: "Track Minecraft release versions in HelmRelease files",
-      fileMatch: ["(^|/)helmrelease\\.ya?ml$"],
+      managerFilePatterns: ["/(^|/)helmrelease\\.ya?ml$/"],
       matchStrings: [
         "# renovate: datasource=custom\\.minecraft-release\\s+version:\\s+[\"']?(?<currentValue>[^\"'\\s]+)[\"']?",
       ],
@@ -15,7 +15,7 @@
     {
       customType: "regex",
       description: "Track Minecraft snapshot versions in HelmRelease files",
-      fileMatch: ["(^|/)helmrelease\\.ya?ml$"],
+      managerFilePatterns: ["/(^|/)helmrelease\\.ya?ml$/"],
       matchStrings: [
         "# renovate: datasource=custom\\.minecraft-snapshot\\s+version:\\s+[\"']?(?<currentValue>[^\"'\\s]+)[\"']?",
       ],

--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -7,5 +7,11 @@
       matchManagers: ["helmfile"],
       overrideDepName: "{{packageName}}",
     },
+    {
+      description: "Override Renovate Operator source",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/mogenius/helm-charts/renovate-operator"],
+      sourceUrl: "https://github.com/mogenius/renovate-operator",
+    },
   ],
 }

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -17,9 +17,9 @@
   ],
   ignorePaths: ["**/*.sops.*", "**/resources/**"],
   flux: {
-    managerFilePatterns: ["/\\.yaml(?:\\.j2)?$/"],
+    managerFilePatterns: ["/^kubernetes/.+\\.yaml(?:\\.j2)?$/"],
   },
   kubernetes: {
-    managerFilePatterns: ["/\\.yaml(?:\\.j2)?$/"],
+    managerFilePatterns: ["/^kubernetes/.+\\.yaml(?:\\.j2)?$/"],
   },
 }


### PR DESCRIPTION
## Summary
- Anchor the built-in `flux` and `kubernetes` `managerFilePatterns` to `^kubernetes/` (matches bjw-s). They currently scan every `.yaml`/`.yaml.j2` in the repo; all Flux/Kustomize resources live under `kubernetes/`.
- Add a `sourceUrl` override mapping `ghcr.io/mogenius/helm-charts/renovate-operator` to `github.com/mogenius/renovate-operator` so the operator's update PRs resolve release notes.
- Migrate `minecraft.json5` from the deprecated `fileMatch` to `managerFilePatterns` (slash-wrapped to keep regex semantics) — the rest of the repo already uses the new key.
- Strip surrounding quotes in the annotated-dependency custom manager, matching `home-operations/renovate-config`: quoted values (`foo_version: "v1.0.0"`) were capturing the quotes into `currentValue`.

## Notes
- Talos machineconfigs (`talos/*.yaml.j2`) and the volsync taskfile template stay with the custom managers, which keep their own broader patterns — confirmed no Flux/k8s resources exist outside `kubernetes/`.

## Verification
- JSON5 of all edited files parses clean.