### PR TITLE
refactor(gpu): igpu-workload spread via reusable component

### DIFF
--- a/kubernetes/apps/base/downloads/tdarr-node/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/tdarr-node/helmrelease.yaml
@@ -25,15 +25,6 @@ spec:
       securityContext:
         fsGroup: 100
         fsGroupChangePolicy: OnRootMismatch
-      labels:
-        igpu-workload: "true"
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              igpu-workload: "true"
     controllers:
       tdarr-node:
         replicas: 1

--- a/kubernetes/apps/base/media/ersatztv/helmrelease.yaml
+++ b/kubernetes/apps/base/media/ersatztv/helmrelease.yaml
@@ -21,15 +21,6 @@ spec:
         runAsGroup: 100
         fsGroup: 100
         fsGroupChangePolicy: OnRootMismatch
-      labels:
-        igpu-workload: "true"
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              igpu-workload: "true"
     controllers:
       ersatztv:
         annotations:

--- a/kubernetes/apps/base/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/base/media/plex/app/helmrelease.yaml
@@ -21,15 +21,6 @@ spec:
         runAsGroup: 100
         fsGroup: 100
         fsGroupChangePolicy: OnRootMismatch
-      labels:
-        igpu-workload: "true"
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              igpu-workload: "true"
     controllers:
       plex:
         annotations:

--- a/kubernetes/apps/base/media/stash/helmrelease.yaml
+++ b/kubernetes/apps/base/media/stash/helmrelease.yaml
@@ -15,15 +15,6 @@ spec:
       resourceClaims:
         - name: gpu
           resourceClaimTemplateName: stash-gpu
-      labels:
-        igpu-workload: "true"
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              igpu-workload: "true"
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/main/downloads/tdarr-node.yaml
+++ b/kubernetes/apps/main/downloads/tdarr-node.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/gpu
+    - ../../../../components/igpu-spread
   interval: 1h
   path: ./kubernetes/apps/base/downloads/tdarr-node
   postBuild:

--- a/kubernetes/apps/main/media/ersatztv.yaml
+++ b/kubernetes/apps/main/media/ersatztv.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/gpu
+    - ../../../../components/igpu-spread
     - ../../../../components/zeroscaler
     - ../../../../components/volsync
   interval: 1h

--- a/kubernetes/apps/main/media/plex.yaml
+++ b/kubernetes/apps/main/media/plex.yaml
@@ -27,6 +27,7 @@ metadata:
 spec:
   components:
     - ../../../../../components/gpu
+    - ../../../../../components/igpu-spread
     - ../../../../../components/volsync
     - ../../../../../components/zeroscaler
   interval: 1h

--- a/kubernetes/apps/main/media/stash.yaml
+++ b/kubernetes/apps/main/media/stash.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/gpu
+    - ../../../../components/igpu-spread
     - ../../../../components/zeroscaler
     - ../../../../components/volsync
   interval: 1h

--- a/kubernetes/components/igpu-spread/kustomization.yaml
+++ b/kubernetes/components/igpu-spread/kustomization.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# Adds the `igpu-workload` label + a soft topology spread (one-per-node,
+# ScheduleAnyway) to an app-template HelmRelease's defaultPodOptions, so Intel
+# iGPU workloads distribute across the iGPU nodes instead of bin-packing onto
+# one. Include alongside components/gpu on bjw-s app-template GPU workloads.
+#
+# Requires a bjw-s app-template HR (patches spec.values.defaultPodOptions, which
+# must already exist — it does on any workload requesting the iGPU resourceClaim).
+#
+# Workloads that CANNOT use this component and keep a MANUAL implementation:
+#   - kyoo: uses the zoriya/helm-charts/kyoo chart (not app-template) — flat
+#     pod-spec keys under the controller, no defaultPodOptions. The label +
+#     topologySpreadConstraints live on controllers.transcoder directly.
+#   - llama-embed / llama-rerank / llama-summary: LLMKube Model/InferenceService
+#     CRDs, not HelmReleases — a HR-targeted patch can't reach them. They set
+#     podLabels on the CRD; topologySpreadConstraints is pending
+#     defilantech/LLMKube#794 landing in a released chart.
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+    patch: |-
+      - op: add
+        path: /spec/values/defaultPodOptions/topologySpreadConstraints
+        value:
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                igpu-workload: "true"
+      - op: add
+        path: /spec/values/defaultPodOptions/labels
+        value:
+          igpu-workload: "true"


### PR DESCRIPTION
## What

DRY up the iGPU `igpu-workload` spread: add a reusable **`components/igpu-spread`** component (same pattern as `components/dragonfly`/`postgres`/`volsync`) instead of copy-pasting the label + `topologySpreadConstraints` block into each HelmRelease.

The component patches an app-template HR's `spec.values.defaultPodOptions` to add:
- `labels.igpu-workload: "true"`
- a soft `topologySpreadConstraints` (maxSkew 1 / `kubernetes.io/hostname` / `ScheduleAnyway`)

## Wired up

Included alongside `components/gpu` on the bjw-s app-template iGPU workloads, with their inline blocks removed:
- plex, stash, tdarr-node, ersatztv  (−36 lines, +4 one-line includes)

## Kept manual (documented in the component header)

These can't use the component and keep their own implementation:
- **kyoo** — `zoriya/helm-charts/kyoo` chart (not app-template): flat pod-spec keys under the controller, no `defaultPodOptions`. Label + spread live on `controllers.transcoder`.
- **llama-embed / llama-rerank / llama-summary** — LLMKube `Model`/`InferenceService` CRDs, not HelmReleases, so a HR-targeted patch can't reach them. They set `podLabels` on the CRD; topologySpread is pending defilantech/LLMKube#794 landing in a released chart.

## Validation

`flate test ks` passes (156). Because flate renders the HRs *with* the component applied, the pass confirms the `op: add` succeeded (it would error if `defaultPodOptions` were absent) and the spread renders into valid Deployments. Note: `flate build` doesn't emit chartRef-rendered pod specs in this setup, so I couldn't grep the final Deployment — worth a glance at one rolled pod post-merge to confirm the constraint landed.
