### PR TITLE
feat(utility): add AMD GPU DRA driver for celestia Vega iGPU

### DIFF
--- a/kubernetes/apps/utility/kube-system/k8s-gpu-dra-driver.yaml
+++ b/kubernetes/apps/utility/kube-system/k8s-gpu-dra-driver.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: k8s-gpu-dra-driver
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/kube-system/k8s-gpu-dra-driver
+  wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/kube-system/kustomization.yaml
+++ b/kubernetes/apps/utility/kube-system/kustomization.yaml
@@ -10,4 +10,5 @@ replacements:
 resources:
   - ./cilium.yaml
   - ./coredns.yaml
+  - ./k8s-gpu-dra-driver.yaml
   - ./metrics-server.yaml

--- a/talos/utility/controlplane/celestia.yaml
+++ b/talos/utility/controlplane/celestia.yaml
@@ -3,6 +3,8 @@
 machine:
   install:
     disk: /dev/sda
+  nodeLabels:
+    topology.kubernetes.io/gpus: amd
 ---
 apiVersion: v1alpha1
 kind: HostnameConfig


### PR DESCRIPTION
Stands up `ROCm/k8s-gpu-dra-driver` on the **utility** cluster so celestia's Ryzen 5700G Vega iGPU (gfx90c) is schedulable via DRA — the prerequisite for moving `llama-ryzen` off its `/dev/dri` hostPath onto a `gpu.amd.com` claim.

Reuses the shared `base/kube-system/k8s-gpu-dra-driver` (same as main), via a utility Flux ks — exactly how utility already shares coredns/metrics-server.

## Feasibility (confirmed before building)

- Utility is k8s 1.36.2 serving `resource.k8s.io/v1` — DRA enabled.
- celestia exposes the Vega through kfd: `gfx_target_version 90012` (gfx90c), `simd_count 32`, `/dev/kfd` + `renderD128` present.
- Driver source enumerates **any** kfd node with `renderMinor>0` (no gfx allowlist), and its CDI injects `/dev/dri/renderD*` — so Vulkan (llama-ryzen's backend) keeps working.

## ⚠️ Requires a Talos apply

celestia is labeled `topology.kubernetes.io/gpus: amd` via `machine.nodeLabels` so the shared base HR's nodeSelector lands the plugin there. **`talosctl apply` the celestia machineconfig** (node label, no reboot) around merge — until the label exists the plugin pod stays Pending.

## Safe to land

Inert until something claims `gpu.amd.com` (llama-ryzen still uses hostPath). Validated: utility kube-system aggregation builds, ks renders with `targetNamespace: kube-system`.

## Next (separate PR)

Verify the ResourceSlice publishes for the Vega, then convert `llama-ryzen` (app-template) to a `gpu.amd.com` claim + drop the hostPath. Single consumer, so a plain claim — no `adminAccess` needed.