### PR TITLE
fix(foreman): submit gate Jobs to llm instead of foreman-system

### DIFF
--- a/kubernetes/apps/base/llm/foreman/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/foreman/helmrelease.yaml
@@ -16,6 +16,21 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
+  # The agent submits gate Jobs into --foreman-namespace, which defaults to
+  # "foreman-system" — a namespace this cluster doesn't have (and the gate-cache
+  # PVC lives in llm anyway), so every verify task died with GATE-ERROR and
+  # cascade-failed its review. The chart doesn't expose the flag yet, so patch
+  # it in until upstream adds an agent.foremanNamespace value.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: foreman-agent
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/args/-
+                value: --foreman-namespace=llm
   values:
     agent:
       # Single shared executor: runs coder/verifier/reviewer tasks and reaches


### PR DESCRIPTION
## Summary
- postRenderer patch appends `--foreman-namespace=llm` to the foreman-agent args.

Every verify task died with `GATE-ERROR: create job: namespaces "foreman-system" not found` and cascade-failed its review (`UpstreamFailed`). The agent's gate-Job namespace flag defaults to `foreman-system`, the chart doesn't render the flag, and the `foreman-gate-cache` PVC the Job mounts lives in `llm` — so `llm` is the only namespace that works.

## Notes
- Temporary: drop the patch once upstream exposes `agent.foremanNamespace` (chart-only change; the binary flag already exists).
- Existing Failed workloads won't self-heal — they need re-creation after this lands.