### PR TITLE
refac(llm): pull llmkube operator from OCIRepository

### DIFF
--- a/kubernetes/apps/base/llm/llmkube/README.md
+++ b/kubernetes/apps/base/llm/llmkube/README.md
@@ -10,7 +10,7 @@ probes, endpoint) — one file per model under `models/`:
 
 ```
 llmkube/
-  helmrepository.yaml   helmrelease.yaml   kustomization.yaml   # the operator
+  ocirepository.yaml    helmrelease.yaml   kustomization.yaml   # the operator
   models/
     kustomization.yaml        # lists the active model files + the shared ServiceMonitor
     servicemonitor.yaml       # one SM scrapes every InferenceService (job = service name)

--- a/kubernetes/apps/base/llm/llmkube/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/llmkube/helmrelease.yaml
@@ -6,13 +6,9 @@ metadata:
   name: llmkube
 spec:
   interval: 1h
-  chart:
-    spec:
-      chart: llmkube
-      version: 0.8.11
-      sourceRef:
-        kind: HelmRepository
-        name: llmkube
+  chartRef:
+    kind: OCIRepository
+    name: llmkube
   install:
     remediation:
       retries: 3

--- a/kubernetes/apps/base/llm/llmkube/helmrepository.yaml
+++ b/kubernetes/apps/base/llm/llmkube/helmrepository.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/helmrepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: llmkube
-spec:
-  interval: 1h
-  url: https://defilantech.github.io/LLMKube/

--- a/kubernetes/apps/base/llm/llmkube/kustomization.yaml
+++ b/kubernetes/apps/base/llm/llmkube/kustomization.yaml
@@ -3,5 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./helmrepository.yaml
+  - ./ocirepository.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/base/llm/llmkube/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/llmkube/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: llmkube
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.8.11
+  url: oci://ghcr.io/defilantech/charts/llmkube


### PR DESCRIPTION
LLMKube now ships its Helm chart as an OCI artifact, so swap the operator's source off the github.io HelmRepository.

- `HelmRepository` (`https://defilantech.github.io/LLMKube/`) → `OCIRepository` `oci://ghcr.io/defilantech/charts/llmkube`, `ref.tag: 0.8.11` (version now pins on the OCIRepository tag; renovate tracks it there).
- HelmRelease points at it via `chartRef` instead of `chart.spec`.

Verified `0.8.11` exists on ghcr with the correct Helm chart media types; `kustomize build` + server-side dry-run pass. Matches the repo's OCI-source preference (intel driver, k8s-gpu-dra-driver, charts-mirror).