### PR TITLE
fix(llm): repo-wiki nav cleanup

### DIFF
--- a/kubernetes/apps/base/llm/repo-wiki/config.yaml
+++ b/kubernetes/apps/base/llm/repo-wiki/config.yaml
@@ -34,6 +34,7 @@ data:
             name: Switch to dark mode
       features:
         - navigation.instant
+        - navigation.indexes
         - navigation.sections
         - navigation.top
         - navigation.footer
@@ -58,7 +59,7 @@ data:
     #!/usr/bin/env python3
     # Multi-pass repo wiki: stage 1 plans pages, stage 2 writes each from its
     # relevant files. Local-model friendly, background, no truncated whole-repo dump.
-    import io, json, os, pathlib, re, subprocess, tarfile, urllib.error, urllib.request, fnmatch
+    import io, json, os, pathlib, re, shutil, subprocess, tarfile, urllib.error, urllib.request, fnmatch
 
     LITELLM  = os.environ["OPENAI_BASE_URL"].rstrip("/")
     KEY      = os.environ["OPENAI_API_KEY"]
@@ -205,16 +206,17 @@ data:
             if not pages:
                 pages = [{"title": "Overview", "slug": "overview", "focus": "repository overview",
                           "files": sorted(files)[:40]}]
-            name = repo.split("/")[-1]
             base = REPO / repo
+            shutil.rmtree(base, ignore_errors=True)
+            (REPO / f"{repo}.md").unlink(missing_ok=True)
             base.mkdir(parents=True, exist_ok=True)
-            index = [f"# {repo}\n", "AI-generated wiki.\n", "## Pages\n"]
+            index = [f"# {repo}\n", "_AI-generated wiki._\n", "## Pages\n"]
             for pg in pages:
                 slug = pg.get("slug") or slugify(pg.get("title", "page"))
                 print(f"  page: {pg.get('title')} ({slug})", flush=True)
                 (base / f"{slug}.md").write_text(write_page(repo, pg, files))
-                index.append(f"- [{pg.get('title', slug)}]({name}/{slug})")
-            (REPO / f"{repo}.md").write_text("\n".join(index))
+                index.append(f"- [{pg.get('title', slug)}]({slug}.md)")
+            (base / "index.md").write_text("\n".join(index))
             state[repo] = sha
             STATE.write_text(json.dumps(state, indent=2))
             commit(f"regenerate {repo} ({len(pages)} pages)")
@@ -222,3 +224,13 @@ data:
         except Exception as e:
             print(f"  skipped {repo}: {e}", flush=True)
             continue
+
+    (REPO / "home.md").unlink(missing_ok=True)
+    root = ["# Repo Wikis\n", "_AI-generated documentation, one section per repository._\n"]
+    for r in candidates:
+        if (REPO / r / "index.md").exists():
+            root.append(f"- [{r}]({r}/index.md)")
+        else:
+            root.append(f"- {r} _(pending)_")
+    (REPO / "index.md").write_text("\n".join(root))
+    commit("update root index")


### PR DESCRIPTION
## Summary
Three fixes for the MkDocs nav, all in the generator + one `mkdocs.yml` feature. No change to the repo list or pipeline behavior.

1. **`/` 404** → generator now writes a root `index.md` (lists every configured repo, links the generated ones, marks pending). MkDocs had no docs-root homepage, so `/` 404'd.
2. **Two nav entries per repo** (`joryirving/home-ops` page + `Home ops` section) → write the per-repo index as `<repo>/index.md` instead of the sibling `<repo>.md`, and enable `navigation.indexes`. MkDocs now collapses page + section into one entry whose landing page is the index.
3. **Duplicate/accumulated pages** (home-ops had 54 files vs `MAX_PAGES_PER_REPO=20`) → `shutil.rmtree(<repo>/)` before each regen. Plan slugs vary run-to-run (non-deterministic), so prior runs' pages were piling up as near-duplicates; now each regen starts clean.

Also removes the stray Otter `home.md`.

## One-time cleanup
The existing accumulation only clears as each repo next regenerates (on its HEAD change). To force a clean rebuild of everything, delete `/app-data/.wiki-state.json` on the PVC — but note `MAX_REPOS_PER_RUN=1`, so that's one repo/night unless you bump it temporarily.

## Verification
- `kustomize build kubernetes/apps/base/llm/repo-wiki` — OK
- `generate.py` compiles (178 lines); `navigation.indexes` present; root + per-repo `index.md` writes confirmed