### PR TITLE
fix(grafana): pin litellm-economics to prometheus-main via dropdown

### DIFF
--- a/kubernetes/apps/base/llm/litellm/app/dashboard/litellm-economics.json
+++ b/kubernetes/apps/base/llm/litellm/app/dashboard/litellm-economics.json
@@ -1076,10 +1076,10 @@
     "list": [
       {
         "current": {
-          "text": "Prometheus",
-          "value": "prometheus"
+          "text": "prometheus-main",
+          "value": "prometheus-main"
         },
-        "hide": 2,
+        "hide": 0,
         "label": "Datasource",
         "name": "datasource",
         "query": "prometheus",


### PR DESCRIPTION
The `litellm-economics` dashboard broke when `prometheus` was repointed to promxy. It's the only dashboard with **selector-less `vector()` literals** (3 bare `vector($subs)` flat-subscription panels + 95 `or vector(0)` fallbacks) — promxy can't anchor a literal to one backend, so it evaluates them against both Prometheis and merges → duplicate empty-label series → broken panels. The other dashboards have no bare `vector()` (litellm's are all anchored to a `sum()` selector), so they're fine.

All of economics' data (`litellm_*`, `unpoller_*`) lives only in the main Prometheus, so it never needed promxy.

**Change** (one file, the datasource template var):
- `hide: 2 → 0` — the datasource var is now a visible dropdown (lists all prometheus-type datasources).
- `current → prometheus-main` — defaults to the main Prometheus instead of the promxy default.

Validated: JSON parses, litellm app `kustomize build` passes.