### PR TITLE
fix(llm): repo-wiki explicit repo list

### DIFF
--- a/kubernetes/apps/base/llm/repo-wiki/config.yaml
+++ b/kubernetes/apps/base/llm/repo-wiki/config.yaml
@@ -5,8 +5,14 @@ metadata:
   name: repo-wiki
 data:
   repos.txt: |
-    joryirving/*
-    misospace/*
+    joryirving/home-ops
+    joryirving/containers
+    misospace/dispatch
+    misospace/KubeTix
+    misospace/miso-chat
+    misospace/windowstead
+    misospace/pr-reviewer-action
+    misospace/miso-gallery
   prompt.md: |
     You are documenting a git repository for an engineering reference wiki.
     Output GitHub-flavored markdown with EXACTLY these H2 sections, in this


### PR DESCRIPTION
## Summary
- Replace the `joryirving/*` / `misospace/*` globs in `repos.txt` with an explicit 8-repo list. The user-endpoint glob fallback used `type=all`, which returns owner **and collaborator** repos, so `joryirving/*` was pulling in `itsmiso-ai/*` (the bot account joryirving collaborates on). An explicit list skips enumeration entirely.

## Notes
- Already-generated out-of-scope page(s) from the first run (e.g. `itsmiso-ai/dispatch-workflow`) won't regenerate but will linger on the PVC until removed — see PR discussion for cleanup.
- 8 repos at `MAX_REPOS_PER_RUN=2` → ~4 runs to seed; bump the cap temporarily for a one-shot backfill.

## Verification
- `kustomize build kubernetes/apps/base/llm/repo-wiki` — OK