### PR TITLE
refactor(kubernetes): split inline OCIRepository into dedicated files

### DIFF
--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -210,5 +210,6 @@ Verify that:
 ## Notes
 
 - Do not create a per-app `ocirepository.yaml` for `app-template` apps in this repository.
+- If an app uses a non-`app-template` chart and needs its own `OCIRepository`, put it in a dedicated `ocirepository.yaml` file alongside `helmrelease.yaml` (never inline in `helmrelease.yaml`) and add `./ocirepository.yaml` to the `kustomization.yaml`.
 - Prefer minimal scaffolding that matches existing apps in the same namespace.
 - If the workload is not a good fit for `app-template`, stop and ask the user before continuing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,7 @@ When reviewing Renovate PRs, enforce these criteria. Reviews may include konflat
 - All applications MUST use `HelmRelease` via Flux, not raw manifests
 - HelmReleases MUST use `spec.chartRef` pointing to an `OCIRepository` with a pinned `ref.tag`. The only exception is `llmkube`, which uses the legacy `spec.chart` pattern.
 - For `app-template`-based apps, reference the shared `OCIRepository` named `app-template` (injected by the namespace component). Do not create per-app `OCIRepository` resources for `app-template`.
+- Per-app `OCIRepository` resources (for non-`app-template` charts) MUST live in a dedicated `ocirepository.yaml` file alongside the `HelmRelease`, not inline in `helmrelease.yaml`. Add `./ocirepository.yaml` to the app's `kustomization.yaml`.
 - Must include `spec.interval` for reconciliation frequency
 - Resource limits (CPU/memory) SHOULD be specified for production workloads, but this is not a hard requirement
 - `valuesFrom` should reference ConfigMaps/Secrets, not inline values

--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: gha-runner-scale-set-controller
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.14.2
-  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/app/kustomization.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/app/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gha-runner-scale-set-controller
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.2
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller

--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners/helmrelease.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: gha-runner-scale-set
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.14.2
-  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners/kustomization.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners/ocirepository.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gha-runner-scale-set
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.2
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set

--- a/kubernetes/apps/base/cert-manager/cert-manager/helmrelease.yaml
+++ b/kubernetes/apps/base/cert-manager/cert-manager/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: cert-manager
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: v1.20.2
-  url: oci://quay.io/jetstack/charts/cert-manager
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/cert-manager/cert-manager/kustomization.yaml
+++ b/kubernetes/apps/base/cert-manager/cert-manager/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/base/cert-manager/cert-manager/ocirepository.yaml
+++ b/kubernetes/apps/base/cert-manager/cert-manager/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cert-manager
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.20.2
+  url: oci://quay.io/jetstack/charts/cert-manager

--- a/kubernetes/apps/base/database/cloudnative-pg/helmrelease.yaml
+++ b/kubernetes/apps/base/database/cloudnative-pg/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: cloudnative-pg
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.28.3
-  url: oci://ghcr.io/cloudnative-pg/charts/cloudnative-pg
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/database/cloudnative-pg/kustomization.yaml
+++ b/kubernetes/apps/base/database/cloudnative-pg/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/database/cloudnative-pg/ocirepository.yaml
+++ b/kubernetes/apps/base/database/cloudnative-pg/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cloudnative-pg
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.28.3
+  url: oci://ghcr.io/cloudnative-pg/charts/cloudnative-pg

--- a/kubernetes/apps/base/database/dragonfly/helmrelease.yaml
+++ b/kubernetes/apps/base/database/dragonfly/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: dragonfly-operator
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: v1.6.1
-  url: oci://ghcr.io/dragonflydb/dragonfly-operator/helm/dragonfly-operator
----
 # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/database/dragonfly/kustomization.yaml
+++ b/kubernetes/apps/base/database/dragonfly/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/database/dragonfly/ocirepository.yaml
+++ b/kubernetes/apps/base/database/dragonfly/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dragonfly-operator
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.6.1
+  url: oci://ghcr.io/dragonflydb/dragonfly-operator/helm/dragonfly-operator

--- a/kubernetes/apps/base/external-secrets/external-secrets/helmrelease.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: external-secrets
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 2.6.0
-  url: oci://ghcr.io/external-secrets/charts/external-secrets
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/external-secrets/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/external-secrets/external-secrets/ocirepository.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: external-secrets
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2.6.0
+  url: oci://ghcr.io/external-secrets/charts/external-secrets

--- a/kubernetes/apps/base/external-secrets/onepassword-connect/helmrelease.yaml
+++ b/kubernetes/apps/base/external-secrets/onepassword-connect/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: onepassword-connect
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 2.4.1
-  url: oci://ghcr.io/1password/connect
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/external-secrets/onepassword-connect/kustomization.yaml
+++ b/kubernetes/apps/base/external-secrets/onepassword-connect/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./clustersecretstore.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/external-secrets/onepassword-connect/ocirepository.yaml
+++ b/kubernetes/apps/base/external-secrets/onepassword-connect/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: onepassword-connect
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2.4.1
+  url: oci://ghcr.io/1password/connect

--- a/kubernetes/apps/base/flux-system/flux-operator/helmrelease.yaml
+++ b/kubernetes/apps/base/flux-system/flux-operator/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: flux-operator
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.52.0
-  url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/flux-system/flux-operator/kustomization.yaml
+++ b/kubernetes/apps/base/flux-system/flux-operator/kustomization.yaml
@@ -4,4 +4,5 @@ namespace: flux-system
 resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./podmonitor.yaml

--- a/kubernetes/apps/base/flux-system/flux-operator/ocirepository.yaml
+++ b/kubernetes/apps/base/flux-system/flux-operator/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-operator
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.52.0
+  url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator

--- a/kubernetes/apps/base/flux-system/headlamp/helmrelease.yaml
+++ b/kubernetes/apps/base/flux-system/headlamp/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: headlamp
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.43.0
-  url: oci://ghcr.io/home-operations/charts-mirror/headlamp
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/flux-system/headlamp/kustomization.yaml
+++ b/kubernetes/apps/base/flux-system/headlamp/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml
+  - ./ocirepository.yaml
   - ./pushsecret.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/base/flux-system/headlamp/ocirepository.yaml
+++ b/kubernetes/apps/base/flux-system/headlamp/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: headlamp
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.43.0
+  url: oci://ghcr.io/home-operations/charts-mirror/headlamp

--- a/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml
+++ b/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: konflate
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.2.31
-  url: oci://ghcr.io/home-operations/charts/konflate
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/flux-system/konflate/kustomization.yaml
+++ b/kubernetes/apps/base/flux-system/konflate/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/flux-system/konflate/ocirepository.yaml
+++ b/kubernetes/apps/base/flux-system/konflate/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: konflate
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.2.31
+  url: oci://ghcr.io/home-operations/charts/konflate

--- a/kubernetes/apps/base/flux-system/tofu-controller/helmrelease.yaml
+++ b/kubernetes/apps/base/flux-system/tofu-controller/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: tofu-controller
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.16.4
-  url: oci://ghcr.io/flux-iac/charts/tofu-controller
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/flux-system/tofu-controller/kustomization.yaml
+++ b/kubernetes/apps/base/flux-system/tofu-controller/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/flux-system/tofu-controller/ocirepository.yaml
+++ b/kubernetes/apps/base/flux-system/tofu-controller/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tofu-controller
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.16.4
+  url: oci://ghcr.io/flux-iac/charts/tofu-controller

--- a/kubernetes/apps/base/games/minecraft/cobbleverse/helmrelease.yaml
+++ b/kubernetes/apps/base/games/minecraft/cobbleverse/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: minecraft-cobbleverse
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 5.1.3
-  url: oci://ghcr.io/itzg/minecraft-server-charts/minecraft
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/games/minecraft/cobbleverse/kustomization.yaml
+++ b/kubernetes/apps/base/games/minecraft/cobbleverse/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./dnsendpoint.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/games/minecraft/cobbleverse/ocirepository.yaml
+++ b/kubernetes/apps/base/games/minecraft/cobbleverse/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: minecraft-cobbleverse
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.3
+  url: oci://ghcr.io/itzg/minecraft-server-charts/minecraft

--- a/kubernetes/apps/base/games/minecraft/create/helmrelease.yaml
+++ b/kubernetes/apps/base/games/minecraft/create/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: minecraft
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 5.1.3
-  url: oci://ghcr.io/itzg/minecraft-server-charts/minecraft
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/games/minecraft/create/kustomization.yaml
+++ b/kubernetes/apps/base/games/minecraft/create/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/games/minecraft/create/ocirepository.yaml
+++ b/kubernetes/apps/base/games/minecraft/create/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: minecraft
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.3
+  url: oci://ghcr.io/itzg/minecraft-server-charts/minecraft

--- a/kubernetes/apps/base/games/minecraft/jellycraft/helmrelease.yaml
+++ b/kubernetes/apps/base/games/minecraft/jellycraft/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: minecraft-jellycraft
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 5.1.3
-  url: oci://ghcr.io/itzg/minecraft-server-charts/minecraft
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/games/minecraft/jellycraft/kustomization.yaml
+++ b/kubernetes/apps/base/games/minecraft/jellycraft/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./dnsendpoint.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/games/minecraft/jellycraft/ocirepository.yaml
+++ b/kubernetes/apps/base/games/minecraft/jellycraft/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: minecraft-jellycraft
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.3
+  url: oci://ghcr.io/itzg/minecraft-server-charts/minecraft

--- a/kubernetes/apps/base/games/minecraft/mc-router/helmrelease.yaml
+++ b/kubernetes/apps/base/games/minecraft/mc-router/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: mc-router
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 1.5.0
-  url: oci://ghcr.io/itzg/minecraft-server-charts/mc-router
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/games/minecraft/mc-router/kustomization.yaml
+++ b/kubernetes/apps/base/games/minecraft/mc-router/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./dnsendpoint.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/games/minecraft/mc-router/ocirepository.yaml
+++ b/kubernetes/apps/base/games/minecraft/mc-router/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mc-router
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.5.0
+  url: oci://ghcr.io/itzg/minecraft-server-charts/mc-router

--- a/kubernetes/apps/base/games/minecraft/takocraft/helmrelease.yaml
+++ b/kubernetes/apps/base/games/minecraft/takocraft/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: minecraft-takocraft
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 5.1.3
-  url: oci://ghcr.io/itzg/minecraft-server-charts/minecraft
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/games/minecraft/takocraft/kustomization.yaml
+++ b/kubernetes/apps/base/games/minecraft/takocraft/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/games/minecraft/takocraft/ocirepository.yaml
+++ b/kubernetes/apps/base/games/minecraft/takocraft/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: minecraft-takocraft
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.3
+  url: oci://ghcr.io/itzg/minecraft-server-charts/minecraft

--- a/kubernetes/apps/base/games/minecraft/vibecraft/helmrelease.yaml
+++ b/kubernetes/apps/base/games/minecraft/vibecraft/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: minecraft
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 5.1.3
-  url: oci://ghcr.io/itzg/minecraft-server-charts/minecraft
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/games/minecraft/vibecraft/kustomization.yaml
+++ b/kubernetes/apps/base/games/minecraft/vibecraft/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/games/minecraft/vibecraft/ocirepository.yaml
+++ b/kubernetes/apps/base/games/minecraft/vibecraft/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: minecraft
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.3
+  url: oci://ghcr.io/itzg/minecraft-server-charts/minecraft

--- a/kubernetes/apps/base/kube-system/cilium/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/cilium/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: cilium
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 1.19.5
-  url: oci://quay.io/cilium/charts/cilium
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/kube-system/cilium/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/cilium/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/kube-system/cilium/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-system/cilium/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cilium
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.19.5
+  url: oci://quay.io/cilium/charts/cilium

--- a/kubernetes/apps/base/kube-system/coredns/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/coredns/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: coredns
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 1.46.0
-  url: oci://ghcr.io/coredns/charts/coredns
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/kube-system/coredns/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/coredns/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/kube-system/coredns/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-system/coredns/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: coredns
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.46.0
+  url: oci://ghcr.io/coredns/charts/coredns

--- a/kubernetes/apps/base/kube-system/intel-gpu-resource-driver/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/intel-gpu-resource-driver/helmrelease.yaml
@@ -1,16 +1,3 @@
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: intel-gpu-resource-driver
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.11.0
-  url: oci://ghcr.io/intel/intel-resource-drivers-for-kubernetes/intel-gpu-resource-driver-chart
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/base/kube-system/intel-gpu-resource-driver/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/intel-gpu-resource-driver/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/kube-system/intel-gpu-resource-driver/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-system/intel-gpu-resource-driver/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: intel-gpu-resource-driver
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.11.0
+  url: oci://ghcr.io/intel/intel-resource-drivers-for-kubernetes/intel-gpu-resource-driver-chart

--- a/kubernetes/apps/base/kube-system/metrics-server/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/metrics-server/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: metrics-server
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 3.13.1
-  url: oci://ghcr.io/home-operations/charts-mirror/metrics-server
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/kube-system/metrics-server/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/metrics-server/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/kube-system/metrics-server/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-system/metrics-server/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: metrics-server
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 3.13.1
+  url: oci://ghcr.io/home-operations/charts-mirror/metrics-server

--- a/kubernetes/apps/base/kube-system/nvidia-device-plugin/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/nvidia-device-plugin/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: nvidia-device-plugin
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.19.2
-  url: oci://ghcr.io/home-operations/charts-mirror/nvidia-device-plugin
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/kube-system/nvidia-device-plugin/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/nvidia-device-plugin/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./runtimeclass.yaml

--- a/kubernetes/apps/base/kube-system/nvidia-device-plugin/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-system/nvidia-device-plugin/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: nvidia-device-plugin
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.19.2
+  url: oci://ghcr.io/home-operations/charts-mirror/nvidia-device-plugin

--- a/kubernetes/apps/base/kube-tools/descheduler/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-tools/descheduler/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: descheduler
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.36.0
-  url: oci://ghcr.io/home-operations/charts-mirror/descheduler
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/kube-tools/descheduler/kustomization.yaml
+++ b/kubernetes/apps/base/kube-tools/descheduler/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/kube-tools/descheduler/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-tools/descheduler/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: descheduler
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.36.0
+  url: oci://ghcr.io/home-operations/charts-mirror/descheduler

--- a/kubernetes/apps/base/kube-tools/reloader/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-tools/reloader/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: reloader
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 2.2.12
-  url: oci://ghcr.io/stakater/charts/reloader
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/kube-tools/reloader/kustomization.yaml
+++ b/kubernetes/apps/base/kube-tools/reloader/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/kube-tools/reloader/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-tools/reloader/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: reloader
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2.2.12
+  url: oci://ghcr.io/stakater/charts/reloader

--- a/kubernetes/apps/base/kube-tools/spegel/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-tools/spegel/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: spegel
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.7.2
-  url: oci://ghcr.io/spegel-org/helm-charts/spegel
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/kube-tools/spegel/kustomization.yaml
+++ b/kubernetes/apps/base/kube-tools/spegel/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/kube-tools/spegel/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-tools/spegel/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: spegel
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.7.2
+  url: oci://ghcr.io/spegel-org/helm-charts/spegel

--- a/kubernetes/apps/base/kube-tools/tuppr/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-tools/tuppr/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: tuppr
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.2.7
-  url: oci://ghcr.io/home-operations/charts/tuppr
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/kube-tools/tuppr/kustomization.yaml
+++ b/kubernetes/apps/base/kube-tools/tuppr/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/kube-tools/tuppr/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-tools/tuppr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tuppr
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.2.7
+  url: oci://ghcr.io/home-operations/charts/tuppr

--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: memini
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: v0.4.13
-  url: oci://registry.erwanleboucher.dev/eleboucher/charts/memini
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/llm/memini/kustomization.yaml
+++ b/kubernetes/apps/base/llm/memini/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/memini/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/memini/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: memini
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v0.4.13
+  url: oci://registry.erwanleboucher.dev/eleboucher/charts/memini

--- a/kubernetes/apps/base/llm/toolhive/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/toolhive/app/helmrelease.yaml
@@ -1,16 +1,3 @@
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: toolhive-operator
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.30.0
-  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/base/llm/toolhive/app/kustomization.yaml
+++ b/kubernetes/apps/base/llm/toolhive/app/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/toolhive/app/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/toolhive/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: toolhive-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.30.0
+  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator

--- a/kubernetes/apps/base/llm/toolhive/crds/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/toolhive/crds/helmrelease.yaml
@@ -1,16 +1,3 @@
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: toolhive-operator-crds
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.30.0
-  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/base/llm/toolhive/crds/kustomization.yaml
+++ b/kubernetes/apps/base/llm/toolhive/crds/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/toolhive/crds/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/toolhive/crds/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: toolhive-operator-crds
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.30.0
+  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds

--- a/kubernetes/apps/base/media/kyoo/helmrelease.yaml
+++ b/kubernetes/apps/base/media/kyoo/helmrelease.yaml
@@ -1,19 +1,4 @@
 ---
-# ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: kyoo
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 5.0.0
-  url: oci://ghcr.io/zoriya/helm-charts/kyoo
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/media/kyoo/kustomization.yaml
+++ b/kubernetes/apps/base/media/kyoo/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/kyoo/ocirepository.yaml
+++ b/kubernetes/apps/base/media/kyoo/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# ---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kyoo
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.0
+  url: oci://ghcr.io/zoriya/helm-charts/kyoo

--- a/kubernetes/apps/base/network/cloudflare-dns/helmrelease.yaml
+++ b/kubernetes/apps/base/network/cloudflare-dns/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: cloudflare-dns
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 1.21.1
-  url: oci://ghcr.io/home-operations/charts-mirror/external-dns
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/network/cloudflare-dns/kustomization.yaml
+++ b/kubernetes/apps/base/network/cloudflare-dns/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/base/network/cloudflare-dns/ocirepository.yaml
+++ b/kubernetes/apps/base/network/cloudflare-dns/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cloudflare-dns
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.21.1
+  url: oci://ghcr.io/home-operations/charts-mirror/external-dns

--- a/kubernetes/apps/base/network/echo/helmrelease.yaml
+++ b/kubernetes/apps/base/network/echo/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: echo
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.1.2
-  url: oci://ghcr.io/home-operations/charts/echo
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/network/echo/kustomization.yaml
+++ b/kubernetes/apps/base/network/echo/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/network/echo/ocirepository.yaml
+++ b/kubernetes/apps/base/network/echo/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: echo
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.2
+  url: oci://ghcr.io/home-operations/charts/echo

--- a/kubernetes/apps/base/network/envoy-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/base/network/envoy-gateway/app/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: envoy-gateway
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: v1.8.1
-  url: oci://mirror.gcr.io/envoyproxy/gateway-helm
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/network/envoy-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/base/network/envoy-gateway/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/network/envoy-gateway/app/ocirepository.yaml
+++ b/kubernetes/apps/base/network/envoy-gateway/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: envoy-gateway
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.8.1
+  url: oci://mirror.gcr.io/envoyproxy/gateway-helm

--- a/kubernetes/apps/base/network/multus/helmrelease.yaml
+++ b/kubernetes/apps/base/network/multus/helmrelease.yaml
@@ -1,16 +1,3 @@
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: multus
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 1.3.2
-  url: oci://ghcr.io/bjw-s-labs/helm/multus
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/base/network/multus/kustomization.yaml
+++ b/kubernetes/apps/base/network/multus/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/network/multus/ocirepository.yaml
+++ b/kubernetes/apps/base/network/multus/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: multus
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.3.2
+  url: oci://ghcr.io/bjw-s-labs/helm/multus

--- a/kubernetes/apps/base/network/unifi-dns/helmrelease.yaml
+++ b/kubernetes/apps/base/network/unifi-dns/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: unifi-dns
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 1.21.1
-  url: oci://ghcr.io/home-operations/charts-mirror/external-dns
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/network/unifi-dns/kustomization.yaml
+++ b/kubernetes/apps/base/network/unifi-dns/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/network/unifi-dns/ocirepository.yaml
+++ b/kubernetes/apps/base/network/unifi-dns/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: unifi-dns
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.21.1
+  url: oci://ghcr.io/home-operations/charts-mirror/external-dns

--- a/kubernetes/apps/base/observability/exporters/blackbox-exporter/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/blackbox-exporter/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: blackbox-exporter
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 11.13.0
-  url: oci://ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/observability/exporters/blackbox-exporter/kustomization.yaml
+++ b/kubernetes/apps/base/observability/exporters/blackbox-exporter/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/observability/exporters/blackbox-exporter/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/exporters/blackbox-exporter/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: blackbox-exporter
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 11.13.0
+  url: oci://ghcr.io/prometheus-community/charts/prometheus-blackbox-exporter

--- a/kubernetes/apps/base/observability/exporters/drm-exporter/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/drm-exporter/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: drm-exporter
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.2.3
-  url: oci://ghcr.io/home-operations/charts/drm-exporter
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/observability/exporters/drm-exporter/kustomization.yaml
+++ b/kubernetes/apps/base/observability/exporters/drm-exporter/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/observability/exporters/drm-exporter/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/exporters/drm-exporter/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: drm-exporter
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.2.3
+  url: oci://ghcr.io/home-operations/charts/drm-exporter

--- a/kubernetes/apps/base/observability/exporters/smartctl-exporter/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/smartctl-exporter/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: smartctl-exporter
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.17.1
-  url: oci://ghcr.io/prometheus-community/charts/prometheus-smartctl-exporter
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/observability/exporters/smartctl-exporter/kustomization.yaml
+++ b/kubernetes/apps/base/observability/exporters/smartctl-exporter/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/base/observability/exporters/smartctl-exporter/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/exporters/smartctl-exporter/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: smartctl-exporter
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.17.1
+  url: oci://ghcr.io/prometheus-community/charts/prometheus-smartctl-exporter

--- a/kubernetes/apps/base/observability/grafana/operator/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/grafana/operator/helmrelease.yaml
@@ -1,16 +1,3 @@
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: grafana-operator
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 5.24.0
-  url: oci://ghcr.io/grafana/helm-charts/grafana-operator
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/base/observability/grafana/operator/kustomization.yaml
+++ b/kubernetes/apps/base/observability/grafana/operator/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/observability/grafana/operator/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/grafana/operator/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: grafana-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.24.0
+  url: oci://ghcr.io/grafana/helm-charts/grafana-operator

--- a/kubernetes/apps/base/observability/kromgo/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/kromgo/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: kromgo
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.14.10
-  url: oci://ghcr.io/home-operations/charts/kromgo
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/observability/kromgo/kustomization.yaml
+++ b/kubernetes/apps/base/observability/kromgo/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/observability/kromgo/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/kromgo/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kromgo
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.10
+  url: oci://ghcr.io/home-operations/charts/kromgo

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: kube-prometheus-stack
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 86.3.2
-  url: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/kustomization.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
 configMapGenerator:
   - name: flux-metrics-configmap
     files:

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kube-prometheus-stack
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 86.3.2
+  url: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack

--- a/kubernetes/apps/base/observability/silence-operator/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/silence-operator/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: silence-operator
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.20.1
-  url: oci://gsoci.azurecr.io/charts/giantswarm/silence-operator
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/observability/silence-operator/kustomization.yaml
+++ b/kubernetes/apps/base/observability/silence-operator/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/observability/silence-operator/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/silence-operator/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: silence-operator
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.20.1
+  url: oci://gsoci.azurecr.io/charts/giantswarm/silence-operator

--- a/kubernetes/apps/base/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/victoria-logs/app/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: victoria-logs
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.13.8
-  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-single
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/observability/victoria-logs/app/kustomization.yaml
+++ b/kubernetes/apps/base/observability/victoria-logs/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./grafanadashboard.yaml
   - ./grafanadatasource.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/observability/victoria-logs/app/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/victoria-logs/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: victoria-logs
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.13.8
+  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-single

--- a/kubernetes/apps/base/observability/victoria-logs/collector/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/victoria-logs/collector/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: victoria-logs-collector
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.3.6
-  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-collector
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/observability/victoria-logs/collector/kustomization.yaml
+++ b/kubernetes/apps/base/observability/victoria-logs/collector/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/observability/victoria-logs/collector/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/victoria-logs/collector/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: victoria-logs-collector
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.3.6
+  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-collector

--- a/kubernetes/apps/base/renovate/renovate-operator/helmrelease.yaml
+++ b/kubernetes/apps/base/renovate/renovate-operator/helmrelease.yaml
@@ -1,16 +1,3 @@
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: renovate-operator
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 4.12.4
-  url: oci://ghcr.io/mogenius/helm-charts/renovate-operator
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/apps/base/renovate/renovate-operator/kustomization.yaml
+++ b/kubernetes/apps/base/renovate/renovate-operator/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/renovate/renovate-operator/ocirepository.yaml
+++ b/kubernetes/apps/base/renovate/renovate-operator/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: renovate-operator
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.12.4
+  url: oci://ghcr.io/mogenius/helm-charts/renovate-operator

--- a/kubernetes/apps/base/rook-ceph/ceph-csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/base/rook-ceph/ceph-csi-drivers/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: ceph-csi-drivers
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 1.0.1
-  url: oci://ghcr.io/home-operations/charts-mirror/ceph-csi-drivers
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/rook-ceph/ceph-csi-drivers/kustomization.yaml
+++ b/kubernetes/apps/base/rook-ceph/ceph-csi-drivers/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/rook-ceph/ceph-csi-drivers/ocirepository.yaml
+++ b/kubernetes/apps/base/rook-ceph/ceph-csi-drivers/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ceph-csi-drivers
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.0.1
+  url: oci://ghcr.io/home-operations/charts-mirror/ceph-csi-drivers

--- a/kubernetes/apps/base/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: rook-ceph
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: v1.20.1
-  url: oci://ghcr.io/rook/rook-ceph
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/rook-ceph/rook-ceph/app/kustomization.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/rook-ceph/rook-ceph/app/ocirepository.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rook-ceph
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.20.1
+  url: oci://ghcr.io/rook/rook-ceph

--- a/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: rook-ceph-cluster
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: v1.20.1
-  url: oci://ghcr.io/rook/rook-ceph-cluster
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/kustomization.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/ocirepository.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rook-ceph-cluster
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.20.1
+  url: oci://ghcr.io/rook/rook-ceph-cluster

--- a/kubernetes/apps/base/security/authentik/helmrelease.yaml
+++ b/kubernetes/apps/base/security/authentik/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: authentik
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 2026.5.3
-  url: oci://ghcr.io/goauthentik/helm-charts/authentik
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/security/authentik/kustomization.yaml
+++ b/kubernetes/apps/base/security/authentik/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/security/authentik/ocirepository.yaml
+++ b/kubernetes/apps/base/security/authentik/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: authentik
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2026.5.3
+  url: oci://ghcr.io/goauthentik/helm-charts/authentik

--- a/kubernetes/apps/base/storage/democratic-csi/helmrelease.yaml
+++ b/kubernetes/apps/base/storage/democratic-csi/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: democratic-csi
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.15.1
-  url: oci://ghcr.io/democratic-csi/charts/democratic-csi
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/storage/democratic-csi/kustomization.yaml
+++ b/kubernetes/apps/base/storage/democratic-csi/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/storage/democratic-csi/ocirepository.yaml
+++ b/kubernetes/apps/base/storage/democratic-csi/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: democratic-csi
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.15.1
+  url: oci://ghcr.io/democratic-csi/charts/democratic-csi

--- a/kubernetes/apps/base/storage/openebs/helmrelease.yaml
+++ b/kubernetes/apps/base/storage/openebs/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: openebs
-spec:
-  interval: 5m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 4.5.1
-  url: oci://ghcr.io/openebs/charts/openebs
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/storage/openebs/kustomization.yaml
+++ b/kubernetes/apps/base/storage/openebs/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/storage/openebs/ocirepository.yaml
+++ b/kubernetes/apps/base/storage/openebs/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: openebs
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.5.1
+  url: oci://ghcr.io/openebs/charts/openebs

--- a/kubernetes/apps/base/storage/snapshot-controller/helmrelease.yaml
+++ b/kubernetes/apps/base/storage/snapshot-controller/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: snapshot-controller
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 5.1.1
-  url: oci://ghcr.io/piraeusdatastore/helm-charts/snapshot-controller
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/storage/snapshot-controller/kustomization.yaml
+++ b/kubernetes/apps/base/storage/snapshot-controller/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/storage/snapshot-controller/ocirepository.yaml
+++ b/kubernetes/apps/base/storage/snapshot-controller/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: snapshot-controller
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.1
+  url: oci://ghcr.io/piraeusdatastore/helm-charts/snapshot-controller

--- a/kubernetes/apps/base/storage/volsync/helmrelease.yaml
+++ b/kubernetes/apps/base/storage/volsync/helmrelease.yaml
@@ -1,18 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata:
-  name: volsync
-spec:
-  interval: 15m
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 0.18.5
-  url: oci://ghcr.io/home-operations/charts-mirror/volsync-perfectra1n
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/kubernetes/apps/base/storage/volsync/kustomization.yaml
+++ b/kubernetes/apps/base/storage/volsync/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   # - ./mutatingadmissionpolicy.yaml
+  - ./ocirepository.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/base/storage/volsync/ocirepository.yaml
+++ b/kubernetes/apps/base/storage/volsync/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: volsync
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.18.5
+  url: oci://ghcr.io/home-operations/charts-mirror/volsync-perfectra1n


### PR DESCRIPTION
Splits per-app `OCIRepository` definitions out of `helmrelease.yaml` into a dedicated `ocirepository.yaml` in the same directory, matching the existing `gatus-sidecar` layout. The shared `app-template` `OCIRepository` (injected by the namespace component) is untouched.

## Changes
- 53 apps: moved the inline `OCIRepository` doc into `ocirepository.yaml`, added `./ocirepository.yaml` to each `kustomization.yaml` (alphabetical position).
- `AGENTS.md` + add-app skill: document that per-app `OCIRepository` resources live in a dedicated file, never inline.

## Verification
No-op on render: `kustomize build` output is byte-identical HEAD vs branch across all 53 apps.