### PR TITLE
feat(llm): grant bridge get/list/delete on workloads (failed-workload retry)

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -60,13 +60,15 @@ spec:
       foreman-dispatch-bridge: {}
     rbac:
       roles:
-        # Create-only on Workloads: the bridge materializes ephemeral work, nothing else.
+        # The bridge creates Workloads and, since v0.3.0, reconciles failed ones:
+        # list/get to find Failed Workloads, delete + create to retry them (bounded).
+        # No update/patch — retry is delete-then-recreate, not in-place mutation.
         foreman-dispatch-bridge:
           type: Role
           rules:
             - apiGroups: ["foreman.llmkube.dev"]
               resources: ["workloads"]
-              verbs: ["create"]
+              verbs: ["create", "get", "list", "delete"]
       bindings:
         foreman-dispatch-bridge:
           type: RoleBinding


### PR DESCRIPTION
## Summary
- Widen the foreman-dispatch-bridge Role on `workloads` from `create` to `create,get,list,delete` for the v0.3.0 retry loop (list Failed → delete + recreate, bounded). No `update`/`patch` — retry is delete-then-recreate.

## Notes
- Pairs with containers#776. Bump the bridge HelmRelease image tag to `0.3.0` once that image builds (this PR is RBAC-only, safe to merge first).
- Verified: `helm template`/kustomize render the Role with the four verbs.