### PR TITLE
feat(llm): foreman coder/gate/reviewer agents

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Agent
+metadata:
+  name: coder
+spec:
+  role: coder
+  # Resolves to http://llama-nvidia.llm.svc:<port>/v1 at task time.
+  inferenceServiceRef:
+    name: llama-nvidia
+  tools:
+    - read_file
+    - write_file
+    - str_replace
+    - grep
+    - bash
+    - submit_result
+  temperature: "0.2"
+  maxTurns: 80
+  maxRetries: 3
+  requestTurnTimeoutSeconds: 1800
+  requestTimeoutSeconds: 7200
+  bashTimeoutSeconds: 60
+  requiredCapability:
+    # Matches the shared foreman-agent (roles: worker,coder,verifier). accelerator
+    # "any" because requiredCapability pins the executor node, not the model — the
+    # model's GPU placement is handled by the llama-nvidia InferenceService.
+    roles:
+      - coder
+    accelerator: any
+  systemPrompt: |
+    You are a coding agent resolving a single GitHub issue in the referenced repo.
+    Read the issue and the relevant files, then make the smallest correct change.
+    Every behavior change needs a test (add a regression test for a bug). Match the
+    surrounding code style. Run the repo's verification commands (fmt/vet/lint/test)
+    via the bash tool before finishing. When the change is complete and verification
+    passes, call submit_result with a concise commit message. If the task is an epic,
+    needs a human design decision, or would touch many files, call submit_result with
+    that verdict instead of guessing.

--- a/kubernetes/apps/base/llm/foreman/agents/gate.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/gate.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Agent
+metadata:
+  name: gate
+spec:
+  role: verifier
+  # Deterministic Agent: inferenceServiceRef omitted (no LLM). The executor's
+  # executeDeterministic() branch runs run_gate_job directly.
+  tools:
+    - run_gate_job
+  requiredCapability:
+    roles:
+      - verifier
+    accelerator: any
+  maxRetries: 3
+  requestTimeoutSeconds: 3900

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Agent
+metadata:
+  name: reviewer
+spec:
+  role: reviewer
+  # Ornith-1.0-35B on the Strix Halo — the big/slow model, used to review rather
+  # than code. Resolves to http://llama-strix.llm.svc:<port>/v1 at task time.
+  inferenceServiceRef:
+    name: llama-strix
+  # Read-only whitelist: no write_file / str_replace. The reviewer describes needed
+  # changes in its verdict, it does not edit the branch.
+  tools:
+    - read_file
+    - grep
+    - bash
+    - fetch_issue
+    - submit_result
+  temperature: "0.35"
+  maxTurns: 80
+  maxRetries: 3
+  requestTurnTimeoutSeconds: 900
+  requestTimeoutSeconds: 5400
+  bashTimeoutSeconds: 60
+  requiredCapability:
+    roles:
+      - worker
+    accelerator: any
+  systemPrompt: |
+    You are a code reviewer (pipeline step 3), scoring the coder's branch against the
+    issue after the gate has run fmt/vet/lint/test. Read the diff and the surrounding
+    code; verify the change actually resolves the issue and that tests cover the
+    behavior change; check correctness, security, and scope creep. You are read-only —
+    do not edit the branch; if a change is needed, describe it in the review. Call
+    submit_result with an approve or request-changes verdict and a concise rationale.

--- a/kubernetes/apps/base/llm/foreman/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/foreman/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name foreman-agent
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      engineVersion: v2
+      data:
+        GITHUB_TOKEN: "{{ .GITHUB_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: github-miso

--- a/kubernetes/apps/base/llm/foreman/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/foreman/helmrelease.yaml
@@ -16,3 +16,21 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
+  values:
+    agent:
+      # Single shared executor: runs coder/verifier/reviewer tasks and reaches
+      # the llama-* InferenceServices over the cluster network. Roles advertised
+      # here are matched against each Agent's requiredCapability.roles.
+      mode: native
+      roles:
+        - worker
+        - coder
+        - verifier
+      image:
+        # coder image ships the Go toolchain + git the coder self-gate needs;
+        # required because roles include "coder".
+        repository: ghcr.io/defilantech/llmkube-foreman-agent-coder
+      # GITHUB_TOKEN the coder role uses to push branches (see externalsecret.yaml).
+      githubToken:
+        secretName: foreman-agent
+        secretKey: GITHUB_TOKEN

--- a/kubernetes/apps/base/llm/foreman/kustomization.yaml
+++ b/kubernetes/apps/base/llm/foreman/kustomization.yaml
@@ -5,3 +5,7 @@ kind: Kustomization
 resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./agents/coder.yaml
+  - ./agents/gate.yaml
+  - ./agents/reviewer.yaml


### PR DESCRIPTION
## Summary
Reconfigure the foreman-agent and define the coder/gate/reviewer Agents in the `llm` namespace.

- **HelmRelease**: single shared native executor — `mode: native`, `roles: [worker, coder, verifier]`, coder image (`…/llmkube-foreman-agent-coder`), `githubToken` from a new ExternalSecret. It runs all task types and reaches the `llama-*` InferenceServices over the cluster network.
- **ExternalSecret** `foreman-agent`: `GITHUB_TOKEN` from 1Password `github-miso` (same pattern as openclaw/dispatch), for the coder's branch push.
- **Agents**: `coder` → `llama-nvidia` (Qwen3.6-27B); `gate` deterministic verifier (no LLM, `run_gate_job`); `reviewer` → `llama-strix` (Ornith-1.0-35B — the big/slow model reviews rather than codes).

## Verification
- `kustomize build kubernetes/apps/base/llm/foreman` → clean.
- All three Agents pass the foreman **validating webhook** via `kubectl apply --dry-run=server` (tools, roles, systemPrompt, inferenceServiceRef accepted).
- `inferenceServiceRef` targets confirmed present: `llama-nvidia`, `llama-strix`.

## Notes
- `requiredCapability.accelerator: any` on purpose — it pins the *executor* node (one shared agent), not the model; GPU placement is already handled by the InferenceServices.
- **Deferred:** coder git-push wiring (`agent.gitRemoteURL` / fork model) isn't set yet — it depends on how work is routed per-repo, which ties into the deferred work-ingestion (bridge → dispatch plugin). Fine until the first real coder run; the Agents register and validate now.
- Agent names `coder`/`gate`/`reviewer` are what a Workload's `coderAgentRef`/`verifierAgentRef`/`reviewerAgentRefs` must reference when work ingestion is wired up.
