### PR TITLE
feat(foreman): run 2 agent replicas so verify/review don't starve

### DIFF
--- a/kubernetes/apps/base/llm/foreman/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/foreman/helmrelease.yaml
@@ -33,9 +33,15 @@ spec:
                 value: --foreman-namespace=llm
   values:
     agent:
-      # Single shared executor: runs coder/verifier/reviewer tasks and reaches
-      # the llama-* InferenceServices over the cluster network. Roles advertised
+      # Shared executors: run coder/verifier/reviewer tasks and reach the
+      # llama-* InferenceServices over the cluster network. Roles advertised
       # here are matched against each Agent's requiredCapability.roles.
+      # The watcher is one-task-per-node (v0.1), so a single replica serializes
+      # the whole pipeline — a deep code-task queue starves verify/review and
+      # no Workload ever finishes. Two replicas let reviews run beside coding;
+      # GPU-safe because the coder hits llama-nvidia, Ornith hits llama-strix,
+      # and gate Jobs are no-ops.
+      replicaCount: 2
       mode: native
       # The bridge creates Workloads (and the operator its AgenticTasks) in the
       # llm namespace. Without this the agent watches "default" and never picks


### PR DESCRIPTION
## Summary
- `agent.replicaCount: 2` on the foreman HelmRelease.

The watcher is one-task-per-node (v0.1): one replica = one task at a time for the *entire* pipeline. The current queue of ~10-minute coder tasks starves every verify/review task, so no Workload can reach a finished PR. Two FleetNodes let a review run beside a code task — GPU-safe (coder→llama-nvidia, Ornith→llama-strix, gates are no-op Jobs).

## Notes
- Complements (doesn't replace) the upstream fix: watcher should prioritize finishing in-flight Workloads over starting new code tasks — filing on LLMKube.