### PR TITLE
feat(renovate): allow mise install && lock post-upgrade task

### DIFF
--- a/kubernetes/apps/base/renovate/renovate-jobs/joryirving.yaml
+++ b/kubernetes/apps/base/renovate/renovate-jobs/joryirving.yaml
@@ -47,7 +47,7 @@ spec:
       value: debug
     - name: RENOVATE_ALLOWED_COMMANDS
       value: |-
-        ["pnpm run bundle"]
+        ["pnpm run bundle", "^mise install && mise lock$"]
     - name: RENOVATE_ALLOWED_UNSAFE_EXECUTIONS
       value: |-
         ["mise"]


### PR DESCRIPTION
Allow-lists `mise install && mise lock` so the `postUpgradeTasks` step in `renovate-config` can run.

**Why:** the operator regenerates `mise.lock` in a container with no usable node for mise, so npm-backed tools (`oxfmt`) get dropped and `mise install --locked` fails on every PR across repos. The companion `renovate-config` PR adds a post-upgrade task that runs `mise install` first (installs the config-pinned node) so the lock resolves; `allowedCommands` must permit it or the task is skipped.

Pairs with joryirving/renovate-config#7. No effect until both merge.