### PR TITLE
chore(llm): refresh strategy doc + enable drm dashboard + drop ryzen privileged

### DIFF
--- a/docs/src/notes/llm-strategy.md
+++ b/docs/src/notes/llm-strategy.md
@@ -41,7 +41,7 @@ Aliases as defined in the LiteLLM configmap, grouped by where they run.
 | ---------------------- | ---------------------------------------- | -------------------- | -------- | ----------------------------------- |
 | `self-hosted`          | Strix ROCm (2 × 2 slots) + Mac LM Studio | Qwen3.6-35B-A3B      | 262k     | Default local brain; vision + tools |
 | `nvidia`               | 3090                                     | Qwen (CUDA)          | 145k     | General local, no vision            |
-| `ryzen`                | Ryzen CPU (Vulkan)                       | Qwen3.5-9B-heretic   | 8.2k     | Tiny/edge tasks                     |
+| `ryzen`                | Ryzen 5700G Vega iGPU (Vulkan, DRA)      | Qwen3.5-9B-heretic   | 8.2k     | Tiny/edge tasks                     |
 | `qwen3-embedding-0-6b` | llama.cpp                                | Qwen3-Embedding-0.6B | —        | Embeddings (1024-dim)               |
 
 ### Cloud (flat-rate subscriptions)

--- a/kubernetes/apps/base/llm/litellm/llama-ryzen/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-ryzen/helmrelease.yaml
@@ -61,8 +61,6 @@ spec:
             image:
               repository: ghcr.io/ggml-org/llama.cpp
               tag: server-vulkan@sha256:c7e3aa0258d9f79f5462f3ef21368af5c3614c75459d368c7ce941b6adb42fca
-            securityContext:
-              privileged: true
             args:
               - --host
               - 0.0.0.0

--- a/kubernetes/apps/base/observability/exporters/drm-exporter-amd/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/drm-exporter-amd/helmrelease.yaml
@@ -35,7 +35,11 @@ spec:
           - sourceLabels: [__meta_kubernetes_endpoint_node_name]
             targetLabel: nodename
       dashboards:
-        enabled: false
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          matchLabels:
+            dashboards: grafana
     resources:
       requests:
         cpu: 10m


### PR DESCRIPTION
Post-DRA-pivot tidy-up — docs, dashboards, and the two cleanups.

## Strategy doc
- `docs/src/notes/llm-strategy.md`: the `ryzen` backend was listed as "Ryzen CPU (Vulkan)" — it's the Ryzen 5700G **Vega iGPU** (Vulkan, now via DRA). Rest of the doc is current (routing-focused, matches the configmap).

## Dashboards
- **Enabled the bundled drm-exporter Grafana dashboard** (`monitoring.dashboards` + `grafanaOperator`, `instanceSelector: dashboards=grafana`). The base HR is shared, so both skirk and celestia render it; the single main Grafana imports it and its `datasource` template var picks **`promxy`** (both clusters, grouped by node) or **`prometheus-utility`** (celestia Vega). The orphan CR on utility (no Grafana there) is harmless.
- **Existing 5 LLM dashboard JSONs audited — clean.** Zero references to retired names (`llama-review`/`gemma-review`/`review`/`burst-watcher`/`devic.es/rocm`), no broken metrics. No edits needed; the Vega is covered by the new chart dashboard, not by editing these.

## Cleanup: drop llama-ryzen `privileged`
Now that the GPU arrives via the DRA claim (CDI-injected `renderD128`, which is `0666`), `privileged` isn't needed — the drm-exporter already runs unprivileged on the same iGPU.

## Watch on merge
Only serving-impacting change is the llama-ryzen `privileged` drop → it restarts. If Vulkan can't reach the device without privileged (unlikely), `git revert` that one file. drm dashboard + doc are inert.