### PR TITLE
feat(llm): add deepwiki-open

### DIFF
--- a/kubernetes/apps/base/llm/deepwiki/configmap.yaml
+++ b/kubernetes/apps/base/llm/deepwiki/configmap.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deepwiki-config
+data:
+  embedder.json: |
+    {
+      "embedder": {
+        "client_class": "OpenAIClient",
+        "initialize_kwargs": {
+          "api_key": "$${OPENAI_API_KEY}",
+          "base_url": "$${OPENAI_BASE_URL}"
+        },
+        "batch_size": 10,
+        "model_kwargs": {
+          "model": "qwen3-embedding-0-6b",
+          "dimensions": 1024,
+          "encoding_format": "float"
+        }
+      },
+      "retriever": {
+        "top_k": 20
+      },
+      "text_splitter": {
+        "split_by": "word",
+        "chunk_size": 350,
+        "chunk_overlap": 100
+      }
+    }
+  generator.json: |
+    {
+      "default_provider": "openai",
+      "providers": {
+        "openai": {
+          "default_model": "self-hosted",
+          "supportsCustomModel": true,
+          "models": {
+            "self-hosted": {
+              "temperature": 0.7,
+              "top_p": 0.8
+            }
+          }
+        }
+      }
+    }

--- a/kubernetes/apps/base/llm/deepwiki/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/deepwiki/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name deepwiki
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        OPENAI_API_KEY: "{{ .LITELLM_MASTER_KEY }}"
+  dataFrom:
+    - extract:
+        key: litellm

--- a/kubernetes/apps/base/llm/deepwiki/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/deepwiki/helmrelease.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: deepwiki
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: deepwiki
+  interval: 15m
+  dependsOn: []
+  values:
+    controllers:
+      deepwiki:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/asyncfuncai/deepwiki-open
+              tag: main@sha256:122fb1cef471aedcc74ade93272e81caf0c0a580663ef0447f549f0b0a10fbe4
+            env:
+              SERVER_BASE_URL: http://localhost:8001
+              OPENAI_BASE_URL: http://litellm.llm:4000/v1
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}"
+            resources:
+              requests:
+                cpu: 100m
+              limits:
+                memory: 2Gi
+    persistence:
+      adalflow:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /root/.adalflow
+      config:
+        type: configMap
+        name: deepwiki-config
+        advancedMounts:
+          deepwiki:
+            app:
+              - path: /app/api/config/embedder.json
+                subPath: embedder.json
+                readOnly: true
+              - path: /app/api/config/generator.json
+                subPath: generator.json
+                readOnly: true
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.jory.dev"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - name: "{{ .Release.Name }}"
+                port: 3000
+    service:
+      app:
+        ports:
+          http:
+            port: 3000
+          api:
+            port: 8001

--- a/kubernetes/apps/base/llm/deepwiki/kustomization.yaml
+++ b/kubernetes/apps/base/llm/deepwiki/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/deepwiki/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/deepwiki/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: deepwiki
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/main/llm/deepwiki.yaml
+++ b/kubernetes/apps/main/llm/deepwiki.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app deepwiki
+spec:
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: litellm
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/deepwiki
+  postBuild:
+    substitute:
+      APP: *app
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/llm/kustomization.yaml
+++ b/kubernetes/apps/main/llm/kustomization.yaml
@@ -9,6 +9,7 @@ replacements:
   - path: ../../../components/replacements/ks.yaml
 resources:
   - ./comfyui.yaml
+  - ./deepwiki.yaml
   - ./hermes.yaml
   - ./litellm.yaml
   - ./llmkube.yaml


### PR DESCRIPTION
## Summary
- Add DeepWiki-Open to the `llm` namespace (app-template HR + ConfigMap + ExternalSecret + Flux KS), internal-only at `deepwiki.jory.dev`.
- Generator → `self-hosted` (strix ornith-35B), embedder → `qwen3-embedding-0-6b` @ 1024 dims, both via in-cluster LiteLLM (`http://litellm.llm:4000/v1`). Config injected by subPath-mounting `embedder.json`/`generator.json` over the image's `/app/api/config`.
- Storage via the volsync component (auto-provisioned `deepwiki` PVC at `/root/.adalflow`); `OPENAI_API_KEY` from the 1Password `litellm` item.

## Notes
- Runtime `${OPENAI_*}` placeholders in the ConfigMap are escaped (`$${...}`) so Flux envsubst leaves them for DeepWiki to resolve.
- Image has no semver tags; pinned by digest (Renovate tracks digest updates).
- Two deploy-time checks: (1) wiki-generation stream may need `NEXT_PUBLIC_SERVER_BASE_URL` + a route to the `:8001` service if the UI hangs (Next.js rewrites cover the rest in-pod); (2) if `llama-embed` rejects the `dimensions` param, drop it (Qwen returns 1024 natively).

## Verification
- `kustomize build kubernetes/apps/base/llm/deepwiki` — OK
- volsync component layering + `APP` substitution renders the PVC/ReplicationSource/Destination — OK