### PR TITLE
feat(kube-system): add AMD GPU DRA driver

### DIFF
--- a/kubernetes/apps/base/kube-system/k8s-gpu-dra-driver/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/k8s-gpu-dra-driver/helmrelease.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: k8s-gpu-dra-driver
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: k8s-gpu-dra-driver
+  interval: 1h
+  values:
+    cdi:
+      dynamicPath: /run/cdi
+    kubeletPlugin:
+      nodeSelector:
+        topology.kubernetes.io/gpus: amd
+      tolerations:
+        - key: llm-workload
+          operator: Exists
+          effect: NoSchedule

--- a/kubernetes/apps/base/kube-system/k8s-gpu-dra-driver/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/k8s-gpu-dra-driver/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/kube-system/k8s-gpu-dra-driver/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-system/k8s-gpu-dra-driver/ocirepository.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: k8s-gpu-dra-driver
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v0.1.0
+  url: oci://ghcr.io/buroa/helm/k8s-gpu-dra-driver

--- a/kubernetes/apps/main/kube-system/k8s-gpu-dra-driver.yaml
+++ b/kubernetes/apps/main/kube-system/k8s-gpu-dra-driver.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: k8s-gpu-dra-driver
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/kube-system/k8s-gpu-dra-driver
+  wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/kube-system/kustomization.yaml
+++ b/kubernetes/apps/main/kube-system/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./coredns.yaml
   - ./irqbalance.yaml
   - ./intel-gpu-resource-driver.yaml
+  - ./k8s-gpu-dra-driver.yaml
   - ./metrics-server.yaml
   - ./nvidia-device-plugin.yaml
   - ./nvidia-power-limit.yaml


### PR DESCRIPTION
Deploys [ROCm/k8s-gpu-dra-driver](https://github.com/ROCm/k8s-gpu-dra-driver) via buroa's chart mirror (`oci://ghcr.io/buroa/helm/k8s-gpu-dra-driver` `v0.1.0`, until upstream cuts a release) to advertise skirk's Strix Halo APU through DRA — the prerequisite for moving the `llama-strix` models off the squat `devic.es/rocm` shim onto `hardware.gpu.resourceClaims` (now that LLMKube 0.8.9 supports DRA).

Mirrors the existing `intel-gpu-resource-driver` structure (OCIRepository → HelmRelease → aggregated ks).

- Kubelet plugin pinned to the AMD node (`topology.kubernetes.io/gpus: amd`), tolerates the `llm-workload` taint.
- `cdi.dynamicPath: /run/cdi` (Talos); webhook left disabled (buroa default).
- Creates the `gpu.amd.com` DeviceClass.

## Safe to land alone

**Inert until something claims `gpu.amd.com`** — the strix models still use squat, so nothing changes for running workloads. It just stands up the driver + publishes ResourceSlices.

## Next (separate PR)

1. Verify the driver publishes a ResourceSlice for the APU on skirk (the open question — does the ROCm driver enumerate the integrated gfx1151?).
2. Swap `llama-strix-a/b` to `resourceClaims: gpu.amd.com` (with a shared claim for the 2-pods-on-1-APU case), then retire the squat generic-device-plugin.

## Validation

- `kustomize build` of the base dir and the kube-system aggregation (Flux load-restrictor) both pass; ks renders with `targetNamespace: kube-system`.
- HelmRelease + OCIRepository pass `kubectl apply --dry-run=server`.