### PR TITLE
fix(llm): automount SA token for foreman-dispatch-bridge

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -10,6 +10,10 @@ spec:
     name: foreman-dispatch-bridge
   interval: 15m
   values:
+    defaultPodOptions:
+      # app-template defaults this off; the bridge needs the SA token to create
+      # Workloads via the in-cluster kube API (load_incluster_config).
+      automountServiceAccountToken: true
     controllers:
       foreman-dispatch-bridge:
         type: cronjob


### PR DESCRIPTION
## Summary
- The bridge CronJob errored with `ConfigException: Service token file does not exist` — app-template defaults `automountServiceAccountToken: false`, so `load_incluster_config()` had no token to create Workloads.
- Enable it via `defaultPodOptions.automountServiceAccountToken: true`.

## Verification
- `helm template` renders `automountServiceAccountToken: true` on the pod (SA `foreman-dispatch-bridge`, create-only Role intact).
- `kustomize build` clean.