### PR TITLE
fix(llm): slash-free bridge agent name (foreman-coder)

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -32,7 +32,9 @@ spec:
               tag: 0.1.0
             env:
               DISPATCH_URL: http://dispatch.llm:3000
-              DISPATCH_AGENT_NAME: foreman/coder
+              # Dash, not slash (like saffron-normal): agents auto-register, but a "/"
+              # splits the queue URL path (/api/agents/{name}/queue) and 404s.
+              DISPATCH_AGENT_NAME: foreman-coder
               DISPATCH_LANES: local,cloud,frontier
               FOREMAN_NAMESPACE: llm
             envFrom:


### PR DESCRIPTION
## Summary
- The bridge queue call 404d: `DISPATCH_AGENT_NAME: foreman/coder` has a slash, so `/api/agents/foreman/coder/queue` splits into two path segments and misses the route.
- Saffron works because its agents are slash-free (`saffron-local`/`-cloud`/`-frontier`). Use `foreman-coder` to match.

## Follow-up
- If the `foreman/<lane>` namespacing is wanted later, the bridge would need to URL-encode the name in the queue path (`%2F`), pending confirmation dispatch decodes it.