### PR TITLE
feat(foreman-dispatch-bridge): agentictasks read RBAC for feedback-carrying retries

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -79,6 +79,11 @@ spec:
             - apiGroups: ["foreman.llmkube.dev"]
               resources: ["workloads"]
               verbs: ["create", "get", "list", "delete"]
+            # Bridge 0.5.0 reads a failed Workload's task results (reviewer
+            # NO-GO findings, coder errors) to build feedback-carrying retries.
+            - apiGroups: ["foreman.llmkube.dev"]
+              resources: ["agentictasks"]
+              verbs: ["get", "list"]
       bindings:
         foreman-dispatch-bridge:
           type: RoleBinding


### PR DESCRIPTION
## Summary
- Add `get/list` on `agentictasks` to the bridge Role.

Bridge 0.5.0 (joryirving/containers#779) reads a failed Workload's task results (reviewer NO-GO findings, coder errors) to build feedback-carrying retries instead of blind identical re-runs. Read-only; safe to merge before Renovate bumps the image.