### PR TITLE
feat(llm): stamp generic gateProfile on foreman bridge Workloads

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -37,6 +37,17 @@ spec:
               DISPATCH_AGENT_NAME: foreman-coder
               DISPATCH_LANES: local,cloud,frontier
               FOREMAN_NAMESPACE: llm
+              # Stamp a generic (no-op) gateProfile on every Workload. This
+              # SUPPRESSES Foreman's Go default gate — critical because none of
+              # these repos are Go, and the coder's in-pod fast self-gate runs in
+              # the Go-only coder image (no node/python), so a real language gate
+              # would fail "command not found", exhaust retries, and downgrade the
+              # coder GO to INCOMPLETE (no PR). Generic + no commands = the self-gate
+              # and the clean-room verify Job both no-op, so the coder pushes and
+              # verification falls to the Ornith reviewer + each repo's CI + the
+              # external PR reviewer. Real per-language gates await the upstream
+              # self-gate fix (defer-to-Job on missing runtime).
+              GATEPROFILE_MAP: '{"*":{"language":"generic"}}'
             envFrom:
               - secretRef:
                   name: foreman-dispatch-bridge


### PR DESCRIPTION
## Summary
- Set `GATEPROFILE_MAP='{"*":{"language":"generic"}}'` on the bridge so every Workload carries a generic (no-op) `gateProfile`.

## Why
Without it, Foreman applies its **Go default gate** — but none of the fed repos are Go. Worse, the coder's in-pod fast self-gate runs in the Go-only coder image (no `node`/`python`), so a real language gate would fail "command not found", exhaust 3 retries, and downgrade the coder GO to **INCOMPLETE — no PR**. A generic profile with no commands no-ops both the self-gate and the clean-room verify Job, so the coder pushes.

Verification still happens — just downstream: the **Ornith reviewer** (in-cluster) + each repo's **CI** + the **external Minimax PR reviewer**.

## Notes
- Uses bridge image 0.2.0 (containers#774, already merged + digest-pinned on main).
- Real per-language gates (the node/python commands are drafted and ready) await an upstream fix so the coder self-gate defers to the clean-room Job when the runtime is absent — tracked separately.