### PR TITLE
feat(llmkube): shared RWX model cache + sunset ceph stage jobs (phase 1)

### DIFF
--- a/kubernetes/apps/base/llm/llmkube/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/llmkube/helmrelease.yaml
@@ -18,7 +18,11 @@ spec:
       retries: 3
   values:
     modelCache:
-      enabled: false
+      enabled: true
+      mode: shared
+      accessMode: ReadWriteMany
+      storageClass: ceph-filesystem
+      size: 200Gi
     prometheus:
       inferencePodMonitor:
         enabled: false

--- a/kubernetes/apps/base/llm/llmkube/models/llama-embed.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/llama-embed.yaml
@@ -4,7 +4,9 @@ kind: Model
 metadata:
   name: qwen3-embedding-0.6b
 spec:
-  source: pvc://llmkube-models/qwen3-embedding-0.6b/Qwen3-Embedding-0.6B-Q8_0.gguf
+  source: hf://Qwen/Qwen3-Embedding-0.6B-GGUF
+  files:
+    - Qwen3-Embedding-0.6B-Q8_0.gguf
   format: gguf
   quantization: Q8_0
   hardware:

--- a/kubernetes/apps/base/llm/llmkube/models/llama-rerank.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/llama-rerank.yaml
@@ -4,7 +4,9 @@ kind: Model
 metadata:
   name: qwen3-reranker-0.6b
 spec:
-  source: pvc://llmkube-models/qwen3-reranker-0.6b/qwen3-reranker-0.6b-q8_0.gguf
+  source: hf://ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF
+  files:
+    - qwen3-reranker-0.6b-q8_0.gguf
   format: gguf
   quantization: Q8_0
   hardware:

--- a/kubernetes/apps/base/llm/llmkube/models/llama-summary.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/llama-summary.yaml
@@ -4,7 +4,9 @@ kind: Model
 metadata:
   name: qwen3.5-4b
 spec:
-  source: https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-UD-Q4_K_XL.gguf
+  source: hf://unsloth/Qwen3.5-4B-GGUF
+  files:
+    - Qwen3.5-4B-UD-Q4_K_XL.gguf
   format: gguf
   quantization: Q4_K_XL
   hardware:

--- a/kubernetes/apps/base/llm/llmkube/models/qwen3.6-27b.yaml
+++ b/kubernetes/apps/base/llm/llmkube/models/qwen3.6-27b.yaml
@@ -4,7 +4,9 @@ kind: Model
 metadata:
   name: qwen3.6-27b
 spec:
-  source: pvc://llmkube-models/qwen3.6-27b/Qwen3.6-27B-UD-Q4_K_XL.gguf
+  source: hf://unsloth/Qwen3.6-27B-MTP-GGUF
+  files:
+    - Qwen3.6-27B-UD-Q4_K_XL.gguf
   format: gguf
   quantization: UD-Q4_K_XL
   hardware:
@@ -69,7 +71,6 @@ spec:
     - --cache-ram
     - "16384"
     - --kv-unified
-    - --metrics
     - --temp
     - "0.6"
     - --top-p

--- a/kubernetes/apps/main/llm/llmkube.yaml
+++ b/kubernetes/apps/main/llm/llmkube.yaml
@@ -99,29 +99,6 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: stage-qwen3-6-27b
-spec:
-  dependsOn:
-    - name: llmkube-models
-  interval: 1h
-  path: ./kubernetes/apps/base/llm/llmkube/stage
-  postBuild:
-    substitute:
-      MODEL_SLUG: qwen3-6-27b
-      MODEL_REPO: unsloth/Qwen3.6-27B-MTP-GGUF
-      MODEL_FILES: Qwen3.6-27B-UD-Q4_K_XL.gguf mmproj-F16.gguf
-      MODEL_DIR: qwen3.6-27b
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  wait: false
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
   name: stage-qwen3-6-35b
 spec:
   dependsOn:
@@ -138,52 +115,6 @@ spec:
       STAGE_NODE_KEY: topology.kubernetes.io/gpus
       STAGE_NODE_VALUE: amd
       STAGE_DEADLINE: "10800"
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  wait: false
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: stage-qwen3-embedding-0-6b
-spec:
-  dependsOn:
-    - name: llmkube-models
-  interval: 1h
-  path: ./kubernetes/apps/base/llm/llmkube/stage
-  postBuild:
-    substitute:
-      MODEL_SLUG: qwen3-embedding-0-6b
-      MODEL_REPO: Qwen/Qwen3-Embedding-0.6B-GGUF
-      MODEL_FILES: Qwen3-Embedding-0.6B-Q8_0.gguf
-      MODEL_DIR: qwen3-embedding-0.6b
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  wait: false
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: stage-qwen3-reranker-0-6b
-spec:
-  dependsOn:
-    - name: llmkube-models
-  interval: 1h
-  path: ./kubernetes/apps/base/llm/llmkube/stage
-  postBuild:
-    substitute:
-      MODEL_SLUG: qwen3-reranker-0-6b
-      MODEL_REPO: ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF
-      MODEL_FILES: qwen3-reranker-0.6b-q8_0.gguf
-      MODEL_DIR: qwen3-reranker-0.6b
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Enables the operator's shared model cache and moves the **ceph-native** models to native `hf://` multi-file staging (#853, shipped in 0.8.18), retiring their stage Jobs.

## Changes
- **`modelCache`**: `shared` / `ReadWriteMany` / `ceph-filesystem` / 200Gi — one cluster-wide cache the init container downloads into and every InferenceService mounts read-only, reachable from any node (the chart's documented multi-node pattern). Survives restarts → no more re-downloads (also fixes `llama-summary`, which had no cache and re-pulled 2.5GB every restart).
- **Convert 4 models** to `source: hf://<repo>` + `files: [...]`: `nvidia` (qwen3.6-27b), `llama-embed`, `llama-rerank`, `llama-summary`. All public repos → anonymous HTTPS fetch, no token.
- **Drop 3 stage Kustomizations** (`stage-qwen3-6-27b` / `-embedding-0-6b` / `-reranker-0-6b`).
- **extraArgs cleanup**: removed redundant `--metrics` from nvidia (operator auto-adds it). Audited all models — that's the only field-duplicate; everything else (sampling, threads, alias, pooling, mmap, chat-template, spec-decoding) has no first-class field, and `speculativeDecoding` only covers `type`+`nDraftMax` so moving the MTP block would *split* it.

## Scope / deferred
- **Strix** (`ornith`, `qwen3.5-4b-vision`) stays on the node-local `llm-models` stage Job — **phase 2**, once its cephfs cold-load is measured (it's on local-hostpath specifically to stay off ceph). Their `--mmproj` → `spec.mmproj` moves then (it's a staging field; unverified for `pvc://`).
- `llmkube-models` PVC kept (now unused) as rollback until the `hf://` path is confirmed live; prune in a follow-up.

## Validation
0.8.18 chart CRD has `files[]`/`mmproj`; live CRD confirms #853 deployed; all 4 models pass server-side dry-run; `kustomize build` of models + main/llm aggregation pass.

## Watch on merge
Models re-download once into the new cache (nvidia ~16GB, summary ~2.5GB, embed/rerank ~0.6GB each) — first start slower, then cached. `--no-mmap` already set where cephfs cold-fault matters (summary); nvidia keeps `--mmap` (CUDA-on-ceph confirmed fine).