### PR TITLE
feat(llm): repo-wiki renderer Otter -> MkDocs Material

### DIFF
--- a/kubernetes/apps/base/llm/repo-wiki/config.yaml
+++ b/kubernetes/apps/base/llm/repo-wiki/config.yaml
@@ -13,6 +13,47 @@ data:
     misospace/windowstead
     misospace/pr-reviewer-action
     misospace/miso-gallery
+  mkdocs.yml: |
+    site_name: Repo Wikis
+    docs_dir: /app-data/repository
+    site_dir: /tmp/site
+    theme:
+      name: material
+      palette:
+        - scheme: slate
+          primary: indigo
+          accent: indigo
+          toggle:
+            icon: material/weather-sunny
+            name: Switch to light mode
+        - scheme: default
+          primary: indigo
+          accent: indigo
+          toggle:
+            icon: material/weather-night
+            name: Switch to dark mode
+      features:
+        - navigation.instant
+        - navigation.sections
+        - navigation.top
+        - navigation.footer
+        - search.suggest
+        - search.highlight
+        - content.code.copy
+        - toc.follow
+    plugins:
+      - search
+    markdown_extensions:
+      - admonition
+      - footnotes
+      - toc:
+          permalink: true
+      - pymdownx.highlight
+      - pymdownx.superfences:
+          custom_fences:
+            - name: mermaid
+              class: mermaid
+              format: !!python/name:pymdownx.superfences.fence_code_format
   generate.py: |
     #!/usr/bin/env python3
     # Multi-pass repo wiki: stage 1 plans pages, stage 2 writes each from its

--- a/kubernetes/apps/base/llm/repo-wiki/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/repo-wiki/externalsecret.yaml
@@ -1,16 +1,4 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/generators.external-secrets.io/password_v1alpha1.json
-apiVersion: generators.external-secrets.io/v1alpha1
-kind: Password
-metadata:
-  name: repo-wiki-secret-key
-spec:
-  length: 48
-  digits: 8
-  symbols: 0
-  noUpper: false
-  allowRepeat: true
----
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -26,14 +14,8 @@ spec:
       data:
         OPENAI_API_KEY: "{{ .LITELLM_MASTER_KEY }}"
         GITHUB_TOKEN: "{{ .GITHUB_TOKEN }}"
-        SECRET_KEY: "{{ .password }}"
   dataFrom:
     - extract:
         key: litellm
     - extract:
         key: github-miso
-    - sourceRef:
-        generatorRef:
-          apiVersion: generators.external-secrets.io/v1alpha1
-          kind: Password
-          name: repo-wiki-secret-key

--- a/kubernetes/apps/base/llm/repo-wiki/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/repo-wiki/helmrelease.yaml
@@ -16,24 +16,16 @@ spec:
         fsGroup: 33
         fsGroupChangePolicy: OnRootMismatch
     controllers:
-      otterwiki:
+      mkdocs:
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
           app:
             image:
-              repository: redimp/otterwiki
-              tag: 2.20.7@sha256:e8c4a4a452edb3246c2381fa302584a4933f9c3a17a1d8a47b947667b28495c5
-            env:
-              SITE_NAME: Repo Wikis
-              REPOSITORY: /app-data/repository
-              SQLALCHEMY_DATABASE_URI: sqlite:////app-data/db.sqlite
-              READ_ACCESS: ANONYMOUS
-              WRITE_ACCESS: ADMIN
-              EMAIL_NEEDS_CONFIRMATION: "false"
-            envFrom:
-              - secretRef:
-                  name: repo-wiki
+              repository: squidfunk/mkdocs-material
+              tag: 9.7.6@sha256:868ad4d39fb5865b72d00173ade00f4eae2b38dde7ff790a011cc44ce4a8ff8e
+            command: ["mkdocs"]
+            args: ["serve", "--dirty", "-f", "/config/mkdocs.yml", "-a", "0.0.0.0:8000"]
             resources:
               requests:
                 cpu: 50m
@@ -82,7 +74,7 @@ spec:
       data:
         existingClaim: repo-wiki
         advancedMounts:
-          otterwiki:
+          mkdocs:
             app:
               - path: /app-data
           repo-wiki-gen:
@@ -102,10 +94,10 @@ spec:
         rules:
           - backendRefs:
               - name: repo-wiki
-                port: 8080
+                port: 8000
     service:
       app:
-        controller: otterwiki
+        controller: mkdocs
         ports:
           http:
-            port: 8080
+            port: 8000


### PR DESCRIPTION
## Summary
Swap the dated-looking Otter Wiki renderer for MkDocs Material. The markdown is decoupled on the PVC, so this only changes the *view* — the nightly Strix generation pipeline (CronJob, `generate.py`, repo list, tuning) is untouched.

- **Renderer:** `redimp/otterwiki` → `squidfunk/mkdocs-material` (digest-pinned). Runs `mkdocs serve` pointed at the PVC docs dir (`/app-data/repository`); live-reloads as the generator writes. Modern theme, **dark mode default** + toggle, instant search, nav sections, mermaid rendering (matches the diagrams the generator emits).
- **Config:** a small static `mkdocs.yml` in the configmap (theme + search + superfences/mermaid). Nav auto-builds from the `<repo>/<slug>.md` tree — no manual nav.
- **Dropped Otter-only baggage:** `SECRET_KEY` + its Password generator, `EMAIL_NEEDS_CONFIRMATION`, `READ_ACCESS`/`WRITE_ACCESS`. MkDocs is read-only and stateless — no auth, no DB, no git dependency (the generator's commits are now just harmless history; `.git` is ignored by MkDocs).
- Service/route → port 8000; generator's podAffinity still co-locates with the always-on renderer pod (`app.kubernetes.io/name: repo-wiki`), so the RWO PVC share is unchanged.

## Notes
- `mkdocs serve` watches `docs_dir` via inotify. Generator + renderer are co-located on one node, so same-node writes should fire reload. **Verify after deploy:** confirm a nightly regen shows up without a renderer restart — if CephFS inotify doesn't propagate, switch to `mkdocs build` + a rebuild-on-generation step.
- Otter's old `db.sqlite` and any Otter-specific files remain on the PVC, harmless (MkDocs ignores dotfiles/non-docs).

## Verification
- `kustomize build kubernetes/apps/base/llm/repo-wiki` — OK (4 resources)
- `mkdocs.yml` parses; `generate.py` unchanged + compiles