### PR TITLE
feat(renovate): group LLMKube and Foreman chart updates

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -121,6 +121,16 @@
       minimumGroupSize: 2,
     },
     {
+      description: "LLMKube Group",
+      groupName: "LLMKube",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/defilantech\\/charts\\//"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+      minimumGroupSize: 2,
+    },
+    {
       description: "Kyoo Group",
       groupName: "Kyoo",
       matchDatasources: ["docker"],


### PR DESCRIPTION
## Summary
- Add a `LLMKube` Renovate group matching `ghcr.io/defilantech/charts/*` (`llmkube` core + `foreman`) so lockstep chart bumps land in one PR instead of two.

## Notes
- `foreman` depends on the `llmkube` core and they release together (both just shipped 0.8.23); `minimumGroupSize: 2` keeps a solo bump as its own PR, matching every other group in this file.
- `renovate-config-validator` clean apart from the pre-existing `minimumGroupSize` convention used by all 16 existing groups.