### PR TITLE
feat(observability): litellm failover, outage and auth/quota alerts

### DIFF
--- a/kubernetes/apps/base/llm/litellm/app/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./prometheusrule.yaml
   - ./ornith1.0-35b.yaml
   - ./qwen3.5-4b.yaml
   - ./qwen3.6-27b.yaml

--- a/kubernetes/apps/base/llm/litellm/app/prometheusrule.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/prometheusrule.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: litellm
+spec:
+  groups:
+    - name: litellm.rules
+      rules:
+        - alert: LiteLLMFallbackChainExhausted
+          expr: |-
+            sum by (requested_model, exception_status, exception_class) (
+              increase(litellm_deployment_failed_fallbacks_total[15m])
+            ) > 0
+          annotations:
+            summary: >-
+              LiteLLM {{ $labels.requested_model }} fallback chain exhausted — no working deployment
+              ({{ $labels.exception_status }} {{ $labels.exception_class }})
+          labels:
+            severity: critical
+        - alert: LiteLLMModelFailover
+          expr: |-
+            sum by (requested_model, fallback_model, exception_status, exception_class) (
+              increase(litellm_deployment_successful_fallbacks_total[10m])
+            ) > 3
+          for: 5m
+          annotations:
+            summary: >-
+              LiteLLM {{ $labels.requested_model }} failing over to {{ $labels.fallback_model }}
+              ({{ $labels.exception_status }} {{ $labels.exception_class }})
+          labels:
+            severity: warning
+        - alert: LiteLLMDeploymentOutage
+          expr: |-
+            max by (litellm_model_name) (litellm_deployment_state) >= 2
+          for: 10m
+          annotations:
+            summary: >-
+              LiteLLM {{ $labels.litellm_model_name }} out of rotation (deployment_state >= 2)
+          labels:
+            severity: warning
+        - alert: LiteLLMAuthOrQuotaFailures
+          expr: |-
+            sum by (litellm_model_name, exception_status) (
+              increase(litellm_deployment_failure_responses_total{exception_status=~"403|429"}[15m])
+            ) > 5
+          for: 5m
+          annotations:
+            summary: >-
+              LiteLLM {{ $labels.litellm_model_name }} returning {{ $labels.exception_status }}
+              (auth/quota — check the upstream key or plan cap)
+          labels:
+            severity: warning


### PR DESCRIPTION
Adds a colocated `PrometheusRule` for LiteLLM so failover/outage events page through the existing `severity`-based Alertmanager routing.

Four rules (`litellm.rules`):
- **LiteLLMFallbackChainExhausted** (critical) — `failed_fallbacks` > 0: a request had no working deployment left.
- **LiteLLMModelFailover** (warning) — `successful_fallbacks` > 3 / 10m: failing over but recovering.
- **LiteLLMDeploymentOutage** (warning) — `deployment_state >= 2` for 10m: a model is out of rotation.
- **LiteLLMAuthOrQuotaFailures** (warning) — >5 `403|429` in 15m: upstream key/quota problem.

The `exception_status` / `exception_class` labels carry the reason (token limit / down / 403 / 429) into each alert summary.

All four queries validated against live Prometheus — they parse and currently fire 0 (no false alarms). Thresholds + `for:` windows chosen to avoid paging on transient cooldowns.