### PR TITLE
feat(llm): set foreman coder commit identity

### DIFF
--- a/kubernetes/apps/base/llm/foreman/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/foreman/helmrelease.yaml
@@ -38,6 +38,13 @@ spec:
       githubToken:
         secretName: foreman-agent
         secretKey: GITHUB_TOKEN
+      # Git identity stamped on coder commits. Required with mode=native + the
+      # coder role: repo.Commit hard-rejects an empty author/committer email, so
+      # without this every coder GO fails at commit (no branch, no PR). Authored
+      # as Saffron via the itsmiso-ai account (the foreman-agent token owner);
+      # the numeric-prefixed noreply links the commits to that GitHub account.
+      commitAuthorName: Saffron
+      commitAuthorEmail: 263493777+itsmiso-ai@users.noreply.github.com
     coder:
       # The coder Job clones + pushes with this Secret (projected as GITHUB_TOKEN).
       # Reuse the same foreman-agent Secret instead of a separate foreman-git-credentials.


### PR DESCRIPTION
## Summary
- Set `agent.commitAuthorName: Saffron` + `agent.commitAuthorEmail` on the foreman HelmRelease so the coder can commit.

## Why
The coder's `repo.Commit` rejects an empty author/committer email, so with the field unset every coder GO fails at the commit step — no branch, no PR (the loop otherwise looks healthy). Commits are authored as **Saffron** and linked to the **itsmiso-ai** account (the `foreman-agent` GITHUB_TOKEN owner) via its `263493777+itsmiso-ai@users.noreply.github.com` noreply.

## Verification
- `helm template` renders `--commit-author-name=Saffron` and `--commit-author-email=…` on the agent deployment.

## Context
Last cluster-side gap for the multi-repo coder now that 0.8.24 (per-task repo clone) is live. Pairs with the bridge's `GATEPROFILE_MAP` (containers#774).