### PR TITLE
fix(llm): OpenAI-mode MiniMax-M3 entry for the frontier coder

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -13,7 +13,7 @@ spec:
   provider: cloud-proxy
   providerConfig:
     baseURL: http://litellm.llm:4000/v1
-    model: MiniMax-M3
+    model: MiniMax-M3-chat
     apiKeySecretRef:
       name: litellm
       key: LITELLM_MASTER_KEY

--- a/kubernetes/apps/base/llm/litellm/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/app/configmap.yaml
@@ -155,6 +155,23 @@ data:
         litellm_params:
           model: chatgpt/gpt-5.4-mini
 
+      # OpenAI-compatible MiniMax-M3 for OpenAI-speaking clients (the foreman
+      # coder-frontier Agent dispatches /chat/completions). The MiniMax-M3 entry
+      # below is Anthropic-messages mode for OpenClaw — pointing an OpenAI client
+      # at it 404s on MiniMax's side.
+      - model_name: MiniMax-M3-chat
+        model_info:
+          mode: chat
+          input_cost_per_token: 0.0000003000
+          output_cost_per_token: 0.0000012000
+          max_input_tokens: 1000000
+          max_output_tokens: 131072
+          supports_function_calling: true
+        litellm_params:
+          model: openai/MiniMax-M3
+          api_base: https://api.minimax.io/v1
+          api_key: os.environ/MINIMAX_API_KEY
+
       # OpenClaw's M3 shim (enabled→adaptive thinking, think-tag stripping) only
       # engages when the model id starts with MiniMax-M3, so keep the name versioned.
       - model_name: MiniMax-M3


### PR DESCRIPTION
## Summary
- New litellm model `MiniMax-M3-chat`: `openai/MiniMax-M3` passthrough to `https://api.minimax.io/v1` (same MINIMAX_API_KEY).
- `coder-frontier` now targets it.

The existing `MiniMax-M3` entry is Anthropic-messages mode for OpenClaw (`api_base: …/anthropic/v1/messages`). The foreman agent speaks OpenAI `/chat/completions`, so every escalated frontier task 404'd on turn 1 (`litellm.APIConnectionError: MinimaxException - 404`) — 9 tasks burned their full retry budget against it overnight.

## Notes
- After merge, the frontier tombstones (gallery 247/251/259/263/271/272, kubetix 157/161/168/171, miso-chat 634 — the `lane: frontier` giveups) need delete + issue unclaim to re-run on the fixed endpoint; commands in the session.

## Verification
- `kustomize build` clean on foreman; litellm config is a ConfigMap edit (reloader restarts the pod).