### PR TITLE
feat(llm): serve Ornith-1.0-35B on llama-strix-b

### DIFF
--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -8,10 +8,10 @@ data:
     model_list:
       # These aliases keep the client-facing names stable while LiteLLM
       # forwards the upstream model IDs that each llama.cpp server expects.
-      # self-hosted (#strix-2x35b): two Strix instances (llama-strix-a/b, Qwen3.6-35B-A3B
-      # Q5, 262k, 2 slots each) + Mac LM Studio leg; litellm simple-shuffle spreads across
-      # all three (Mac only when the laptop's up). 2+2, not 3+2: leaves the APU GTT headroom
-      # for comfyui (5 slots starved its iGPU allocation → OOM).
+      # self-hosted (#strix-2x35b): llama-strix-a (Qwen3.6-35B-A3B Q5, 262k, 2 slots) +
+      # Mac LM Studio leg; litellm simple-shuffle spreads across both (Mac only when the
+      # laptop's up). llama-strix-b now serves the standalone `ornith` model — its
+      # self-hosted leg is kept below, commented out, to restore the 2× split.
       - model_name: self-hosted
         model_info:
           mode: chat
@@ -30,23 +30,23 @@ data:
           max_parallel_requests: 2
           order: 1
 
-      - model_name: self-hosted
-        model_info:
-          mode: chat
-          input_cost_per_token: 0.0000001250
-          cache_creation_input_token_cost: 0.0000001250
-          cache_read_input_token_cost: 0.0000000125
-          output_cost_per_token: 0.0000004999
-          max_input_tokens: 262144
-          max_output_tokens: 16384
-          supports_function_calling: true
-          supports_vision: true
-        litellm_params:
-          model: openai/self-hosted
-          api_base: http://llama-strix-b.llm:8080/v1
-          api_key: llama-strix-b
-          max_parallel_requests: 2
-          order: 1
+      # - model_name: self-hosted
+      #   model_info:
+      #     mode: chat
+      #     input_cost_per_token: 0.0000001250
+      #     cache_creation_input_token_cost: 0.0000001250
+      #     cache_read_input_token_cost: 0.0000000125
+      #     output_cost_per_token: 0.0000004999
+      #     max_input_tokens: 262144
+      #     max_output_tokens: 16384
+      #     supports_function_calling: true
+      #     supports_vision: true
+      #   litellm_params:
+      #     model: openai/self-hosted
+      #     api_base: http://llama-strix-b.llm:8080/v1
+      #     api_key: llama-strix-b
+      #     max_parallel_requests: 2
+      #     order: 1
 
       - model_name: self-hosted
         model_info:
@@ -91,6 +91,25 @@ data:
           api_base: http://llama-nvidia.llm:8080/v1
           api_key: llama-nvidia
           max_parallel_requests: 1
+
+      # ornith (#strix-2x35b): Ornith-1.0-35B (Q5_K_M, 262k, 2 slots) on llama-strix-b,
+      # agentic-coding MoE. Standalone — no fallback, not in the auto router.
+      - model_name: ornith
+        model_info:
+          mode: chat
+          input_cost_per_token: 0.0000001250
+          cache_creation_input_token_cost: 0.0000001250
+          cache_read_input_token_cost: 0.0000000125
+          output_cost_per_token: 0.0000004999
+          max_input_tokens: 262144
+          max_output_tokens: 16384
+          supports_function_calling: true
+          supports_vision: false
+        litellm_params:
+          model: openai/ornith
+          api_base: http://llama-strix-b.llm:8080/v1
+          api_key: llama-strix-b
+          max_parallel_requests: 2
 
       - model_name: qwen3-embedding-0-6b
         model_info:

--- a/kubernetes/apps/base/llm/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/kustomization.yaml
@@ -10,8 +10,9 @@ resources:
   - ./llama-embed.yaml
   - ./llama-rerank.yaml
   - ./llama-summary.yaml
-  # 2× 35B-Q5 (#strix-2x35b): two llama-strix-a/b instances (2 slots each) own the
-  # Strix; litellm simple-shuffle spreads `self-hosted` across them. 2+2 (not 3+2) keeps
-  # APU GTT headroom for comfyui. 35B-Q8 alt off.
+  # 2× 35B-Q5 (#strix-2x35b): two instances (2 slots each) share the Strix —
+  # llama-strix-a serves `self-hosted` (Qwen3.6-35B-A3B), llama-strix-b serves the
+  # standalone `ornith` model (Ornith-1.0-35B). 2+2 (not 3+2) keeps APU GTT headroom
+  # for comfyui. 35B-Q8 alt off.
   # - ./llama-strix.yaml
   - ./llama-strix-35b-q5.yaml

--- a/kubernetes/apps/base/llm/llmkube/models/llama-strix-35b-q5.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/llama-strix-35b-q5.yaml
@@ -32,6 +32,24 @@ spec:
           resourceClaimTemplateName: llama-strix-gpu
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: ornith-1.0-35b
+spec:
+  source: pvc://llm-models/ornith-1.0-35b/ornith-1.0-35b-Q5_K_M.gguf
+  format: gguf
+  quantization: Q5_K_M
+  hardware:
+    accelerator: rocm
+    gpu:
+      enabled: true
+      vendor: amd
+      layers: 99
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: llama-strix-gpu
+---
+apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
 metadata:
   name: llama-strix-a
@@ -139,7 +157,7 @@ metadata:
   labels:
     krr/ignore: "true"
 spec:
-  modelRef: qwen3.6-35b-a3b-q5
+  modelRef: ornith-1.0-35b
   runtime: llamacpp
   image: docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:8a59a303e2b4c99dcd1d339411e72473bb034b6f8ffd8317f17f7931b62ea8ca
   command:
@@ -172,26 +190,10 @@ spec:
     type: ClusterIP
   extraArgs:
     - --alias
-    - self-hosted
-    - --mmproj
-    - /model-source/qwen3.6-35b-a3b-q5/mmproj-F16.gguf
+    - ornith
     - --cont-batching
-    - --spec-type
-    - draft-mtp
-    - --spec-draft-p-min
-    - "0.75"
-    - --spec-draft-n-max
-    - "3"
-    - --spec-draft-type-k
-    - q8_0
-    - --spec-draft-type-v
-    - q8_0
-    - -sps
-    - "0.75"
     - --cache-prompt
     - --kv-unified
-    - --image-min-tokens
-    - "1024"
     - --temp
     - "0.6"
     - --top-p


### PR DESCRIPTION
## Summary
- Repoint `llama-strix-b` from the second Qwen3.6-35B-A3B-Q5 `self-hosted` leg to a new `ornith-1.0-35b` Model (Ornith-1.0-35B, Q5_K_M), aliased `ornith`.
- Drop `--mmproj` and the whole `--spec-type draft-mtp` / `--spec-draft-*` / `-sps` / `--image-min-tokens` block — Ornith is text-only with no MTP draft head.
- litellm: add a standalone `ornith` model (→ `llama-strix-b`, no fallback, not in the `auto` router); the strix-b `self-hosted` leg is **commented out**, not removed, so the 2x split can be restored.
- `llama-strix-a` untouched — still serves `self-hosted` alongside the Mac leg.

## Verification
- `flate test all --path ./kubernetes/clusters/main` → 413 passed (only the pre-existing mc-router warning)
- `flate diff ks` confirms: strix-b alias/modelRef/extraArgs delta + new `ornith-1.0-35b` Model + the litellm ConfigMap change

## Notes
- **Pre-merge requirement:** the GGUF must be staged on the `llm-models` PVC (skirk) at `ornith-1.0-35b/ornith-1.0-35b-Q5_K_M.gguf` (`modelCache` is disabled, so no auto-download) **before** this reconciles, or `llama-strix-b` crashloops on a missing file. One-off `hf download` Job, run out of band.
- **Verify after rollout:** Ornith's card warns the Qwen chat template needs modification. With `jinja: true` llama.cpp uses the GGUF's embedded template — if thinking/tool-calls come back empty or malformed, add `--chat-template-file`.