### PR TITLE
feat(llm): add repo-wiki (scheduled LLM repo docs + Otter Wiki)

### DIFF
--- a/kubernetes/apps/base/llm/repo-wiki/config.yaml
+++ b/kubernetes/apps/base/llm/repo-wiki/config.yaml
@@ -1,0 +1,133 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: repo-wiki
+data:
+  repos.txt: |
+    joryirving/*
+    misospace/*
+  prompt.md: |
+    You are documenting a git repository for an engineering reference wiki.
+    Output GitHub-flavored markdown with EXACTLY these H2 sections, in this
+    order, with no additions or omissions:
+
+    ## Overview        — what the repo is and does, in 3-5 sentences
+    ## Architecture    — components and how they fit; include one mermaid diagram
+    ## Key Components  — a table of: path | purpose
+    ## Setup / Usage   — how to run, build, or apply it
+    ## Runbook         — common operations, failure modes, and recovery steps
+    ## Skill Candidates — discrete, reusable procedures worth extracting later
+
+    Be concrete and cite real file paths from the provided source. If a section
+    genuinely has no content, write "N/A" under it. Do not invent features.
+  generate.py: |
+    #!/usr/bin/env python3
+    import io, json, os, pathlib, subprocess, tarfile, urllib.error, urllib.request, fnmatch
+
+    LITELLM = os.environ["OPENAI_BASE_URL"].rstrip("/")
+    KEY     = os.environ["OPENAI_API_KEY"]
+    TOKEN   = os.environ.get("GITHUB_TOKEN", "")
+    MODEL   = os.environ.get("WIKI_MODEL", "nvidia")
+    MAX     = int(os.environ.get("MAX_REPOS_PER_RUN", "2"))
+    REPO    = pathlib.Path(os.environ.get("WIKI_REPO", "/app-data/repository"))
+    STATE   = pathlib.Path("/app-data/.wiki-state.json")
+    PROMPT  = pathlib.Path("/config/prompt.md").read_text()
+    ENTRIES = [l.strip() for l in pathlib.Path("/config/repos.txt").read_text().splitlines()
+               if l.strip() and not l.startswith("#")]
+
+    SKIP = ("*.png", "*.jpg", "*.jpeg", "*.gif", "*.ico", "*.svg", "*.pdf", "*.zip",
+            "*.gz", "*.tar", "*.lock", "*.woff*", "*.ttf", "*.bin", "*.wasm")
+
+    def gh(path):
+        req = urllib.request.Request(f"https://api.github.com{path}",
+            headers={"Authorization": f"Bearer {TOKEN}", "User-Agent": "repo-wiki",
+                     "Accept": "application/vnd.github+json"})
+        return json.load(urllib.request.urlopen(req, timeout=30))
+
+    def list_repos(owner):
+        for kind in ("orgs", "users"):
+            try:
+                out, page = [], 1
+                while True:
+                    batch = gh(f"/{kind}/{owner}/repos?per_page=100&type=all&page={page}")
+                    if not batch:
+                        break
+                    out += batch
+                    page += 1
+                return out
+            except urllib.error.HTTPError as e:
+                if e.code == 404 and kind == "orgs":
+                    continue
+                raise
+        return []
+
+    def expand(entry):
+        if not entry.endswith("/*"):
+            return [entry]
+        return [r["full_name"] for r in list_repos(entry[:-2])
+                if not r["archived"] and not r["fork"]]
+
+    def clone_url(repo):
+        return f"https://x-access-token:{TOKEN}@github.com/{repo}.git" if TOKEN \
+            else f"https://github.com/{repo}.git"
+
+    def head_sha(repo):
+        out = subprocess.run(["git", "ls-remote", clone_url(repo), "HEAD"],
+                             capture_output=True, text=True).stdout
+        return out.split()[0] if out else ""
+
+    def pack(repo):
+        url = f"https://api.github.com/repos/{repo}/tarball"
+        req = urllib.request.Request(url, headers={"Authorization": f"Bearer {TOKEN}",
+                                                   "User-Agent": "repo-wiki"})
+        tar = tarfile.open(fileobj=io.BytesIO(urllib.request.urlopen(req, timeout=120).read()))
+        chunks, total = [], 0
+        for m in tar.getmembers():
+            if not m.isfile() or m.size > 64_000:
+                continue
+            rel = m.name.split("/", 1)[-1]
+            if any(fnmatch.fnmatch(rel.lower(), p) for p in SKIP):
+                continue
+            try:
+                text = tar.extractfile(m).read().decode("utf-8")
+            except Exception:
+                continue
+            chunks.append(f"=== {rel} ===\n{text}")
+            total += len(text)
+            if total > 400_000:
+                break
+        return "\n\n".join(chunks)
+
+    def generate(repo, packed):
+        body = json.dumps({"model": MODEL, "temperature": 0.2, "messages": [
+            {"role": "system", "content": PROMPT},
+            {"role": "user", "content": f"Repository: {repo}\n\n{packed}"}]}).encode()
+        req = urllib.request.Request(f"{LITELLM}/chat/completions", data=body,
+            headers={"Authorization": f"Bearer {KEY}", "Content-Type": "application/json"})
+        resp = json.load(urllib.request.urlopen(req, timeout=600))
+        return resp["choices"][0]["message"]["content"]
+
+    subprocess.run(["git", "config", "--global", "--add", "safe.directory", str(REPO)], check=False)
+    REPO.mkdir(parents=True, exist_ok=True)
+    if not (REPO / ".git").exists():
+        subprocess.run(["git", "init", "-q", str(REPO)], check=True)
+    state = json.loads(STATE.read_text()) if STATE.exists() else {}
+
+    candidates = sorted({r for e in ENTRIES for r in expand(e)})
+    stale = [(r, s) for r in candidates if (s := head_sha(r)) and state.get(r) != s][:MAX]
+    print(f"{len(candidates)} repos discovered, {len(stale)} to regenerate this run", flush=True)
+
+    for repo, sha in stale:
+        print(f"generating {repo}", flush=True)
+        page = REPO / f"{repo}.md"
+        page.parent.mkdir(parents=True, exist_ok=True)
+        page.write_text(generate(repo, pack(repo)))
+        state[repo] = sha
+
+    STATE.write_text(json.dumps(state, indent=2))
+    if stale:
+        subprocess.run(["git", "-C", str(REPO), "add", "-A"], check=True)
+        subprocess.run(["git", "-C", str(REPO), "-c", "user.email=repo-wiki@jory.dev",
+                        "-c", "user.name=repo-wiki", "commit", "-q", "-m",
+                        f"regenerate {len(stale)} wiki(s)"], check=False)

--- a/kubernetes/apps/base/llm/repo-wiki/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/repo-wiki/externalsecret.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/generators.external-secrets.io/password_v1alpha1.json
+apiVersion: generators.external-secrets.io/v1alpha1
+kind: Password
+metadata:
+  name: repo-wiki-secret-key
+spec:
+  length: 48
+  digits: 8
+  symbols: 0
+  noUpper: false
+  allowRepeat: true
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name repo-wiki
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        OPENAI_API_KEY: "{{ .LITELLM_MASTER_KEY }}"
+        GITHUB_TOKEN: "{{ .GITHUB_TOKEN }}"
+        SECRET_KEY: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: litellm
+    - extract:
+        key: github-miso
+    - sourceRef:
+        generatorRef:
+          apiVersion: generators.external-secrets.io/v1alpha1
+          kind: Password
+          name: repo-wiki-secret-key

--- a/kubernetes/apps/base/llm/repo-wiki/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/repo-wiki/helmrelease.yaml
@@ -40,6 +40,16 @@ spec:
                 memory: 512Mi
       repo-wiki-gen:
         type: cronjob
+        pod:
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: app.kubernetes.io/name
+                        operator: In
+                        values: ["repo-wiki"]
+                  topologyKey: kubernetes.io/hostname
         cronjob:
           schedule: "0 */2 * * *"
           timeZone: America/Edmonton

--- a/kubernetes/apps/base/llm/repo-wiki/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/repo-wiki/helmrelease.yaml
@@ -1,0 +1,98 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: repo-wiki
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: repo-wiki
+  interval: 15m
+  dependsOn: []
+  values:
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 33
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      otterwiki:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: redimp/otterwiki
+              tag: 2.20.7@sha256:e8c4a4a452edb3246c2381fa302584a4933f9c3a17a1d8a47b947667b28495c5
+            env:
+              SITE_NAME: Repo Wikis
+              REPOSITORY: /app-data/repository
+              SQLALCHEMY_DATABASE_URI: sqlite:////app-data/db.sqlite
+              READ_ACCESS: ANONYMOUS
+              WRITE_ACCESS: ADMIN
+            envFrom:
+              - secretRef:
+                  name: repo-wiki
+            resources:
+              requests:
+                cpu: 50m
+              limits:
+                memory: 512Mi
+      repo-wiki-gen:
+        type: cronjob
+        cronjob:
+          schedule: "0 */2 * * *"
+          timeZone: America/Edmonton
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+        containers:
+          app:
+            image:
+              repository: python
+              tag: "3.13@sha256:f669133e924384c808cee1fc5dc896a5316421a9342dfa77efeebdcbc1222ae3"
+            command: ["python3", "/config/generate.py"]
+            env:
+              OPENAI_BASE_URL: http://litellm.llm:4000/v1
+              WIKI_MODEL: nvidia
+              MAX_REPOS_PER_RUN: "2"
+              WIKI_REPO: /app-data/repository
+            envFrom:
+              - secretRef:
+                  name: repo-wiki
+            resources:
+              requests:
+                cpu: 100m
+              limits:
+                memory: 1Gi
+    persistence:
+      data:
+        existingClaim: repo-wiki
+        advancedMounts:
+          otterwiki:
+            app:
+              - path: /app-data
+          repo-wiki-gen:
+            app:
+              - path: /app-data
+      config:
+        type: configMap
+        name: repo-wiki
+        globalMounts:
+          - path: /config
+    route:
+      app:
+        hostnames: ["wikis.jory.dev"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - name: repo-wiki
+                port: 8080
+    service:
+      app:
+        controller: otterwiki
+        ports:
+          http:
+            port: 8080

--- a/kubernetes/apps/base/llm/repo-wiki/kustomization.yaml
+++ b/kubernetes/apps/base/llm/repo-wiki/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./config.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/repo-wiki/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/repo-wiki/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: repo-wiki
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/main/llm/kustomization.yaml
+++ b/kubernetes/apps/main/llm/kustomization.yaml
@@ -16,5 +16,6 @@ resources:
   - ./memini.yaml
   - ./open-webui.yaml
   - ./openclaw.yaml
+  - ./repo-wiki.yaml
   - ./searxng.yaml
   - ./toolhive.yaml

--- a/kubernetes/apps/main/llm/repo-wiki.yaml
+++ b/kubernetes/apps/main/llm/repo-wiki.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app repo-wiki
+spec:
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: litellm
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/repo-wiki
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_ACCESSMODES: ReadWriteMany
+      VOLSYNC_STORAGECLASS: ceph-filesystem
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-filesystem
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/llm/repo-wiki.yaml
+++ b/kubernetes/apps/main/llm/repo-wiki.yaml
@@ -14,10 +14,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_ACCESSMODES: ReadWriteMany
-      VOLSYNC_STORAGECLASS: ceph-filesystem
-      VOLSYNC_SNAPSHOTCLASS: csi-ceph-filesystem
   wait: false
   prune: true
   sourceRef:


### PR DESCRIPTION
## Summary
- Adds a declarative, scheduled pipeline that LLM-generates a consistent reference wiki per repo and serves it read-only with Otter Wiki at `wikis.jory.dev` (internal).
- **Generator** (`repo-wiki-gen` CronJob, every 2h): expands the globs in `repos.txt` (`joryirving/*`, `misospace/*`, archived/forks skipped), regenerates only repos whose HEAD changed since last run, capped at `MAX_REPOS_PER_RUN=2` so it never hammers the GPU. Stock `python:3.13` image, stdlib-only `generate.py` (no pip/npm at runtime), pinned to the `nvidia` LiteLLM model, `timeout=600`.
- **Renderer**: `redimp/otterwiki` pinned by digest, `READ_ACCESS=ANONYMOUS` / `WRITE_ACCESS=ADMIN` (read-only), dark mode.
- Markdown is the source of truth in a git repo on a shared **CephFS RWX** PVC (volsync component, mirrors `litellm`); the generator commits, Otter renders, and a future distill agent reads the same `.md`. Nothing is written into the source repos.
- Consistency comes from a pinned `prompt.md` (fixed section set) + pinned model, both in git. Repo list and cadence are git values, not clickops.

## Notes
- `GITHUB_TOKEN` from the 1Password `github-miso` item (covers both orgs); `OPENAI_API_KEY` from `litellm`; Otter `SECRET_KEY` via an ESO `Password` generator.
- First-deploy checks: (1) the generator and Otter share `/app-data` — confirm Otter renders externally-committed pages and that the `fsGroup: 33` + git `safe.directory` handling is clean across the two pods; (2) confirm `misospace` private repos resolve with the bot token.
- Minor merge conflict expected with #7850 (deepwiki removal) on `main/llm/kustomization.yaml` — trivial.

## Verification
- `kustomize build kubernetes/apps/base/llm/repo-wiki` — OK (5 resources)
- `kustomize build --load-restrictor LoadRestrictionsNone kubernetes/apps/main/llm` — OK
- volsync component layering renders the RWX `ceph-filesystem` PVC
- embedded `generate.py` compiles (`python3 -c compile`)