### PR TITLE
ci(reviews): use argv list for konflate evidence provider

### DIFF
--- a/.github/konflate-evidence-providers.json
+++ b/.github/konflate-evidence-providers.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "konflate-rendered-diff",
-    "command": "python3 \"$GITHUB_WORKSPACE/.github/scripts/konflate_evidence.py\"",
+    "command": ["python3", ".github/scripts/konflate_evidence.py"],
     "timeout_sec": 45
   }
 ]


### PR DESCRIPTION
Converts the \`konflate-rendered-diff\` command from a shell string to an argv array so it runs via \`subprocess.run\` instead of \`bash -lc\`, clearing the action's bash trust-boundary warning that surfaced in run #28345781627.

- Path: \`$GITHUB_WORKSPACE/...\` → relative \`.github/...\` (the action's review step has the repo root as CWD, so the resolved file is the same)
- Script \`konflate_evidence.py\` does not reference \`GITHUB_WORKSPACE\`; it reads \`PR_NUMBER\`, \`KONFLATE_MCP_URL\`, \`KONFLATE_MCP_TOKEN\` from env, all of which the action propagates into the provider subprocess