### PR TITLE
feat(games): add gpu game streaming

### DIFF
--- a/docs/superpowers/plans/2026-06-22-gpu-game-streaming.md
+++ b/docs/superpowers/plans/2026-06-22-gpu-game-streaming.md
@@ -1,0 +1,55 @@
+# GPU Game Streaming Implementation Plan
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+**Goal:** Deploy Games-on-Whales (Wolf + Fenrir) with Test Ball app and a GPU handoff watcher in the main cluster, enabling game streaming that yields the NVIDIA GPU to Direwolf sessions and restores LLM inference after idle timeout.
+**Architecture:** Wolf/Fenrir in base/games, Flux Kustomization overlays in main/games. gpu-handoff-watcher watches Direwolf CRDs, scales llama-nvidia InferenceService to 0 during active sessions, restores after idle timeout.
+**Tech Stack:** Games-on-Whales (shrinedogg/dsluo), Flux HelmRelease + OCIRepository, app-template for watcher, llmkube InferenceService API, Kubernetes RBAC.
+---
+
+## Prerequisites
+
+- [ ] Verify Games-on-Whales chart version and CRDs against upstream (shrinedogg/dsluo pattern). Pull Fenrir CRDs to `fenrir-crds.yaml` before Wolf deploys.
+- [ ] Confirm `llama-nvidia` InferenceService current replica count is 1 and `priority` field supports scaling to 0 without data loss.
+
+## Base: Games-on-Whales
+
+- [ ] Create `kubernetes/apps/base/games/games-on-whales/` directory
+- [ ] Create `kustomization.yaml` — list all resources, no inline namespace
+- [ ] Create `ocirepository.yaml` — pin Wolf chart by tag via OCIRepository named `games-on-whales`
+- [ ] Create `fenrir-source.yaml` — separate OCI source for Fenrir chart (if not bundled with Wolf)
+- [ ] Create `fenrir-crds.yaml` — static CRD manifests pulled from chart, applied before HelmRelease
+- [ ] Create `helmrelease.yaml` — Wolf deployment via app-template or native GoW chart. Include Test Ball in `apps.yaml` or inline values. Follow repo sorting rules.
+- [ ] Create `user.yaml` — default user config ConfigMap/Secret (use external-secrets for credentials)
+- [ ] Create `apps.yaml` — App definitions including Test Ball
+- [ ] Create `wolf-entrypoint.yaml` — any custom entrypoint or env overrides needed
+
+## Base: GPU Handoff Watcher
+
+- [ ] Create `kubernetes/apps/base/games/gpu-handoff-watcher/` directory
+- [ ] Create `kustomization.yaml`
+- [ ] Create `ocirepository.yaml` — app-template OCIRepository named `gpu-handoff-watcher`
+- [ ] Create `configmap.yaml` — `INFERENCESERVICE_NAME=llama-nvidia`, `INFERENCESERVICE_NAMESPACE=llm`, `IDLE_TIMEOUT=900`, `WATCHER_NAMESPACE=games`
+- [ ] Create `rbac.yaml` — Role + RoleBinding to watch `direwolf` CRDs in games ns, patch `inferenceservice` in llm ns (ClusterRole if cross-ns)
+- [ ] Create `helmrelease.yaml` — app-template Deployment running the watcher script. Resource limits: 64Mi memory, 50m CPU.
+
+## Main Cluster Overlay
+
+- [ ] Create `kubernetes/apps/main/games/games-on-whales.yaml` — Flux Kustomization pointing to `./kubernetes/apps/base/games/games-on-whales`, with `postBuild.substitute.APP=games-on-whales`
+- [ ] Create `kubernetes/apps/main/games/gpu-handoff-watcher.yaml` — Flux Kustomization pointing to `./kubernetes/apps/base/games/gpu-handoff-watcher`, with `postBuild.substitute.APP=gpu-handoff-watcher`
+- [ ] Update `kubernetes/apps/main/games/kustomization.yaml` — add both resources to the list
+
+## Optional: Priority Adjustment
+
+- [ ] If needed, add `priority` field to `qwen3.6-27b.yaml` InferenceService spec to allow the watcher to scale replicas safely. Verify with llmkube docs.
+
+## Validation
+
+- [ ] Run `flate test all --path ./kubernetes/clusters/main` — must pass with no render errors
+- [ ] Run `git diff` review — verify namespace injection via kustomization, no plain-text secrets, YAML sorting rules followed, OCIRepository per-app pattern correct
+- [ ] Verify Fenrir CRDs are applied before Wolf HelmRelease (check kustomization resource order or HelmRelease dependsOn)
+
+## Notes
+
+- Follow shrinedogg/dsluo patterns for GoW config. Their docs and examples are the source of truth for Wolf/Fenrir interaction.
+- Pull and verify chart CRDs before commit — don't rely on runtime CRD installation for Fenrir.
+- The watcher must handle the case where llama-nvidia doesn't exist yet (cluster bootstrap race). Use a startup probe or init container that waits for the InferenceService CRD.
+- First PR excludes Steam/NonSteamLaunchers/Genshin/Honkai. Add an `apps.yaml` comment noting these are future scope.

--- a/docs/superpowers/specs/2026-06-22-gpu-game-streaming-design.md
+++ b/docs/superpowers/specs/2026-06-22-gpu-game-streaming-design.md
@@ -1,0 +1,78 @@
+# GPU Game Streaming Design
+
+## Scope
+
+Deploy Games-on-Whales (Wolf + Fenrir) in `main/games` namespace with a Test Ball app, plus a hybrid GPU handoff watcher that manages GPU contention between game streaming and LLM inference. Steam launchers, Genshin Impact, and Honkai are explicitly out of scope; a future note may reference them.
+
+## Architecture
+
+### Games-on-Whales
+
+- **Wolf** — The main container runtime. Handles session management, VR streaming, and app orchestration. Deployed via HelmRelease using the official GoW chart.
+- **Fenrir** — Wolf's companion CRD controller. Manages custom resources (`Direwolf` sessions, `App` definitions). Requires CRDs applied before Wolf starts.
+- **Test Ball** — Minimal first-party app included for smoke-testing the streaming pipeline end-to-end without requiring a full game asset.
+
+### GPU Handoff Watcher
+
+A lightweight watcher that monitors `Direwolf` session state and adjusts the `llama-nvidia` InferenceService replica count:
+
+1. Detects active Direwolf sessions via the Kubernetes API.
+2. Scales `llama-nvidia` replicas from 1 → 0 when sessions exist.
+3. Waits for all sessions to go idle up to a configurable timeout (default 15 min).
+4. Restores `llama-nvidia` replicas to 1 after sessions end and idle timeout elapses.
+
+The watcher runs as a standard Deployment in the `games` namespace with RBAC to watch `Direwolf` CRDs and patch the `InferenceService`.
+
+### File Layout
+
+```
+kubernetes/apps/base/games/
+├── games-on-whales/
+│   ├── kustomization.yaml
+│   ├── ocirepository.yaml
+│   ├── helmrelease.yaml
+│   ├── fenrir-source.yaml        # Fenrir Helm chart OCI source
+│   ├── fenrir-crds.yaml          # Pre-pulled CRD manifests
+│   ├── user.yaml                 # Default user config
+│   ├── apps.yaml                 # App definitions (Test Ball)
+│   └── wolf-entrypoint.yaml      # Custom entrypoint overrides
+├── gpu-handoff-watcher/
+│   ├── kustomization.yaml
+│   ├── ocirepository.yaml
+│   ├── helmrelease.yaml
+│   ├── configmap.yaml            # Timeout, InferenceService ref
+│   └── rbac.yaml                 # Watch Direwolf, patch InferenceService
+
+kubernetes/apps/main/games/
+├── kustomization.yaml            # Add games-on-whales.yaml, gpu-handoff-watcher.yaml
+├── games-on-whales.yaml          # Flux Kustomization overlay
+└── gpu-handoff-watcher.yaml      # Flux Kustomization overlay
+```
+
+Optionally: `kubernetes/apps/base/llm/llmkube/models/qwen3.6-27b.yaml` may need a `priority` field adjustment to allow preemption during handoff.
+
+## Handoff Behavior
+
+| Condition | llama-nvidia replicas | Action |
+|---|---|---|
+| No active Direwolf sessions | 1 | Normal operation |
+| New Direwolf session created | 0 → scale down | Immediate |
+| Sessions exist, idle < timeout | 0 | Hold |
+| All sessions ended, idle > timeout | 0 → 1 | Restore |
+
+The watcher never scales llama-nvidia above its original replica count. It only scales to zero and back.
+
+## Validation
+
+- `flate test all --path ./kubernetes/clusters/main` — renders all Kustomizations + HelmReleases
+- `git diff` review before push — verify no secrets, correct namespace injection, sorting rules followed
+- Smoke-test: deploy Test Ball, verify streaming session, confirm llama-nvidia scales to 0, end session, wait for timeout, confirm restore
+
+## Non-Goals
+
+- Steam launcher support
+- NonSteamLauncher integration
+- Genshin Impact
+- Honkai series games
+- Multi-GPU handoff (single GPU assumption)
+- Persistent volume provisioning for game assets (out of scope for initial PR)

--- a/kubernetes/apps/base/games/games-on-whales/app/apps.yaml
+++ b/kubernetes/apps/base/games/games-on-whales/app/apps.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/shrinedogg/fenrir/main/schemas/direwolf.games-on-whales.github.io/app.json
+apiVersion: direwolf.games-on-whales.github.io/v1alpha1
+kind: App
+metadata:
+  name: testball
+spec:
+  appAssetWebP: UklGRlQAAABXRUJQVlA4IEgAAADQHQCdASKShYsoBDAqD0IaqbUZmPk4EnHR8QBs
+  id: 1
+  isHDRSupported: true
+  title: Test Ball
+  wolfConfig:
+    audio:
+      source: audiotestsrc wave=ticks is-live=true
+    runtimeVariables:
+      renderNode: /dev/dri/renderD128
+    startAudioServer: false
+    startVirtualCompositor: false
+    video:
+      source: |
+        videotestsrc pattern=ball flip=true is-live=true !
+        video/x-raw, framerate={fps}/1

--- a/kubernetes/apps/base/games/games-on-whales/app/helmrelease.yaml
+++ b/kubernetes/apps/base/games/games-on-whales/app/helmrelease.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: games-on-whales
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: games-on-whales
+  interval: 1h
+  dependsOn: []
+  values:
+    controllers:
+      direwolf_operator:
+        serviceAccount:
+          identifier: games-on-whales
+        containers:
+          operator:
+            args:
+              - "--lb-sharing-key=direwolf"
+            env:
+              AGENT_IMAGE: docker.io/shrinedogg/wolf-agent:v0.1.0@sha256:1205f62ab4f4dd8cde97387e0055beba62cfe673f91df4ebe38aee0d4cf3cc08
+              POD_NAMESPACE: games
+              WOLF_IMAGE: docker.io/shrinedogg/wolf:v0.1.0@sha256:9d062c45ed7533ba5949db3d739448a83aa6c85a712a41193c496d4b6c1158f8
+            image:
+              digest: sha256:398681deb415a4220fd3c68c6c500dbd2f5251f458be716e8663dd5152516df6
+              repository: docker.io/shrinedogg/direwolf-operator
+              tag: v0.1.0
+      moonlight_proxy:
+        containers:
+          proxy:
+            image:
+              digest: sha256:e8b7cf17ea1bab75c1cec1889a1166ebb3da4c5f0972ae8a7d7cc8dc2571fef0
+              repository: docker.io/shrinedogg/moonlight-proxy
+              tag: v0.1.1
+    service:
+      app:
+        annotations:
+          lbipam.cilium.io/ips: 10.69.10.43
+          lbipam.cilium.io/sharing-key: direwolf
+    serviceAccount:
+      games-on-whales: {}

--- a/kubernetes/apps/base/games/games-on-whales/app/kustomization.yaml
+++ b/kubernetes/apps/base/games/games-on-whales/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./rbac.yaml
+  - ./wolf-entrypoint.yaml
+  - ./user.yaml
+  - ./apps.yaml

--- a/kubernetes/apps/base/games/games-on-whales/app/ocirepository.yaml
+++ b/kubernetes/apps/base/games/games-on-whales/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: games-on-whales
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.0.1-25011901255-SNAPSHOT
+  url: oci://ghcr.io/games-on-whales/charts/direwolf-operator

--- a/kubernetes/apps/base/games/games-on-whales/app/rbac.yaml
+++ b/kubernetes/apps/base/games/games-on-whales/app/rbac.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: games-on-whales-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - events
+      - pods
+      - secrets
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - deployments/status
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - direwolf.games-on-whales.github.io
+    resources:
+      - apps
+      - pairings
+      - sessions
+      - users
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - direwolf.games-on-whales.github.io
+    resources:
+      - apps/status
+      - pairings/status
+      - sessions/status
+      - users/status
+    verbs:
+      - get
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: games-on-whales-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: games-on-whales-operator
+subjects:
+  - kind: ServiceAccount
+    name: games-on-whales

--- a/kubernetes/apps/base/games/games-on-whales/app/user.yaml
+++ b/kubernetes/apps/base/games/games-on-whales/app/user.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/shrinedogg/fenrir/main/schemas/direwolf.games-on-whales.github.io/user.json
+apiVersion: direwolf.games-on-whales.github.io/v1alpha1
+kind: User
+metadata:
+  name: alex
+spec:
+  resources:
+    limits:
+      memory: 8G
+      nvidia.com/gpu: "1"
+    requests:
+      memory: 8G
+      nvidia.com/gpu: "1"
+  sidecarPolicies:
+    wolf:
+      env:
+        - name: NVIDIA_DRIVER_CAPABILITIES
+          value: all
+        - name: NVIDIA_VISIBLE_DEVICES
+          value: "all"
+      resources:
+        limits:
+          nvidia.com/gpu: "1"
+        requests:
+          nvidia.com/gpu: "1"
+      volumeMounts:
+        - mountPath: /entrypoint.sh
+          name: wolf-root-entrypoint
+          subPath: entrypoint.sh
+    wolfAgent:
+      securityContext:
+        capabilities:
+          add:
+            - NET_ADMIN
+      volumeMounts:
+        - mountPath: /run/udev
+          name: udev-data
+  volumes:
+    - configMap:
+        defaultMode: 493
+        name: wolf-root-entrypoint
+      name: wolf-root-entrypoint
+    - emptyDir: {}
+      name: udev-data

--- a/kubernetes/apps/base/games/games-on-whales/app/wolf-entrypoint.yaml
+++ b/kubernetes/apps/base/games/games-on-whales/app/wolf-entrypoint.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/v1/configmap.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+  name: wolf-root-entrypoint
+data:
+  entrypoint.sh: |
+    #!/usr/bin/env bash
+    set -e
+
+    source /opt/gow/bash-lib/utils.sh
+
+    # Force root: 10-setup_user.sh becomes a no-op and we never gosu.
+    export UNAME=root PUID=0 PGID=0 HOME=/root
+
+    for init_script in /etc/cont-init.d/*.sh; do
+      gow_log
+      gow_log "[ : executing... ]"
+      # shellcheck source=/dev/null
+      source "$init_script"
+    done
+
+    gow_log "Launching the container's startup script as root"
+    chmod +x /opt/gow/startup.sh
+    exec /opt/gow/startup.sh

--- a/kubernetes/apps/base/games/games-on-whales/crds/fenrir-crds.yaml
+++ b/kubernetes/apps/base/games/games-on-whales/crds/fenrir-crds.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: fenrir-crds
+spec:
+  interval: 1h
+  path: ./crds
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: fenrir
+  wait: true

--- a/kubernetes/apps/base/games/games-on-whales/crds/fenrir-source.yaml
+++ b/kubernetes/apps/base/games/games-on-whales/crds/fenrir-source.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/gitrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: fenrir
+spec:
+  interval: 1h
+  ref:
+    commit: fd91750567dc038b0f608bd86be7bb335601aab0
+  url: https://github.com/shrinedogg/fenrir

--- a/kubernetes/apps/base/games/games-on-whales/crds/kustomization.yaml
+++ b/kubernetes/apps/base/games/games-on-whales/crds/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./fenrir-source.yaml
+  - ./fenrir-crds.yaml

--- a/kubernetes/apps/base/games/gpu-handoff-watcher/configmap.yaml
+++ b/kubernetes/apps/base/games/gpu-handoff-watcher/configmap.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gpu-handoff-watcher-script
+data:
+  watch.sh: |
+    #!/bin/sh
+    set -eu
+
+    # ---- Configuration ----
+    PROMETHEUS_URL="$${PROMETHEUS_URL:-http://prometheus-operated.observability.svc.cluster.local:9090}"
+    LLAMA_JOB="$${LLAMA_JOB:-llama-nvidia}"
+    LLAMA_NAMESPACE="$${LLAMA_NAMESPACE:-llm}"
+    SESSIONS_NAMESPACE="$${SESSIONS_NAMESPACE:-games}"
+    POLL_INTERVAL_SECONDS="$${POLL_INTERVAL_SECONDS:-30}"
+    FORCE_AFTER_SECONDS="$${FORCE_AFTER_SECONDS:-900}"
+    RESTORE_DELAY_SECONDS="$${RESTORE_DELAY_SECONDS:-300}"
+
+    # ---- State (lost on restart, which is fine) ----
+    sessions_active_since=""
+    scaled_down="false"
+    no_sessions_since=""
+
+    # ---- Helpers ----
+    log() { echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] $*"; }
+
+    now_epoch() { date +%s; }
+
+    query_prometheus() {
+      local query="$1"
+      curl -sfG --max-time 10 \
+        --data-urlencode "query=$${query}" \
+        "$${PROMETHEUS_URL}/api/v1/query" \
+        | sed -n 's/.*"value":\[[^]]*,"\([^"]*\)".*/\1/p' \
+        | head -n 1
+    }
+
+    # ---- Check for active game sessions ----
+    # Active = not in Pending or Ended state (someone is playing).
+    has_active_sessions() {
+      local output
+      output=$(kubectl get sessions -n "$${SESSIONS_NAMESPACE}" -o json 2>/dev/null) || {
+        log "WARN: cannot list sessions — CRD may not be installed yet"
+        return 1
+      }
+
+      local active
+      active=$(printf '%s' "$output" | \
+        jq '[.items[]? | select(
+          .status.conditions // [] | map(select(.type == "Ready")) | if length > 0 then .[0].status == "True" else false end
+        )] | length' 2>/dev/null) || {
+        log "WARN: jq failed on sessions output"
+        return 1
+      }
+
+      [ "$${active}" -gt 0 ] 2>/dev/null
+    }
+
+    # ---- Check if llama is busy via Prometheus ----
+    llama_busy() {
+      local requests_processing requests_deferred prompt_tokens predicted_tokens
+
+      requests_processing=$(query_prometheus "max_over_time(llamacpp:requests_processing{job=\"$${LLAMA_JOB}\"}[10m])")
+      requests_deferred=$(query_prometheus "max_over_time(llamacpp:requests_deferred{job=\"$${LLAMA_JOB}\"}[10m])")
+      prompt_tokens=$(query_prometheus "increase(llamacpp:prompt_tokens_total{job=\"$${LLAMA_JOB}\"}[10m])")
+      predicted_tokens=$(query_prometheus "increase(llamacpp:tokens_predicted_total{job=\"$${LLAMA_JOB}\"}[10m])")
+
+      log "llama metrics: processing=$${requests_processing} deferred=$${requests_deferred} prompt_tok=$${prompt_tokens} predict_tok=$${predicted_tokens}"
+
+      local busy="false"
+      if [ "$${requests_processing:-0}" != "0" ] || \
+         [ "$${requests_deferred:-0}" != "0" ] || \
+         [ "$${prompt_tokens:-0}" != "0" ] || \
+         [ "$${predicted_tokens:-0}" != "0" ]; then
+        busy="true"
+      fi
+
+      [ "$busy" = "true" ]
+    }
+
+    # ---- Scale InferenceService ----
+    scale_llama() {
+      local replicas="$1"
+      log "Scaling InferenceService $${LLAMA_JOB} in $${LLAMA_NAMESPACE} to $${replicas} replicas"
+
+      kubectl patch inferenceservice "$${LLAMA_JOB}" \
+        -n "$${LLAMA_NAMESPACE}" \
+        --type merge \
+        -p "{\"spec\":{\"replicas\":$${replicas}}}" 2>/dev/null || {
+        log "ERROR: failed to scale InferenceService — resource may not exist yet"
+        return 1
+      }
+
+      log "Successfully scaled to $${replicas} replica(s)"
+    }
+
+    # ---- Main loop ----
+    log "gpu-handoff-watcher started (poll=$${POLL_INTERVAL_SECONDS}s force=$${FORCE_AFTER_SECONDS}s restore=$${RESTORE_DELAY_SECONDS}s)"
+    log "watching sessions in namespace: $${SESSIONS_NAMESPACE}"
+    log "llama InferenceService: $${LLAMA_NAMESPACE}/$${LLAMA_JOB}"
+
+    while true; do
+      if has_active_sessions; then
+        # ---- Sessions are active ----
+        if [ -z "$${sessions_active_since}" ]; then
+          sessions_active_since=$(now_epoch)
+          log "Active sessions detected"
+        fi
+
+        if [ "$scaled_down" = "false" ]; then
+          force_elapsed=$(( $(now_epoch) - sessions_active_since ))
+
+          if llama_busy; then
+            if [ "$${force_elapsed}" -ge "$${FORCE_AFTER_SECONDS}" ]; then
+              log "LLM busy but force timeout reached ($${force_elapsed}s >= $${FORCE_AFTER_SECONDS}s) — forcing scale-down"
+              scale_llama 0 && scaled_down="true"
+            else
+              remaining=$(( FORCE_AFTER_SECONDS - force_elapsed ))
+              log "Sessions active, LLM busy — waiting $${remaining}s before force (elapsed $${force_elapsed}s)"
+            fi
+          else
+            log "Sessions active, LLM idle — scaling down immediately"
+            scale_llama 0 && scaled_down="true"
+          fi
+        fi
+
+        # Reset restore timer on each active check
+        no_sessions_since=""
+
+      else
+        # ---- No active sessions ----
+        if [ -n "$${sessions_active_since}" ]; then
+          log "All sessions ended"
+          sessions_active_since=""
+        fi
+
+        if [ "$scaled_down" = "true" ]; then
+          if [ -z "$${no_sessions_since}" ]; then
+            no_sessions_since=$(now_epoch)
+          fi
+
+          restore_elapsed=$(( $(now_epoch) - no_sessions_since ))
+          if [ "$${restore_elapsed}" -ge "$${RESTORE_DELAY_SECONDS}" ]; then
+            log "No sessions for $${restore_elapsed}s (>= $${RESTORE_DELAY_SECONDS}s) — restoring InferenceService"
+            scale_llama 1 && scaled_down="false"
+            no_sessions_since=""
+          else
+            remaining=$(( RESTORE_DELAY_SECONDS - restore_elapsed ))
+            log "Waiting $${remaining}s before restore (elapsed $${restore_elapsed}s/$${RESTORE_DELAY_SECONDS}s)"
+          fi
+        fi
+      fi
+
+      sleep "$${POLL_INTERVAL_SECONDS}"
+    done

--- a/kubernetes/apps/base/games/gpu-handoff-watcher/helmrelease.yaml
+++ b/kubernetes/apps/base/games/gpu-handoff-watcher/helmrelease.yaml
@@ -1,0 +1,76 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gpu-handoff-watcher
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gpu-handoff-watcher
+  interval: 15m
+  dependsOn: []
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 100
+        fsGroup: 100
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      gpu-handoff-watcher:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        serviceAccount:
+          identifier: gpu-handoff-watcher
+        containers:
+          app:
+            image:
+              repository: docker.io/alpine/k8s
+              tag: 1.34.1@sha256:ec714df3813b5405292860f8a1c55c5727bf8c33c88992f1e981efad8065547f
+            command:
+              - /bin/sh
+              - -c
+              - |
+                apk add --no-cache curl jq
+                exec /bin/sh /config/watch.sh
+            env:
+              PROMETHEUS_URL: "http://prometheus-operated.observability.svc.cluster.local:9090"
+              LLAMA_JOB: "llama-nvidia"
+              LLAMA_NAMESPACE: "llm"
+              SESSIONS_NAMESPACE: "games"
+              POLL_INTERVAL_SECONDS: "30"
+              FORCE_AFTER_SECONDS: "900"
+              RESTORE_DELAY_SECONDS: "300"
+              TZ: America/Edmonton
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+    persistence:
+      config:
+        type: configMap
+        name: gpu-handoff-watcher-script
+        defaultMode: 0755
+        globalMounts:
+          - path: /config/watch.sh
+            subPath: watch.sh
+            readOnly: true
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          gpu-handoff-watcher:
+            app:
+              - path: /tmp
+                subPath: tmp
+    serviceAccount:
+      gpu-handoff-watcher: {}

--- a/kubernetes/apps/base/games/gpu-handoff-watcher/kustomization.yaml
+++ b/kubernetes/apps/base/games/gpu-handoff-watcher/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/base/games/gpu-handoff-watcher/ocirepository.yaml
+++ b/kubernetes/apps/base/games/gpu-handoff-watcher/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gpu-handoff-watcher
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/games/gpu-handoff-watcher/rbac.yaml
+++ b/kubernetes/apps/base/games/gpu-handoff-watcher/rbac.yaml
@@ -1,0 +1,53 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gpu-handoff-watcher-games
+rules:
+  - apiGroups:
+      - direwolf.games-on-whales.github.io
+    resources:
+      - sessions
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gpu-handoff-watcher-games
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gpu-handoff-watcher-games
+subjects:
+  - kind: ServiceAccount
+    name: gpu-handoff-watcher
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gpu-handoff-watcher-llm
+  namespace: llm
+rules:
+  - apiGroups:
+      - inference.llmkube.dev
+    resources:
+      - inferenceservices
+    verbs:
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gpu-handoff-watcher-llm
+  namespace: llm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: gpu-handoff-watcher-llm
+subjects:
+  - kind: ServiceAccount
+    name: gpu-handoff-watcher
+    namespace: games

--- a/kubernetes/apps/main/games/games-on-whales-crds.yaml
+++ b/kubernetes/apps/main/games/games-on-whales-crds.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: games-on-whales-crds
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/games/games-on-whales/crds
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/kubernetes/apps/main/games/games-on-whales.yaml
+++ b/kubernetes/apps/main/games/games-on-whales.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app games-on-whales
+spec:
+  dependsOn:
+    - name: games-on-whales-crds
+  interval: 1h
+  path: ./kubernetes/apps/base/games/games-on-whales/app
+  postBuild:
+    substitute:
+      APP: *app
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/games/gpu-handoff-watcher.yaml
+++ b/kubernetes/apps/main/games/gpu-handoff-watcher.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: gpu-handoff-watcher
+spec:
+  dependsOn:
+    - name: games-on-whales-crds
+  interval: 1h
+  path: ./kubernetes/apps/base/games/gpu-handoff-watcher
+  postBuild:
+    substitute:
+      APP: gpu-handoff-watcher
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/main/games/kustomization.yaml
+++ b/kubernetes/apps/main/games/kustomization.yaml
@@ -5,13 +5,28 @@ kind: Kustomization
 namespace: games
 components:
   - ../../../components/namespace
+patches:
+  - target:
+      kind: Namespace
+    patch: |
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: not-used
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/audit: privileged
+          pod-security.kubernetes.io/warn: privileged
 replacements:
   - path: ../../../components/replacements/ks.yaml
 resources:
   # - ./core-keeper.yaml
   - ./enshrouded.yaml
+  - ./games-on-whales-crds.yaml
+  - ./games-on-whales.yaml
+  - ./gpu-handoff-watcher.yaml
   - ./minecraft.yaml
-    # - ./palworld.yaml
+  # - ./palworld.yaml
   - ./romm.yaml
   - ./valheim.yaml
-    # - ./vrising.yaml
+  # - ./vrising.yaml


### PR DESCRIPTION
Adds an enabled Games-on-Whales/Fenrir stack in main/games with a Test Ball app for first-pass Moonlight streaming validation. Also adds a GPU handoff watcher that scales llama-nvidia down for active game sessions and restores it after sessions clear.\n\nValidation:\n- flate test all --path ./kubernetes/clusters/main