### PR TITLE
fix(llm): foreman-agent taskNamespace = llm (scheduled tasks not running)

### DIFF
--- a/kubernetes/apps/base/llm/foreman/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/foreman/helmrelease.yaml
@@ -22,6 +22,10 @@ spec:
       # the llama-* InferenceServices over the cluster network. Roles advertised
       # here are matched against each Agent's requiredCapability.roles.
       mode: native
+      # The bridge creates Workloads (and the operator its AgenticTasks) in the
+      # llm namespace. Without this the agent watches "default" and never picks
+      # them up — tasks sit in Scheduled forever.
+      taskNamespace: llm
       roles:
         - worker
         - coder


### PR DESCRIPTION
## Summary
- AgenticTasks were stuck in `Scheduled` (FleetNodeAssigned) but never executed. The foreman-agent task-watcher defaulted to the `default` namespace, while the operator creates Workloads/AgenticTasks in `llm`.
- Set `agent.taskNamespace: llm` so the executor watches the right namespace.

## Verification
- Agent log confirmed `agentictask-watcher ... namespace: default`; tasks exist in `llm`.
- `kustomize build` clean.

## Next blocker (separate)
- Agent also logs `--git-remote-url is unset; coder-role tasks will fail with GitRemoteURLNotConfigured`. Once tasks run, the coder needs `agent.gitRemoteURL` + commit author to push branches — pending a decision on the push/fork model.