### PR TITLE
feat(llm): swap llama-strix to AMD DRA, off the squat shim

### DIFF
--- a/kubernetes/apps/base/llm/llmkube/models/llama-strix-35b-q5.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/llama-strix-35b-q5.yaml
@@ -1,4 +1,18 @@
 ---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: llama-strix-gpu
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.amd.com
+            adminAccess: true
+            allocationMode: All
+---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
 metadata:
@@ -12,10 +26,10 @@ spec:
     gpu:
       enabled: true
       vendor: amd
-      count: 1
       layers: 99
-      resourceName: devic.es/rocm
-      resourceClaims: []
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: llama-strix-gpu
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService


### PR DESCRIPTION
Moves the active strix model (`qwen3.6-35b-a3b-q5` → `llama-strix-a/b`) off the squat `devic.es/rocm` plugin onto DRA, now that the `gpu.amd.com` driver (#7699) enumerates skirk's Strix Halo APU:

```
ResourceSlice 00000-gpu.amd.com-skirk: device gpu-0-128 (amdgpu, 40 CU, 80 SIMD, 124Gi)
```

- New `llama-strix-gpu` ResourceClaimTemplate: `gpu.amd.com`, `adminAccess: true` + `allocationMode: All` so **both** InferenceServices share the single APU device — the same primitive your Intel embed/rerank RCT already uses successfully in `llm`.
- Model `hardware.gpu`: drop `resourceName`/`count`/the `resourceClaims: []` CEL-bug workaround; request the DRA claim. The claim trips LLMKube's GPU-args gate, so `--n-gpu-layers 99` (full offload) still emits.

## Watch on merge

Both strix pods restart and must come up on DRA. The unverified bit is **`adminAccess` sharing on the AMD driver specifically** (proven on Intel here). If a pod stays Pending or the ROCm image can't reach the device via CDI, **rollback is `git revert`** — squat is still installed (now inert), so reverting the Model restores `resourceName: devic.es/rocm` and it's back immediately.

Validated: server-side apply dry-run (mirrors Flux) succeeds for the RCT, Model, and both InferenceServices; `kustomize build` clean.

## Follow-ups

- Retire the squat generic-device-plugin once both pods are confirmed serving on DRA.
- The commented-out 35B-Q8 alt still references squat — convert when re-enabled.