### PR TITLE
feat(utility): move llama-ryzen to DRA + add drm-exporter-amd

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-ryzen/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-ryzen/helmrelease.yaml
@@ -13,6 +13,9 @@ spec:
   values:
     defaultPodOptions:
       hostIPC: true
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: llama-ryzen-gpu
     controllers:
       llama-ryzen:
         annotations:
@@ -122,6 +125,8 @@ spec:
               GGML_VK_VISIBLE_DEVICES: "0"
               UR_L0_ENABLE_RELAXED_ALLOCATION_LIMITS: "1"
             resources:
+              claims:
+                - name: gpu
               requests:
                 cpu: 500m
                 memory: 8Gi
@@ -162,11 +167,6 @@ spec:
         existingClaim: llama-ryzen
         globalMounts:
           - path: /models
-      dev-dri:
-        type: hostPath
-        hostPath: /dev/dri
-        globalMounts:
-          - path: /dev/dri
     service:
       app:
         type: LoadBalancer

--- a/kubernetes/apps/base/llm/litellm/llama-ryzen/resourceclaimtemplate.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-ryzen/resourceclaimtemplate.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: llama-ryzen-gpu
+spec:
+  spec:
+    devices:
+      requests:
+        - name: gpu
+          exactly:
+            deviceClassName: gpu.amd.com

--- a/kubernetes/apps/utility/observability/exporters/drm-exporter-amd.yaml
+++ b/kubernetes/apps/utility/observability/exporters/drm-exporter-amd.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: drm-exporter-amd
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/utility/observability/exporters/drm-exporter-amd
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/observability/exporters/drm-exporter-amd/kustomization.yaml
+++ b/kubernetes/apps/utility/observability/exporters/drm-exporter-amd/kustomization.yaml
@@ -3,9 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./externalsecret.yaml
-  - ./helmrelease.yaml
   - ./ocirepository.yaml
-  - ./resourceclaimtemplate.yaml
-  - ./servicemonitor.yaml
-  - ./pvc.yaml
+  - ../../../../base/observability/exporters/drm-exporter-amd

--- a/kubernetes/apps/utility/observability/exporters/drm-exporter-amd/ocirepository.yaml
+++ b/kubernetes/apps/utility/observability/exporters/drm-exporter-amd/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: drm-exporter
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.2.4
+  url: oci://ghcr.io/home-operations/charts/drm-exporter

--- a/kubernetes/apps/utility/observability/exporters/kustomization.yaml
+++ b/kubernetes/apps/utility/observability/exporters/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./blackbox-exporter.yaml
   - ./blackbox-exporter-probes.yaml
+  - ./drm-exporter-amd.yaml
   - ./smartctl-exporter.yaml


### PR DESCRIPTION
The `gpu.amd.com` driver enumerates celestia's Vega iGPU (verified: `gpu-0-128`, 8 CU / 32 SIMD), so put the utility cluster's GPU workloads on DRA.

## llama-ryzen → DRA

- New `llama-ryzen-gpu` ResourceClaimTemplate — plain single-pod claim (one consumer, so no `adminAccess`/`All`, unlike the shared strix claim).
- HR requests the claim (pod + container) and **drops the `/dev/dri` hostPath**. The driver's CDI injects `renderD128`, so the Vulkan backend (`--device Vulkan0`) keeps working. Kept `privileged` for now (separate cleanup if desired).

## drm-exporter-amd on utility

- Overlay that adds the `drm-exporter` OCIRepository (chart source) and references the **shared base AMD HR** (DRA `gpu.amd.com`, unprivileged). celestia's `gpus: amd` label satisfies the shared HR's nodeSelector; the `llm-workload` toleration is a no-op there.

## Watch on merge

llama-ryzen restarts onto the DRA claim. Unverified-until-applied bit: Vulkan via the DRA-injected render node (ROCm path is proven on the Strix; Vulkan render-node injection is the new variable here). **Rollback = `git revert`** → restores the hostPath.

Validated: `kustomize build` of both pieces, the cross-dir overlay, and the utility observability aggregation; RCT passes server-side dry-run on utility.