### PR TITLE
feat(llm): spin up Foreman (stub mode) as an experiment

### DIFF
--- a/kubernetes/apps/base/llm/foreman/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/foreman/helmrelease.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: foreman
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: foreman
+  interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    operator:
+      enabled: true
+    agent:
+      enabled: true
+      # stub: registers a FleetNode + writes synthetic Succeeded results.
+      # No GitHub token, no model inference, no repo pushes — control-plane
+      # smoke test only. Flip to `native` + wire githubToken/gitRemoteURL/
+      # inferenceServiceRef to actually run the self-hosted Qwen coder.
+      mode: stub
+      roles:
+        - worker
+        - verifier
+      gateCache:
+        enabled: false
+    coder:
+      enabled: false

--- a/kubernetes/apps/base/llm/foreman/kustomization.yaml
+++ b/kubernetes/apps/base/llm/foreman/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/llm/foreman/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/foreman/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: foreman
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.8.18
+  url: oci://ghcr.io/defilantech/charts/foreman

--- a/kubernetes/apps/main/llm/foreman.yaml
+++ b/kubernetes/apps/main/llm/foreman.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app foreman
+spec:
+  dependsOn:
+    - name: llmkube
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/foreman
+  postBuild:
+    substitute:
+      APP: *app
+      CLUSTER: ${CLUSTER}
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/main/llm/kustomization.yaml
+++ b/kubernetes/apps/main/llm/kustomization.yaml
@@ -10,6 +10,7 @@ replacements:
 resources:
   - ./comfyui.yaml
   - ./deepwiki.yaml
+  - ./foreman.yaml
   - ./hermes.yaml
   - ./litellm.yaml
   - ./llmkube.yaml


### PR DESCRIPTION
Stands up LLMKube's opt-in agentic control plane ([Foreman](https://llmkube.com/docs/foreman)) as a low-stakes experiment — operator + one agent in the `llm` namespace, Flux-managed so tearing it down is just reverting this.

## What lands
- `oci://ghcr.io/defilantech/charts/foreman` `0.8.18` (same registry as the llmkube operator), `dependsOn: llmkube`.
- foreman-operator (the 4 controllers for `Workload`/`AgenticTask`/`Agent`/`FleetNode`) + 5 CRDs + a self-signed validating webhook (no cert-manager dep).
- foreman-agent in **`mode: stub`** — registers a `FleetNode` and writes synthetic `Succeeded` results. **No GitHub token, no model inference, no repo pushes** — this only exercises the control plane.
- `gateCache` PVC + Job-mode coder SA disabled (unused in stub).

## Why stub first
It validates the whole machinery (CRD install, operator reconcile, scheduler, FleetNode registration) with zero blast radius. Native mode — which actually runs a coder against our self-hosted Qwen3.6-35B-A3B (Foreman's documented reference coder) — needs real GitHub auth + a target repo/fork + an Agent CR, which are deliberate decisions for a follow-up.

## Validation
`helm template` render-checked with these values (clean: 2 Deployments, 5 CRDs, webhook, RBAC; gateCache drops cleanly; the `--coder-git-secret` flag is lazy, not a mount, so no secret needed in stub). `kustomize build` + server-side dry-run pass.

## After merge
FleetNode should self-register. To go native: flip `agent.mode: native`, add `githubToken`/`gitRemoteURL`/`commitAuthor*`, and an `Agent` (role: coder) with `inferenceServiceRef` → `llama-strix-a`, then apply a `Workload`.