### PR TITLE
refactor(kubernetes): give every app-template app its own OCIRepository

### DIFF
--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -12,8 +12,8 @@ This skill scaffolds a new application for this repository's Flux layout.
 - Base app manifests live in `kubernetes/apps/base/<namespace>/<app>/`
 - Cluster overlays live in `kubernetes/apps/<cluster>/<namespace>/`
 - Flux app manifests are named `kubernetes/apps/<cluster>/<namespace>/<app>.yaml`
-- Namespace and shared repositories come from `kubernetes/components/namespace`
-- `app-template` is referenced as `spec.chartRef.name: app-template`
+- The Namespace and alerting rules come from `kubernetes/components/namespace`
+- Every app declares its own per-app `OCIRepository` in `ocirepository.yaml`; `app-template` apps point `spec.chartRef.name` at that per-app repo (named after the app)
 - Secrets use `external-secrets` with the `onepassword` `ClusterSecretStore`
 
 ## Workflow
@@ -53,6 +53,7 @@ At minimum, create:
 
 - `kustomization.yaml`
 - `helmrelease.yaml`
+- `ocirepository.yaml`
 
 Optionally create:
 
@@ -70,9 +71,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
     - ./helmrelease.yaml
+    - ./ocirepository.yaml
 ```
 
-Add `./externalsecret.yaml` only if secrets are needed. Add other resource files only when required.
+Add `./externalsecret.yaml` only if secrets are needed. Add other resource files only when required. Keep the resource list alphabetized.
 
 #### `kubernetes/apps/base/<namespace>/<app>/helmrelease.yaml`
 
@@ -86,7 +88,7 @@ metadata:
 spec:
     chartRef:
         kind: OCIRepository
-        name: app-template
+        name: <app>
     dependsOn: []
     interval: 15m
     values:
@@ -126,6 +128,29 @@ spec:
 ```
 
 Adjust the template to match local patterns in the same namespace. Add `route`, `persistence`, `env`, `envFrom`, or extra manifests only when needed.
+
+#### `kubernetes/apps/base/<namespace>/<app>/ocirepository.yaml`
+
+For an `app-template` app, point at the shared chart with a per-app source named after the app:
+
+```yaml
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+    name: <app>
+spec:
+    interval: 5m
+    layerSelector:
+        mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+        operation: copy
+    ref:
+        tag: 5.0.1
+    url: oci://ghcr.io/bjw-s-labs/helm/app-template
+```
+
+For a non-`app-template` chart, set `url` and `ref.tag` to that chart's OCI source instead. `spec.chartRef.name` in the `HelmRelease` must match this `metadata.name`.
 
 #### `kubernetes/apps/base/<namespace>/<app>/externalsecret.yaml`
 
@@ -204,12 +229,12 @@ Verify that:
 1. The base app directory contains the expected files.
 2. Every selected cluster has an overlay app manifest.
 3. Every selected cluster overlay `kustomization.yaml` references the new app.
-4. The HelmRelease uses the shared `app-template` repository name rather than a per-app `OCIRepository`.
+4. The app has its own `ocirepository.yaml` (named after the app), it is listed in `kustomization.yaml`, and the HelmRelease's `spec.chartRef.name` matches it.
 5. No plain-text secrets were introduced.
 
 ## Notes
 
-- Do not create a per-app `ocirepository.yaml` for `app-template` apps in this repository.
-- If an app uses a non-`app-template` chart and needs its own `OCIRepository`, put it in a dedicated `ocirepository.yaml` file alongside `helmrelease.yaml` (never inline in `helmrelease.yaml`) and add `./ocirepository.yaml` to the `kustomization.yaml`.
+- Every app gets its own `ocirepository.yaml` (named after the app), including `app-template` apps. There is no shared/injected `app-template` `OCIRepository`.
+- Never put the `OCIRepository` inline in `helmrelease.yaml`; it lives in its own `ocirepository.yaml`.
 - Prefer minimal scaffolding that matches existing apps in the same namespace.
 - If the workload is not a good fit for `app-template`, stop and ask the user before continuing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Flux recursively searches `kubernetes/${cluster}/apps/` for `kustomization.yaml`
 - Apps use `HelmRelease` via Flux, rarely raw manifests
 - Clusters are mostly identical except for app selections and sizing
 - **AI instructions**: `.agents/instructions/pr-review.instructions.md` is the live system prompt for the AI PR reviewer. `.agents/instructions/sorting.instructions.md` defines YAML sorting rules (including `app-template`-specific ordering). When editing YAML, follow the sorting instructions.
-- **Namespace component**: `kubernetes/components/namespace/` injects the Namespace resource, alerting rules, and the shared `app-template` `OCIRepository` into every app via kustomize components.
+- **Namespace component**: `kubernetes/components/namespace/` injects the Namespace resource and alerting rules into every app via kustomize components. Helm chart sources are per-app: each app declares its own `OCIRepository` in `ocirepository.yaml`.
 - **Namespace replacement**: `kubernetes/components/replacements/ks.yaml` propagates `spec.targetNamespace` into Flux Kustomizations automatically.
 
 ## Common Operations
@@ -125,8 +125,7 @@ When reviewing Renovate PRs, enforce these criteria. Reviews may include konflat
 
 - All applications MUST use `HelmRelease` via Flux, not raw manifests
 - HelmReleases MUST use `spec.chartRef` pointing to an `OCIRepository` with a pinned `ref.tag`. The only exception is `llmkube`, which uses the legacy `spec.chart` pattern.
-- For `app-template`-based apps, reference the shared `OCIRepository` named `app-template` (injected by the namespace component). Do not create per-app `OCIRepository` resources for `app-template`.
-- Per-app `OCIRepository` resources (for non-`app-template` charts) MUST live in a dedicated `ocirepository.yaml` file alongside the `HelmRelease`, not inline in `helmrelease.yaml`. Add `./ocirepository.yaml` to the app's `kustomization.yaml`.
+- Every app (including `app-template`-based apps) defines its own per-app `OCIRepository` in a dedicated `ocirepository.yaml` alongside the `HelmRelease`, named after the app, with `./ocirepository.yaml` listed in the app's `kustomization.yaml`. Do not put the `OCIRepository` inline in `helmrelease.yaml`, and do not rely on a shared/injected `OCIRepository`.
 - Must include `spec.interval` for reconciliation frequency
 - Resource limits (CPU/memory) SHOULD be specified for production workloads, but this is not a hard requirement
 - `valuesFrom` should reference ConfigMaps/Secrets, not inline values

--- a/kubernetes/apps/base/downloads/autobrr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/autobrr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: autobrr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/autobrr/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/autobrr/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/base/downloads/autobrr/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/autobrr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: autobrr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/bazarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/bazarr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: bazarr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/bazarr/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/bazarr/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/downloads/bazarr/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/bazarr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: bazarr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/brrpolice/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/brrpolice/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: brrpolice
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/brrpolice/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/brrpolice/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/downloads/brrpolice/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/brrpolice/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: brrpolice
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/decluttarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/decluttarr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: decluttarr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/decluttarr/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/decluttarr/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/downloads/decluttarr/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/decluttarr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: decluttarr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/deduparr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/deduparr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: deduparr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/deduparr/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/deduparr/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/downloads/deduparr/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/deduparr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: deduparr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/flaresolverr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/flaresolverr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: flaresolverr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/flaresolverr/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/flaresolverr/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/downloads/flaresolverr/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/flaresolverr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flaresolverr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/kapowarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/kapowarr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: kapowarr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/kapowarr/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/kapowarr/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/downloads/kapowarr/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/kapowarr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kapowarr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/metube/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/metube/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: metube
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/metube/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/metube/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/downloads/metube/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/metube/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: metube
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/mylar/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/mylar/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: mylar
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/mylar/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/mylar/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/downloads/mylar/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/mylar/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mylar
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/pinchflat/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/pinchflat/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: pinchflat
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/pinchflat/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/pinchflat/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/downloads/pinchflat/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/pinchflat/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: pinchflat
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/prowlarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/prowlarr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: prowlarr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/prowlarr/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/prowlarr/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/downloads/prowlarr/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/prowlarr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: prowlarr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/qbittorrent/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/qbittorrent/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: qbittorrent
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/qbittorrent/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/qbittorrent/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/downloads/qbittorrent/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/qbittorrent/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: qbittorrent
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/qui/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/qui/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: qui
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/qui/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/qui/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/downloads/qui/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/qui/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: qui
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/radarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/radarr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: radarr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/radarr/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/radarr/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/base/downloads/radarr/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/radarr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: radarr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/recyclarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/recyclarr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: recyclarr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/recyclarr/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/recyclarr/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
 configMapGenerator:
   - name: recyclarr-configmap
     files:

--- a/kubernetes/apps/base/downloads/recyclarr/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/recyclarr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: recyclarr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/sabnzbd/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/sabnzbd/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: sabnzbd
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/sabnzbd/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/sabnzbd/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
 configMapGenerator:
   - name: sabnzbd-scripts
     files:

--- a/kubernetes/apps/base/downloads/sabnzbd/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/sabnzbd/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: sabnzbd
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/sonarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/sonarr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: sonarr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/sonarr/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/sonarr/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./pvc.yaml
 configMapGenerator:
   - name: sonarr-configmap

--- a/kubernetes/apps/base/downloads/sonarr/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/sonarr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: sonarr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/downloads/tdarr-node/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/tdarr-node/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: tdarr-node
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/downloads/tdarr-node/kustomization.yaml
+++ b/kubernetes/apps/base/downloads/tdarr-node/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/downloads/tdarr-node/ocirepository.yaml
+++ b/kubernetes/apps/base/downloads/tdarr-node/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tdarr-node
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/games/core-keeper/helmrelease.yaml
+++ b/kubernetes/apps/base/games/core-keeper/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: core-keeper
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/games/core-keeper/kustomization.yaml
+++ b/kubernetes/apps/base/games/core-keeper/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./dnsendpoint.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/base/games/core-keeper/ocirepository.yaml
+++ b/kubernetes/apps/base/games/core-keeper/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: core-keeper
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/games/enshrouded/helmrelease.yaml
+++ b/kubernetes/apps/base/games/enshrouded/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: enshrouded
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/games/enshrouded/kustomization.yaml
+++ b/kubernetes/apps/base/games/enshrouded/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./dnsendpoint.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/games/enshrouded/ocirepository.yaml
+++ b/kubernetes/apps/base/games/enshrouded/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: enshrouded
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/games/palworld/helmrelease.yaml
+++ b/kubernetes/apps/base/games/palworld/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: palworld
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/games/palworld/kustomization.yaml
+++ b/kubernetes/apps/base/games/palworld/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./dnsendpoint.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/base/games/palworld/ocirepository.yaml
+++ b/kubernetes/apps/base/games/palworld/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: palworld
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/games/romm/helmrelease.yaml
+++ b/kubernetes/apps/base/games/romm/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: romm
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/games/romm/kustomization.yaml
+++ b/kubernetes/apps/base/games/romm/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
 configMapGenerator:
   - name: romm-config
     files:

--- a/kubernetes/apps/base/games/romm/ocirepository.yaml
+++ b/kubernetes/apps/base/games/romm/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: romm
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/games/valheim/helmrelease.yaml
+++ b/kubernetes/apps/base/games/valheim/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: valheim
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/games/valheim/kustomization.yaml
+++ b/kubernetes/apps/base/games/valheim/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./dnsendpoint.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/games/valheim/ocirepository.yaml
+++ b/kubernetes/apps/base/games/valheim/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: valheim
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/games/vrising/helmrelease.yaml
+++ b/kubernetes/apps/base/games/vrising/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: vrising
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/games/vrising/kustomization.yaml
+++ b/kubernetes/apps/base/games/vrising/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./dnsendpoint.yaml
     # - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/base/games/vrising/ocirepository.yaml
+++ b/kubernetes/apps/base/games/vrising/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: vrising
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/home-automation/home-assistant/helmrelease.yaml
+++ b/kubernetes/apps/base/home-automation/home-assistant/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: home-assistant
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/home-automation/home-assistant/kustomization.yaml
+++ b/kubernetes/apps/base/home-automation/home-assistant/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/base/home-automation/home-assistant/ocirepository.yaml
+++ b/kubernetes/apps/base/home-automation/home-assistant/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: home-assistant
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/home-automation/hoymiles-mqtt/helmrelease.yaml
+++ b/kubernetes/apps/base/home-automation/hoymiles-mqtt/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: hoymiles-mqtt
   interval: 15m
   dependsOn:
     - name: mosquitto

--- a/kubernetes/apps/base/home-automation/hoymiles-mqtt/kustomization.yaml
+++ b/kubernetes/apps/base/home-automation/hoymiles-mqtt/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/home-automation/hoymiles-mqtt/ocirepository.yaml
+++ b/kubernetes/apps/base/home-automation/hoymiles-mqtt/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hoymiles-mqtt
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/home-automation/matter-server/helmrelease.yaml
+++ b/kubernetes/apps/base/home-automation/matter-server/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: matter-server
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/home-automation/matter-server/kustomization.yaml
+++ b/kubernetes/apps/base/home-automation/matter-server/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/home-automation/matter-server/ocirepository.yaml
+++ b/kubernetes/apps/base/home-automation/matter-server/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: matter-server
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/home-automation/mosquitto/helmrelease.yaml
+++ b/kubernetes/apps/base/home-automation/mosquitto/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: mosquitto
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/home-automation/mosquitto/kustomization.yaml
+++ b/kubernetes/apps/base/home-automation/mosquitto/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/home-automation/mosquitto/ocirepository.yaml
+++ b/kubernetes/apps/base/home-automation/mosquitto/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mosquitto
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/home-automation/rtlamr2mqtt/helmrelease.yaml
+++ b/kubernetes/apps/base/home-automation/rtlamr2mqtt/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: rtlamr2mqtt
   interval: 15m
   dependsOn:
     - name: mosquitto

--- a/kubernetes/apps/base/home-automation/rtlamr2mqtt/kustomization.yaml
+++ b/kubernetes/apps/base/home-automation/rtlamr2mqtt/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/home-automation/rtlamr2mqtt/ocirepository.yaml
+++ b/kubernetes/apps/base/home-automation/rtlamr2mqtt/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rtlamr2mqtt
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/home-automation/zigbee/helmrelease.yaml
+++ b/kubernetes/apps/base/home-automation/zigbee/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: zigbee
   interval: 15m
   dependsOn:
     - name: mosquitto

--- a/kubernetes/apps/base/home-automation/zigbee/kustomization.yaml
+++ b/kubernetes/apps/base/home-automation/zigbee/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/home-automation/zigbee/ocirepository.yaml
+++ b/kubernetes/apps/base/home-automation/zigbee/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: zigbee
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/kube-system/irqbalance/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/irqbalance/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: irqbalance
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/kube-system/irqbalance/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/irqbalance/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - ocirepository.yaml

--- a/kubernetes/apps/base/kube-system/irqbalance/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-system/irqbalance/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: irqbalance
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/kube-system/nvidia-power-limit/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/nvidia-power-limit/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: nvidia-power-limit
   interval: 1h
   values:
     defaultPodOptions:

--- a/kubernetes/apps/base/kube-system/nvidia-power-limit/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/nvidia-power-limit/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/kube-system/nvidia-power-limit/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-system/nvidia-power-limit/ocirepository.yaml
@@ -3,7 +3,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: app-template
+  name: nvidia-power-limit
 spec:
   interval: 5m
   layerSelector:

--- a/kubernetes/apps/base/llm/agentmemory/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/agentmemory/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: agentmemory
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/llm/agentmemory/kustomization.yaml
+++ b/kubernetes/apps/base/llm/agentmemory/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/agentmemory/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/agentmemory/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: agentmemory
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: comfyui
   dependsOn: []
   interval: 15m
   values:

--- a/kubernetes/apps/base/llm/comfyui/app/kustomization.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/comfyui/app/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: comfyui
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/comfyui/miso-gallery/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/comfyui/miso-gallery/helmrelease.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: miso-gallery
   interval: 15m
   values:
     defaultPodOptions:

--- a/kubernetes/apps/base/llm/comfyui/miso-gallery/kustomization.yaml
+++ b/kubernetes/apps/base/llm/comfyui/miso-gallery/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/comfyui/miso-gallery/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/comfyui/miso-gallery/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: miso-gallery
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/hermes/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/hermes/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: hermes
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/llm/hermes/kustomization.yaml
+++ b/kubernetes/apps/base/llm/hermes/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./configmap.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/hermes/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/hermes/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hermes
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: litellm
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/llm/litellm/app/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./servicemonitor.yaml
   - ./dashboard

--- a/kubernetes/apps/base/llm/litellm/app/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: litellm
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/litellm/llama-ryzen/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-ryzen/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: llama-ryzen
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/llm/litellm/llama-ryzen/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-ryzen/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./servicemonitor.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/base/llm/litellm/llama-ryzen/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-ryzen/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: llama-ryzen
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/open-webui/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/open-webui/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: open-webui
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/llm/open-webui/kustomization.yaml
+++ b/kubernetes/apps/base/llm/open-webui/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/open-webui/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/open-webui/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: open-webui
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: openclaw
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/llm/openclaw/app/kustomization.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./configmap.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
 #  openclaw models auth login --provider openai

--- a/kubernetes/apps/base/llm/openclaw/app/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: openclaw
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/openclaw/dispatch/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/dispatch/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: dispatch
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/llm/openclaw/dispatch/kustomization.yaml
+++ b/kubernetes/apps/base/llm/openclaw/dispatch/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/openclaw/dispatch/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/openclaw/dispatch/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dispatch
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/openclaw/extended-memory/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/extended-memory/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: extended-memory
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/llm/openclaw/extended-memory/kustomization.yaml
+++ b/kubernetes/apps/base/llm/openclaw/extended-memory/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./configmap.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/openclaw/extended-memory/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/openclaw/extended-memory/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: extended-memory
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/openclaw/idle-watcher/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/idle-watcher/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: llama-idle-watcher
   interval: 15m
   dependsOn:
     - name: openclaw

--- a/kubernetes/apps/base/llm/openclaw/idle-watcher/kustomization.yaml
+++ b/kubernetes/apps/base/llm/openclaw/idle-watcher/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./configmap.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/openclaw/idle-watcher/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/openclaw/idle-watcher/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: llama-idle-watcher
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/openclaw/miso-chat/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/miso-chat/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: miso-chat
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/llm/openclaw/miso-chat/kustomization.yaml
+++ b/kubernetes/apps/base/llm/openclaw/miso-chat/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/openclaw/miso-chat/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/openclaw/miso-chat/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: miso-chat
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/searxng/app/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: searxng
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/llm/searxng/app/kustomization.yaml
+++ b/kubernetes/apps/base/llm/searxng/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
 configMapGenerator:
   - name: searxng-configmap
     files:

--- a/kubernetes/apps/base/llm/searxng/app/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/searxng/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: searxng
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/searxng/mcp/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/searxng/mcp/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: mcp-searxng
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/llm/searxng/mcp/kustomization.yaml
+++ b/kubernetes/apps/base/llm/searxng/mcp/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./mcpserverentry.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/searxng/mcp/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/searxng/mcp/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mcp-searxng
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/ersatztv/helmrelease.yaml
+++ b/kubernetes/apps/base/media/ersatztv/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: ersatztv
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/ersatztv/kustomization.yaml
+++ b/kubernetes/apps/base/media/ersatztv/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/ersatztv/ocirepository.yaml
+++ b/kubernetes/apps/base/media/ersatztv/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ersatztv
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/kavita/helmrelease.yaml
+++ b/kubernetes/apps/base/media/kavita/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: kavita
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/kavita/kustomization.yaml
+++ b/kubernetes/apps/base/media/kavita/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/kavita/ocirepository.yaml
+++ b/kubernetes/apps/base/media/kavita/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kavita
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/komga/helmrelease.yaml
+++ b/kubernetes/apps/base/media/komga/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: komga
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/komga/kustomization.yaml
+++ b/kubernetes/apps/base/media/komga/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/komga/ocirepository.yaml
+++ b/kubernetes/apps/base/media/komga/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: komga
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/maintainerr/helmrelease.yaml
+++ b/kubernetes/apps/base/media/maintainerr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: maintainerr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/maintainerr/kustomization.yaml
+++ b/kubernetes/apps/base/media/maintainerr/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/maintainerr/ocirepository.yaml
+++ b/kubernetes/apps/base/media/maintainerr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: maintainerr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/plex/agregarr/helmrelease.yaml
+++ b/kubernetes/apps/base/media/plex/agregarr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: agregarr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/plex/agregarr/kustomization.yaml
+++ b/kubernetes/apps/base/media/plex/agregarr/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/plex/agregarr/ocirepository.yaml
+++ b/kubernetes/apps/base/media/plex/agregarr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: agregarr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/base/media/plex/app/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: plex
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/plex/app/kustomization.yaml
+++ b/kubernetes/apps/base/media/plex/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/plex/app/ocirepository.yaml
+++ b/kubernetes/apps/base/media/plex/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: plex
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/plex/imagemaid/helmrelease.yaml
+++ b/kubernetes/apps/base/media/plex/imagemaid/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: imagemaid
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/plex/imagemaid/kustomization.yaml
+++ b/kubernetes/apps/base/media/plex/imagemaid/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/plex/imagemaid/ocirepository.yaml
+++ b/kubernetes/apps/base/media/plex/imagemaid/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: imagemaid
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/plex/kometa/helmrelease.yaml
+++ b/kubernetes/apps/base/media/plex/kometa/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: kometa
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/plex/kometa/kustomization.yaml
+++ b/kubernetes/apps/base/media/plex/kometa/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
 configMapGenerator:
   - name: kometa-configmap
     files:

--- a/kubernetes/apps/base/media/plex/kometa/ocirepository.yaml
+++ b/kubernetes/apps/base/media/plex/kometa/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kometa
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/plex/plex-auto-languages/helmrelease.yaml
+++ b/kubernetes/apps/base/media/plex/plex-auto-languages/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: plex-auto-languages
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/plex/plex-auto-languages/kustomization.yaml
+++ b/kubernetes/apps/base/media/plex/plex-auto-languages/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/plex/plex-auto-languages/ocirepository.yaml
+++ b/kubernetes/apps/base/media/plex/plex-auto-languages/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: plex-auto-languages
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/plex/plex-trakt-sync/helmrelease.yaml
+++ b/kubernetes/apps/base/media/plex/plex-trakt-sync/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: plex-trakt-sync
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/plex/plex-trakt-sync/kustomization.yaml
+++ b/kubernetes/apps/base/media/plex/plex-trakt-sync/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
 configMapGenerator:
   - name: plex-trakt-sync
     files:

--- a/kubernetes/apps/base/media/plex/plex-trakt-sync/ocirepository.yaml
+++ b/kubernetes/apps/base/media/plex/plex-trakt-sync/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: plex-trakt-sync
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/seerr/helmrelease.yaml
+++ b/kubernetes/apps/base/media/seerr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: seerr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/seerr/kustomization.yaml
+++ b/kubernetes/apps/base/media/seerr/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/seerr/ocirepository.yaml
+++ b/kubernetes/apps/base/media/seerr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: seerr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/stash/helmrelease.yaml
+++ b/kubernetes/apps/base/media/stash/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: stash
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/stash/kustomization.yaml
+++ b/kubernetes/apps/base/media/stash/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/stash/ocirepository.yaml
+++ b/kubernetes/apps/base/media/stash/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: stash
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/tautulli/helmrelease.yaml
+++ b/kubernetes/apps/base/media/tautulli/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: tautulli
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/tautulli/kustomization.yaml
+++ b/kubernetes/apps/base/media/tautulli/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/tautulli/ocirepository.yaml
+++ b/kubernetes/apps/base/media/tautulli/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tautulli
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/wizarr/helmrelease.yaml
+++ b/kubernetes/apps/base/media/wizarr/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: wizarr
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/wizarr/kustomization.yaml
+++ b/kubernetes/apps/base/media/wizarr/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/wizarr/ocirepository.yaml
+++ b/kubernetes/apps/base/media/wizarr/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: wizarr
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/media/your-spotify/helmrelease.yaml
+++ b/kubernetes/apps/base/media/your-spotify/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: your-spotify
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/media/your-spotify/kustomization.yaml
+++ b/kubernetes/apps/base/media/your-spotify/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/media/your-spotify/ocirepository.yaml
+++ b/kubernetes/apps/base/media/your-spotify/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: your-spotify
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/network/cloudflare-tunnel/helmrelease.yaml
+++ b/kubernetes/apps/base/network/cloudflare-tunnel/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: cloudflare-tunnel
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/network/cloudflare-tunnel/kustomization.yaml
+++ b/kubernetes/apps/base/network/cloudflare-tunnel/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/network/cloudflare-tunnel/ocirepository.yaml
+++ b/kubernetes/apps/base/network/cloudflare-tunnel/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cloudflare-tunnel
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/observability/exporters/dcgm-exporter/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/dcgm-exporter/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: dcgm-exporter
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/observability/exporters/dcgm-exporter/kustomization.yaml
+++ b/kubernetes/apps/base/observability/exporters/dcgm-exporter/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./configmap.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./servicemonitor.yaml

--- a/kubernetes/apps/base/observability/exporters/dcgm-exporter/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/exporters/dcgm-exporter/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dcgm-exporter
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/observability/exporters/hoymiles-exporter/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/hoymiles-exporter/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: hoymiles-exporter
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/observability/exporters/hoymiles-exporter/kustomization.yaml
+++ b/kubernetes/apps/base/observability/exporters/hoymiles-exporter/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./prometheusrule.yaml
   - ./servicemonitor.yaml
   - ./grafanadashboard.yaml

--- a/kubernetes/apps/base/observability/exporters/hoymiles-exporter/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/exporters/hoymiles-exporter/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hoymiles-exporter
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/observability/exporters/nut-exporter/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/nut-exporter/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: nut-exporter
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/observability/exporters/nut-exporter/kustomization.yaml
+++ b/kubernetes/apps/base/observability/exporters/nut-exporter/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./prometheusrule.yaml
   - ./servicemonitor.yaml
   - ./dashboard

--- a/kubernetes/apps/base/observability/exporters/nut-exporter/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/exporters/nut-exporter/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: nut-exporter
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/observability/exporters/rocm-smi-exporter/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/rocm-smi-exporter/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: rocm-smi-exporter
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/observability/exporters/rocm-smi-exporter/kustomization.yaml
+++ b/kubernetes/apps/base/observability/exporters/rocm-smi-exporter/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./servicemonitor.yaml

--- a/kubernetes/apps/base/observability/exporters/rocm-smi-exporter/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/exporters/rocm-smi-exporter/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rocm-smi-exporter
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/observability/exporters/speedtest-exporter/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/speedtest-exporter/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: speedtest-exporter
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/observability/exporters/speedtest-exporter/kustomization.yaml
+++ b/kubernetes/apps/base/observability/exporters/speedtest-exporter/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./prometheusrule.yaml
   - ./servicemonitor.yaml

--- a/kubernetes/apps/base/observability/exporters/speedtest-exporter/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/exporters/speedtest-exporter/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: speedtest-exporter
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/observability/exporters/unpoller/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/unpoller/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: unpoller
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/observability/exporters/unpoller/kustomization.yaml
+++ b/kubernetes/apps/base/observability/exporters/unpoller/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/observability/exporters/unpoller/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/exporters/unpoller/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: unpoller
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/observability/grafana/mcp/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/grafana/mcp/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: mcp-grafana
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/observability/grafana/mcp/kustomization.yaml
+++ b/kubernetes/apps/base/observability/grafana/mcp/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/observability/grafana/mcp/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/grafana/mcp/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mcp-grafana
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/observability/karma/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/karma/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: karma
   interval: 15m
   dependsOn:
     - name: kube-prometheus-stack

--- a/kubernetes/apps/base/observability/karma/kustomization.yaml
+++ b/kubernetes/apps/base/observability/karma/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
 configMapGenerator:
   - name: karma-configmap
     files:

--- a/kubernetes/apps/base/observability/karma/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/karma/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: karma
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/observability/network-ups-tools/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/network-ups-tools/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: network-ups-tools
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/observability/network-ups-tools/kustomization.yaml
+++ b/kubernetes/apps/base/observability/network-ups-tools/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - ocirepository.yaml

--- a/kubernetes/apps/base/observability/network-ups-tools/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/network-ups-tools/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: network-ups-tools
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/observability/promxy/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/promxy/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: promxy
   interval: 15m
   dependsOn:
     - name: kube-prometheus-stack

--- a/kubernetes/apps/base/observability/promxy/kustomization.yaml
+++ b/kubernetes/apps/base/observability/promxy/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
 configMapGenerator:
   - name: promxy-configmap
     files:

--- a/kubernetes/apps/base/observability/promxy/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/promxy/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: promxy
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/acars/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/acars/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: acars
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/acars/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/acars/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./pvc.yaml
 configMapGenerator:
   - name: acars-config

--- a/kubernetes/apps/base/self-hosted/acars/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/acars/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: acars
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/actual/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/actual/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: actual
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/actual/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/actual/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/actual/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/actual/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: actual
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/archiveteam/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/archiveteam/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: archiveteam
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/archiveteam/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/archiveteam/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/base/self-hosted/archiveteam/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/archiveteam/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: archiveteam
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/atuin/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/atuin/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: atuin
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/atuin/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/atuin/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/atuin/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/atuin/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: atuin
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/bentopdf/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/bentopdf/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: bentopdf
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/bentopdf/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/bentopdf/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/bentopdf/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/bentopdf/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: bentopdf
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/free-game-notifier/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/free-game-notifier/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: free-game-notifier
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/free-game-notifier/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/free-game-notifier/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/free-game-notifier/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/free-game-notifier/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: free-game-notifier
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/hypermind/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/hypermind/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: hypermind
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/hypermind/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/hypermind/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/hypermind/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/hypermind/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hypermind
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/it-tools/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/it-tools/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: it-tools
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/it-tools/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/it-tools/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/it-tools/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/it-tools/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: it-tools
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/manyfold/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/manyfold/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: manyfold
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/manyfold/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/manyfold/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/manyfold/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/manyfold/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: manyfold
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/meshcentral/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/meshcentral/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: meshcentral
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/meshcentral/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/meshcentral/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./configmap.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/meshcentral/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/meshcentral/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: meshcentral
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/paperless/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/paperless/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: paperless
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/paperless/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/paperless/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/paperless/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/paperless/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: paperless
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/picoshare/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/picoshare/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: picoshare
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/picoshare/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/picoshare/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/picoshare/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/picoshare/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: picoshare
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/rss-forwarder/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/rss-forwarder/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: rss-forwarder
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/rss-forwarder/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/rss-forwarder/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/rss-forwarder/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/rss-forwarder/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rss-forwarder
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/scanservjs/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/scanservjs/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: scanservjs
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/scanservjs/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/scanservjs/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/scanservjs/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/scanservjs/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: scanservjs
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/spoolman/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/spoolman/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: spoolman
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/spoolman/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/spoolman/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/spoolman/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/spoolman/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: spoolman
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/thelounge/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/thelounge/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: thelounge
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/thelounge/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/thelounge/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/thelounge/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/thelounge/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: thelounge
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/self-hosted/webhook/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/webhook/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: webhook
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/self-hosted/webhook/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/webhook/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml
 configMapGenerator:
   - name: webhook-configmap
     files:

--- a/kubernetes/apps/base/self-hosted/webhook/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/webhook/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: webhook
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/storage/kopia/helmrelease.yaml
+++ b/kubernetes/apps/base/storage/kopia/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: kopia
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/storage/kopia/kustomization.yaml
+++ b/kubernetes/apps/base/storage/kopia/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/storage/kopia/ocirepository.yaml
+++ b/kubernetes/apps/base/storage/kopia/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kopia
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/workadventure/coturn/helmrelease.yaml
+++ b/kubernetes/apps/base/workadventure/coturn/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: coturn
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/workadventure/coturn/kustomization.yaml
+++ b/kubernetes/apps/base/workadventure/coturn/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./dnsendpoint.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/workadventure/coturn/ocirepository.yaml
+++ b/kubernetes/apps/base/workadventure/coturn/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: coturn
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/workadventure/synapse/helmrelease.yaml
+++ b/kubernetes/apps/base/workadventure/synapse/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: synapse
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/workadventure/synapse/kustomization.yaml
+++ b/kubernetes/apps/base/workadventure/synapse/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/workadventure/synapse/ocirepository.yaml
+++ b/kubernetes/apps/base/workadventure/synapse/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: synapse
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/workadventure/workadventure/helmrelease.yaml
+++ b/kubernetes/apps/base/workadventure/workadventure/helmrelease.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: workadventure
   interval: 15m
   dependsOn: []
   values:

--- a/kubernetes/apps/base/workadventure/workadventure/kustomization.yaml
+++ b/kubernetes/apps/base/workadventure/workadventure/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/workadventure/workadventure/ocirepository.yaml
+++ b/kubernetes/apps/base/workadventure/workadventure/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: workadventure
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/components/namespace/kustomization.yaml
+++ b/kubernetes/components/namespace/kustomization.yaml
@@ -5,4 +5,3 @@ kind: Component
 resources:
   - ./namespace.yaml
   - ./alerts
-  - ./repos

--- a/kubernetes/components/namespace/repos/kustomization.yaml
+++ b/kubernetes/components/namespace/repos/kustomization.yaml
@@ -1,6 +1,0 @@
----
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - ./ocirepository.yaml


### PR DESCRIPTION
Replaces the shared `app-template` `OCIRepository` (injected per-namespace by the namespace component) with a dedicated per-app `ocirepository.yaml` for all 93 `app-template` apps, repointing each HelmRelease's `chartRef` at it. Drops the now-unused `repos` source from the namespace component.

Follows #7720 (which split out non-`app-template` sources) — per-app `OCIRepository` is now the universal convention, matching bjw-s/onedr0p.

## Why
Per-app sources give independent control over the `app-template` chart version: staged upgrades and per-app revert, instead of one big-bang bump across every app. Each app folder is also self-contained.

## Trade-off
~73 (main) OCIRepository objects reconciling on interval instead of one shared per namespace. Renovate still groups `app-template` bumps by datasource, so it stays one PR.

## Verification (`flate`, working tree vs `origin/main`)
Workloads are a **no-op** — `flate diff hr` is empty on all three clusters. Only the Flux source layer changes (`flate diff ks`), and it's entirely accounted for:

| cluster | repos added | shared removed | chartRef flips | hr |
|---|---|---|---|---|
| main | +73 | −19 | 73 | no-op |
| utility | +3 net | | | no-op |
| test | +1 | −9 | 1 | no-op |

No non-OCIRepository kind is touched. `test` removes 8 shared sources from namespaces that had no `app-template` app (dead-source cleanup).

## Docs
`AGENTS.md` + add-app skill updated to make per-app `OCIRepository` the universal rule.