### PR TITLE
feat(llm): dispatch-heartbeat cronjobs (sync + groom)

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/heartbeat/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/heartbeat/helmrelease.yaml
@@ -1,0 +1,86 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dispatch-heartbeat
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: dispatch-heartbeat
+  interval: 15m
+  values:
+    # Scheduled triggers that replace saffron's heartbeat (now paused):
+    #   sync  → POST /api/sync/scheduled  (item 1: pull issues from GitHub + reconcile)
+    #   groom → POST /api/groomer/run     (item 4: groom one candidate into a claimable lane)
+    # Dispatch owns the actual work + server-side locks; these just poke it on a cadence.
+    # Both authenticate with DISPATCH_AGENT_TOKEN from the dispatch app's Secret.
+    controllers:
+      sync:
+        type: cronjob
+        cronjob:
+          schedule: "*/15 * * * *"
+          timeZone: America/Edmonton
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+          backoffLimit: 0
+        containers:
+          app:
+            image:
+              repository: docker.io/curlimages/curl
+              tag: 8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
+            command:
+              - sh
+              - -c
+              - >-
+                curl -fsS -X POST
+                -H "Authorization: Bearer $DISPATCH_AGENT_TOKEN"
+                -H "Content-Type: application/json"
+                -d '{}'
+                http://dispatch.llm:3000/api/sync/scheduled
+            env:
+              DISPATCH_AGENT_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: dispatch
+                    key: DISPATCH_AGENT_TOKEN
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 32Mi
+      groom:
+        type: cronjob
+        cronjob:
+          schedule: "*/10 * * * *"
+          timeZone: America/Edmonton
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+          backoffLimit: 0
+        containers:
+          app:
+            image:
+              repository: docker.io/curlimages/curl
+              tag: 8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
+            command:
+              - sh
+              - -c
+              - >-
+                curl -fsS -X POST
+                -H "Authorization: Bearer $DISPATCH_AGENT_TOKEN"
+                -H "Content-Type: application/json"
+                -d '{}'
+                http://dispatch.llm:3000/api/groomer/run
+            env:
+              DISPATCH_AGENT_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: dispatch
+                    key: DISPATCH_AGENT_TOKEN
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 32Mi

--- a/kubernetes/apps/base/llm/dispatch/heartbeat/kustomization.yaml
+++ b/kubernetes/apps/base/llm/dispatch/heartbeat/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/llm/dispatch/heartbeat/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/dispatch/heartbeat/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dispatch-heartbeat
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/main/llm/dispatch.yaml
+++ b/kubernetes/apps/main/llm/dispatch.yaml
@@ -45,3 +45,24 @@ spec:
     name: flux-system
     namespace: flux-system
   wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app dispatch-heartbeat
+spec:
+  dependsOn:
+    - name: dispatch
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/dispatch/heartbeat
+  postBuild:
+    substitute:
+      APP: *app
+      CLUSTER: ${CLUSTER}
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
## Summary
Replace the dispatch-facing parts of saffron's heartbeat (now paused) with scheduled CronJobs, so dispatch keeps syncing + grooming without saffron.

- **`dispatch-heartbeat`** app-template release under `base/llm/dispatch/heartbeat/`, two cronjob controllers:
  - `sync` — `*/15` → `POST /api/sync/scheduled` (heartbeat item 1: pull issues from GitHub + reconcile closed).
  - `groom` — `*/10` → `POST /api/groomer/run` (heartbeat item 4: groom one candidate into a claimable worker lane).
- Curl images (pinned `8.21.0@sha256`), Bearer `DISPATCH_AGENT_TOKEN` reused from the existing `dispatch` Secret (no new ExternalSecret). `dependsOn: dispatch`.

## Verification
- `kustomize build` clean; `helm template` renders both CronJobs with correct schedules, endpoints, and secret ref.
- `POST /api/sync/scheduled` and `/api/groomer/run` both accept `{}` + Bearer `DISPATCH_AGENT_TOKEN`; each has a server-side lock (overlaps 409 safely).

## Notes
- Pairs with dispatch#493 (groomer now routes ready issues to a claimable lane) — together the pipeline self-feeds: sync → groom → bridge claims → Foreman runs it.
- Saffron heartbeat items 2/3/5 (lane probe, worker-cron toggle, run reporting) are obsolete now that the bridge replaced the worker crons.
- **Audit candidate:** move this scheduler *inside* dispatch (internal interval) so no external CronJob is needed at all.
