### PR TITLE
feat(litellm): add neuralwatt routing

### DIFF
--- a/docs/src/notes/llm-strategy.md
+++ b/docs/src/notes/llm-strategy.md
@@ -9,8 +9,8 @@ and for designing intent-based routing on top of them.
 
 ## Subscriptions
 
-Almost everything is flat-rate. The only metered/API-billed token is Moonshot — and it's now a
-_failover_ under `kimi-k2.6` (OpenCode is primary), so it only bills when OpenCode is unavailable.
+Subscriptions remain the primary capacity. Neuralwatt supplies energy-metered near-frontier capacity,
+while Moonshot is the last token-metered failover under `kimi-k2.6`.
 
 | Plan                | Price                                        | Cap                                                                          | Reset                              | Models                                                                       | Primary use                                                                   |
 | ------------------- | -------------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
@@ -18,7 +18,8 @@ _failover_ under `kimi-k2.6` (OpenCode is primary), so it only bills when OpenCo
 | **MiniMax Plus**    | ~$200 USD/yr ($20/mo, annual = 2mo free)     | 300 prompts / 5h                                                             | rolling 5h                         | M3 and M2.7, via the Anthropic endpoint                                      | Agentic reasoning workhorse                                                   |
 | **Opencode Go**     | $10 USD/mo                                   | $12 / 5h, $30 / wk, $60 / mo (dollar-denominated)                            | rolling 5h / wk / mo               | 14 models incl. DeepSeek V4 Flash/Pro, GLM-5.x, Kimi, MiMo, Qwen3.7, MiniMax | High-volume cheap lane (dsv4f) + grab-bag access                              |
 | **GLM Coding Lite** | ~$151 USD/yr (promotional, region-dependent) | ~80 prompts / 5h                                                             | rolling 5h                         | GLM-5.2, GLM-5.1 (added 2026-06-17), GLM-4.7, GLM-4.5-Air                    | GLM coding access; fallback lane                                              |
-| **Moonshot (Kimi)** | pay-per-use                                  | none (per-key RPM/TPM only)                                                  | n/a                                | kimi-k2.6                                                                    | Metered failover under `kimi-k2.6` (OpenCode primary); bills only on failover |
+| **Moonshot (Kimi)** | pay-per-use                                  | none (per-key RPM/TPM only)                                                  | n/a                                | kimi-k2.6                                                                    | Last-resort metered failover under `kimi-k2.6`                                 |
+| **Neuralwatt**      | pay-per-use ($5/kWh energy billing)          | account credit; API-key allowances available                                | n/a                                | Kimi K2.6/K2.7 Code, GLM-5.2                                                  | Metered near-frontier capacity after flat plans                                |
 
 Caveats worth remembering:
 
@@ -50,11 +51,25 @@ Aliases as defined in the LiteLLM configmap, grouped by where they run.
 | `MiniMax`              | MiniMax Plus                  | MiniMax-M3 (Anthropic endpoint) | 1M       | Big-context generation                             |
 | `MiniMax-M2.7`         | MiniMax Plus                  | MiniMax-M2.7                    | 204.8k   | Agentic reasoning workhorse                        |
 | `glm-5.1`              | GLM Coding Lite → OpenCode Go | glm-5.1                         | 203k     | GLM coding; z.ai primary, OpenCode failover        |
-| `glm-5.2`              | GLM Coding Lite → OpenCode Go | glm-5.2                         | 1M       | GLM big-context; z.ai primary, OpenCode failover   |
+| `glm-5.2`              | GLM Coding Lite → OpenCode Go → Neuralwatt | glm-5.2              | 1M       | GLM big-context; Neuralwatt is metered last resort |
 | `chatgpt/gpt-5.5`      | ChatGPT Plus                  | gpt-5.5 (Codex/OAuth)           | —        | Frontier                                           |
 | `chatgpt/gpt-5.4`      | ChatGPT Plus                  | gpt-5.4                         | —        | Frontier (cheaper)                                 |
 | `chatgpt/gpt-5.4-mini` | ChatGPT Plus                  | gpt-5.4-mini                    | —        | Cheap fallback                                     |
-| `kimi-k2.6`            | OpenCode Go → Moonshot        | kimi-k2.6                       | 262k     | OpenCode-primary (flat); Moonshot only on failover |
+| `kimi-k2.6`            | OpenCode Go → Neuralwatt → Moonshot | kimi-k2.6                  | 262k     | Flat plan first; energy PAYG before token PAYG     |
+| `kimi-k2.7`            | Neuralwatt                    | kimi-k2.7-code                  | 262k     | Metered near-frontier coding/reasoning lane        |
+
+### Neuralwatt (energy-metered PAYG)
+
+| Alias                         | Upstream model | Ctx  | Role                                      |
+| ----------------------------- | -------------- | ---- | ----------------------------------------- |
+| `kimi-k2.7`                   | kimi-k2.7-code | 262k | Smart near-frontier coding/reasoning lane |
+| `neuralwatt/glm-5.2`          | glm-5.2        | 1M   | Direct long-context reasoning lane        |
+
+Neuralwatt charges this account for measured GPU energy rather than tokens. PAYG is $5/kWh;
+prefix-cache hits avoid prefill work and therefore reduce the charged energy. Neuralwatt also publishes
+token prices for compatibility, but those are not the billing basis here, so LiteLLM intentionally has no
+static token-cost metadata for these deployments. Use Neuralwatt's usage API/dashboard for authoritative
+cost and energy until its response-level `cost` and `energy` extensions are exported into Prometheus.
 
 ### Cloud (Opencode Go gateway, `opencode.ai/zen/go/v1`)
 
@@ -66,8 +81,10 @@ Aliases as defined in the LiteLLM configmap, grouped by where they run.
 | `mimo-v2.5` / `mimo-v2.5-pro`       | mimo-v2.5(-pro)   | 262k        | Lighter analysis lane                               |
 | `qwen3.7-plus`                      | qwen3.7-plus      | 1M          | Big-context Qwen via gateway                        |
 
-**Provider failover** (LiteLLM `order:`, transparent to callers): `glm-5.1`/`glm-5.2` → z.ai then
-OpenCode; `kimi-k2.6` → OpenCode then Moonshot. The standalone `go-glm-5.1`/`go-kimi-k2.6` aliases
+**Provider failover** (LiteLLM `order:`, transparent to callers): `glm-5.1` → z.ai then OpenCode;
+`glm-5.2` → z.ai, OpenCode, then Neuralwatt; `kimi-k2.6` → OpenCode, Neuralwatt, then Moonshot.
+This reacts when an upstream starts rejecting requests; it cannot detect that an unpublished rolling
+subscription allowance is merely _close_ to exhausted. The standalone `go-glm-5.1`/`go-kimi-k2.6` aliases
 were retired in favour of this. `go-minimax-m3/m2.7` stay separate — MiniMax's direct endpoint is
 Anthropic-shape and can't be grouped with the chat-shape gateway copy.
 

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -246,6 +246,19 @@ data:
           api_key: os.environ/OPENCODE_API_KEY
           order: 2
 
+      - model_name: glm-5.2
+        model_info:
+          mode: chat
+          max_input_tokens: 1048560
+          max_output_tokens: 16384
+          supports_function_calling: true
+          supports_prompt_caching: true
+        litellm_params:
+          model: openai/glm-5.2
+          api_base: https://api.neuralwatt.com/v1
+          api_key: os.environ/NEURALWATT_API_KEY
+          order: 3
+
       - model_name: kimi-k2.6
         model_info:
           mode: chat
@@ -266,6 +279,20 @@ data:
       - model_name: kimi-k2.6
         model_info:
           mode: chat
+          max_input_tokens: 262128
+          max_output_tokens: 16384
+          supports_function_calling: true
+          supports_prompt_caching: true
+          supports_vision: true
+        litellm_params:
+          model: openai/kimi-k2.6
+          api_base: https://api.neuralwatt.com/v1
+          api_key: os.environ/NEURALWATT_API_KEY
+          order: 2
+
+      - model_name: kimi-k2.6
+        model_info:
+          mode: chat
           input_cost_per_token: 0.0000009500
           cache_creation_input_token_cost: 0.0000009500
           cache_read_input_token_cost: 0.0000001600
@@ -278,7 +305,35 @@ data:
           model: moonshot/kimi-k2.6
           api_base: https://api.moonshot.ai/v1
           api_key: os.environ/MOONSHOT_API_KEY
-          order: 2
+          order: 3
+
+      # Direct Neuralwatt aliases for opt-in PAYG use and cost comparison.
+      # Billing is energy-based, so static per-token costs would misstate spend.
+      # Stable alias: Neuralwatt is currently the only configured Kimi K2.7 provider.
+      - model_name: kimi-k2.7
+        model_info:
+          mode: chat
+          max_input_tokens: 262128
+          max_output_tokens: 16384
+          supports_function_calling: true
+          supports_prompt_caching: true
+          supports_vision: true
+        litellm_params:
+          model: openai/kimi-k2.7-code
+          api_base: https://api.neuralwatt.com/v1
+          api_key: os.environ/NEURALWATT_API_KEY
+
+      - model_name: neuralwatt/glm-5.2
+        model_info:
+          mode: chat
+          max_input_tokens: 1048560
+          max_output_tokens: 16384
+          supports_function_calling: true
+          supports_prompt_caching: true
+        litellm_params:
+          model: openai/glm-5.2
+          api_base: https://api.neuralwatt.com/v1
+          api_key: os.environ/NEURALWATT_API_KEY
 
       - model_name: dsv4f
         model_info:
@@ -518,6 +573,7 @@ data:
     environment:
       - MINIMAX_API_KEY
       - MOONSHOT_API_KEY
+      - NEURALWATT_API_KEY
       - OPENCODE_API_KEY
       - ZAI_API_KEY
       - REDIS_HOST

--- a/kubernetes/apps/base/llm/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/externalsecret.yaml
@@ -18,6 +18,7 @@ spec:
         GENERIC_CLIENT_SECRET: "{{ .LITELLM_CLIENT_SECRET }}"
         MINIMAX_API_KEY: "{{ .MINIMAX_API_KEY }}"
         MOONSHOT_API_KEY: "{{ .MOONSHOT_API_KEY }}"
+        NEURALWATT_API_KEY: "{{ .NEURALWATT_API_KEY }}"
         OPENCODE_API_KEY: "{{ .OPENCODE_API_KEY }}"
         ZAI_API_KEY: "{{ .ZAI_API_KEY }}"
   dataFrom:
@@ -27,6 +28,8 @@ spec:
         key: minimax
     - extract:
         key: moonshot
+    - extract:
+        key: neuralwatt
     - extract:
         key: opencode
     - extract:


### PR DESCRIPTION
Adds Neuralwatt as metered fallback capacity for GLM-5.2 and Kimi K2.6, plus a direct Kimi K2.7 alias, while keeping subscription providers first.

Validated embedded YAML, provider order, and the rendered LiteLLM app with kubectl kustomize; flate was unavailable locally.
