### PR TITLE
feat(llm): groom with the 4B vision model

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/helmrelease.yaml
@@ -23,7 +23,11 @@ spec:
             env:
               DISPATCH_EXCLUDED_LABELS: renovate
               DISPATCH_GROOMER_DRY_RUN: false
-              DISPATCH_GROOMER_MODEL: nvidia
+              # Grooming is triage/classification, not code — a small model suffices.
+              # vision = Qwen3.5-4B (llama-vision) via litellm. dispatch constrains the
+              # output with a json_schema response_format (grammar-enforced on llama.cpp),
+              # so the 4B produces reliable structure.
+              DISPATCH_GROOMER_MODEL: vision
               DISPATCH_GROOMER_REPO_CONTEXT_ENABLED: true
               DISPATCH_HOSTED_GROOMER_ENABLED: true
               DISPATCH_LANE_CONFIG_JSON: '{"lanes":[{"id":"local","title":"Local","claimable":true,"role":"default","description":"Local model lane (nvidia) \u2014 routine, scoped implementation work.","color":"#3b82f6"},{"id":"cloud","title":"Cloud","claimable":true,"description":"Cloud model lane (dsv4p) \u2014 medium complexity, multi-file changes, debugging with inference.","color":"#8b5cf6"},{"id":"frontier","title":"Frontier","claimable":true,"role":"escalation","description":"Frontier model lane (glm-5.2) \u2014 architecture, security-sensitive, hard bugs.","color":"#f97316"},{"id":"backlog","title":"Backlog","claimable":false,"description":"Needs grooming before work can start. Not directly claimable.","color":"#6b7280"}],"laneAliases":{"normal":"local","escalated":"frontier"}}'


### PR DESCRIPTION
## Summary
- `DISPATCH_GROOMER_MODEL: nvidia` → `vision` (Qwen3.5-4B, `llama-vision` via litellm). Grooming is triage/classification, so a 4B is sufficient — this frees the bigger model for the coder/reviewer.

## Sequencing
- Pairs with **misospace/dispatch#516** (json_schema-constrained groomer output), which is what makes the 4B's structure reliable. **Best merged after #516 is built + deployed.** Safe either way: without #516 the groomer just runs in plain JSON mode (today's behavior) + the existing output validator/coercion still repairs content.
- After both land, **dry-run a groom against `vision`** and confirm schema-valid output before trusting it broadly. The audit issues (misospace/dispatch#498–#511) are a handy live test set — check the 4B lanes the umbrella (#498) to backlog and the concrete children to worker lanes.