### PR TITLE
feat(games): gpu sharing via priorityclass preemption + steam app

### DIFF
--- a/kubernetes/apps/base/games/games-on-whales/apps.yaml
+++ b/kubernetes/apps/base/games/games-on-whales/apps.yaml
@@ -87,3 +87,59 @@ spec:
       source: |
         videotestsrc pattern=ball flip=true is-live=true !
         video/x-raw, framerate={fps}/1
+---
+# yaml-language-server: $schema=https://github.com/games-on-whales/fenrir/raw/refs/heads/main/schemas/direwolf.games-on-whales.github.io/app_v1alpha1.json
+apiVersion: direwolf.games-on-whales.github.io/v1alpha1
+kind: App
+metadata:
+  name: steam
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+spec:
+  appAssetWebP: UklGRhwBAABXRUJQVlA4IBABAADQHACdASosAZABPm02mUmkIqKhICgAgA2JaW7hd2EbQAnsA99snIe+2Yy09snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPfbJyHvtk5D32ych77ZOQ99snIe+2TkPekAAD+/9O4f/1K366KRn9B8NO3tyIAAAAAAAAAAAAAAAAAA
+  id: 2
+  isHDRSupported: true
+  title: Steam
+  wolfConfig:
+    runtimeVariables:
+      renderNode: /dev/dri/renderD128
+  volumeClaimTemplate:
+    accessModes:
+      - ReadWriteOnce
+    storageClassName: ceph-block
+    resources:
+      requests:
+        storage: 300Gi
+  template:
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/games-on-whales/steam:edge@sha256:ded0b1b47acd9adb8af9f068342f26ac31008904d9bbb91045d1a04e7d66a632
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              nvidia.com/gpu: "1"
+          command:
+            - /bin/bash
+            - -c
+            - |
+              cleanup() {
+                echo "Cleaning up..." >&2
+                exit 0
+              }
+              trap cleanup SIGINT SIGTERM
+
+              while [ ! -S $XDG_RUNTIME_DIR/$WAYLAND_DISPLAY ]; do
+                echo "Waiting for wayland display..." >&2
+                sleep 1
+              done
+
+              while [ ! -S $XDG_RUNTIME_DIR/pulse-socket ]; do
+                echo "Waiting for pulse socket..." >&2
+                sleep 1
+              done
+
+              export PULSE_SINK="$(pactl list sinks short | awk '$2 ~ /^virtual_sink/ {print $2; exit}')"
+              export PULSE_SOURCE="${PULSE_SINK}.monitor"
+              exec /entrypoint.sh

--- a/kubernetes/apps/base/kube-system/nvidia-device-plugin/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/nvidia-device-plugin/helmrelease.yaml
@@ -12,6 +12,18 @@ spec:
   values:
     runtimeClassName: nvidia
     failOnInitError: false
+    config:
+      default: timeslice
+      map:
+        timeslice: |-
+          version: v1
+          flags:
+            migStrategy: none
+          sharing:
+            timeSlicing:
+              resources:
+                - name: nvidia.com/gpu
+                  replicas: 2
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/apps/base/llm/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./priorityclass.yaml
   - ./pvc.yaml
   - ./servicemonitor.yaml
   - ./qwen3.6-27b.yaml

--- a/kubernetes/apps/base/llm/llmkube/models/priorityclass.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/priorityclass.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/scheduling.k8s.io/priorityclass_v1.json
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: gpu-preemptible
+value: -100
+globalDefault: false
+description: LLM inference that yields its GPU to default-priority game sessions.

--- a/kubernetes/apps/base/llm/llmkube/models/qwen3.6-27b.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/qwen3.6-27b.yaml
@@ -26,7 +26,7 @@ spec:
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:2ea4be99dab097e84527ec552b8e5a552095cee3625b2cce8c052eb816a6c941
   replicas: 1
-  priority: normal
+  priorityClassName: gpu-preemptible
   runtimeClassName: nvidia
   nodeSelector:
     topology.kubernetes.io: egpu


### PR DESCRIPTION
Recreates dsluo's "GPU sharing via PriorityClass preemption" for Games-on-Whales on the single 3090, and adds an experimental Steam / NonSteamLaunchers app. Replaces the GPU-handoff *watcher* (removed in the earlier refactor) with scheduler-driven preemption — no custom controller.

## Mechanism

1. **Time-slice the 3090** so it advertises `nvidia.com/gpu: 2` (shared VRAM, no partition).
2. **`llama-nvidia` runs under `gpu-preemptible` (-100)** and holds 1 of 2 slices.
3. A game session is **wolf (1) + app (1) = 2** GPU requests at default priority (0). Only 1 slice is free → the scheduler **preempts** the -100 LLM → 2 free → session runs with the full GPU. When the session ends, llama's pending pod reschedules and reloads. No watcher, no fork.

`replicas: 2` is deliberate: more would leave room for llama to co-exist with a game and VRAM-OOM on the shared 24 GB; fewer blocks 2-GPU sessions. (Test Ball is wolf-only = 1 GPU, so it co-runs with llama without preempting — expected.)

## Changes

- `nvidia-device-plugin`: time-slicing config (`replicas: 2`).
- `llmkube`: new `gpu-preemptible` PriorityClass; `qwen3.6-27b` InferenceService set to `priorityClassName: gpu-preemptible` (replaces `priority: normal` — llmkube 0.8.14 honors `priorityClassName` over the enum).
- `games-on-whales`: Steam app (id 2) with a 300Gi `ceph-block` PVC for the Proton prefix + game installs.

## Networking

Moonlight stays on the Cilium LB IP. It can't move behind Envoy Gateway: the gateway is HTTP-only and Moonlight is multi-port L4 with per-session dynamic UDP ports. Detail in the spec.

## Deferred to post-apply (runtime, can't be validated in CI)

- Confirm node advertises `nvidia.com/gpu: 2`; llama pod resolves to priority -100.
- Confirm preemption: Test Ball co-runs; a 2-GPU app evicts llama; llama reloads on session end.
- Steam PVC binds; **verify the actual NVIDIA render node on ganyu** — if it isn't `renderD128`, fix `renderNode` in both Apps and correct the stale `talos1`/3090-Ti comments (spec item #4, intentionally gated on this check).

## Caveat

Genshin/Honkai via HoYoPlay are an **experiment, not a deliverable**: the same mhyprot/ACE anti-cheat that's "borked"/ban-risk under containerized Proton applies to all HoYo titles. This ships the pipeline + launcher; whether the games launch is unknown until tested.

Migrating this to the skirk Strix Halo node is future work (different GPU access model — DRA, not device-plugin time-slicing).
