### PR TITLE
feat(observability): add drm-exporter-amd via AMD DRA

### DIFF
--- a/kubernetes/apps/base/observability/exporters/drm-exporter-amd/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/drm-exporter-amd/helmrelease.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: drm-exporter-amd
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: drm-exporter
+  interval: 15m
+  dependsOn:
+    - name: k8s-gpu-dra-driver
+      namespace: kube-system
+  values:
+    fullnameOverride: drm-exporter-amd
+    config:
+      logLevel: info
+    securityContext:
+      privileged: false
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: [ALL]
+        add: []
+    dra:
+      enabled: true
+      deviceClassName: gpu.amd.com
+      adminAccess: true
+      allocationMode: All
+    monitoring:
+      serviceMonitor:
+        enabled: true
+        relabelings:
+          - sourceLabels: [__meta_kubernetes_endpoint_node_name]
+            targetLabel: nodename
+      dashboards:
+        enabled: false
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 64Mi
+    nodeSelector:
+      topology.kubernetes.io/gpus: amd
+    tolerations:
+      - key: llm-workload
+        operator: Exists
+        effect: NoSchedule

--- a/kubernetes/apps/base/observability/exporters/drm-exporter-amd/kustomization.yaml
+++ b/kubernetes/apps/base/observability/exporters/drm-exporter-amd/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/observability/exporters/drm-exporter/ocirepository.yaml
+++ b/kubernetes/apps/base/observability/exporters/drm-exporter/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.2.3
+    tag: 0.2.4
   url: oci://ghcr.io/home-operations/charts/drm-exporter

--- a/kubernetes/apps/main/observability/exporters/drm-exporter-amd.yaml
+++ b/kubernetes/apps/main/observability/exporters/drm-exporter-amd.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: drm-exporter-amd
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/observability/exporters/drm-exporter-amd
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/observability/exporters/kustomization.yaml
+++ b/kubernetes/apps/main/observability/exporters/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./blackbox-exporter.yaml
   - ./dcgm-exporter.yaml
   - ./drm-exporter.yaml
+  - ./drm-exporter-amd.yaml
   - ./blackbox-exporter-probes.yaml
   - ./hoymiles-exporter.yaml
   - ./nut-exporter.yaml


### PR DESCRIPTION
Now that skirk's gfx1151 APU is on the `gpu.amd.com` DRA driver and drm-exporter `0.2.4` ships the qmlib fix (`799a63b` — APUs that don't expose `mem_busy_percent` no longer abort every refresh), drm-exporter can finally read the APU. This adds a skirk-scoped release using the chart's native DRA support, mirroring the Intel control-plane release.

- **`drm-exporter-amd`** — native `dra.enabled` with `deviceClassName: gpu.amd.com`, `adminAccess: true`, `allocationMode: All` (non-consuming monitor claim, same shape as `llama-strix-gpu`, so it won't steal from the llama pods). `dependsOn` the AMD DRA driver, scoped to skirk (`nodeSelector` + `llm-workload` toleration), caps dropped (no `PERFMON`/`SYS_RAWIO` on AMD), dashboard render off (Intel release ships the shared one).
- **OCIRepository** bumped `0.2.3 → 0.2.4` (qmlib-only change; rolls the Intel release too).

Runs **alongside** rocm-smi-exporter, not replacing it: drm-exporter covers engine utilization, frequency, and memory on the APU, but qmlib still has no integrated-GPU hwmon (`// TODO: need to add integrated support` in `power()`), so power/temperature stay on rocm-smi. Dashboard panels will move to drm-exporter where it has coverage in a follow-up.

Verified `kustomize build` and a `helm template` render of the `0.2.4` chart with these values (RCT + pod claim wired, caps cleared, scheduling correct).