### PR TITLE
feat(foreman): anti-hallucination guardrails in both coder prompts

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -43,7 +43,11 @@ spec:
     the problem to be subtler than it looks, and prefer root-cause fixes over
     surface patches. Read the issue and the relevant files, then make the smallest
     correct change. Every behavior change needs a test (add a regression test for
-    a bug). Match the surrounding code style. Run the repo's verification commands
+    a bug). Match the surrounding code style. Ground every external fact in something
+    you can read: reference GitHub Actions by version tag (uses: azure/setup-helm@v5)
+    and NEVER write commit SHAs, URLs, or version numbers from memory — if you cannot
+    verify a value from the repo, leave a TODO comment instead. Prefer tools
+    preinstalled on CI runners (yq, jq, helm) over pip/npm-installing alternatives. Run the repo's verification commands
     (fmt/vet/lint/test) via the bash tool before finishing. When the change is
     complete and verification passes, call submit_result with a concise commit
     message. If the task is an epic, needs a human design decision, or would touch

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -32,7 +32,12 @@ spec:
     You are a coding agent resolving a single GitHub issue in the referenced repo.
     Read the issue and the relevant files, then make the smallest correct change.
     Every behavior change needs a test (add a regression test for a bug). Match the
-    surrounding code style. Run the repo's verification commands (fmt/vet/lint/test)
+    surrounding code style.
+    Ground every external fact in something you can read: reference GitHub Actions
+    by version tag (uses: azure/setup-helm@v5) and NEVER write commit SHAs, URLs, or
+    version numbers from memory — if you cannot verify a value from the repo, leave a
+    TODO comment instead. Prefer tools preinstalled on CI runners (yq, jq, helm) over
+    pip/npm-installing alternatives. Run the repo's verification commands (fmt/vet/lint/test)
     via the bash tool before finishing. When the change is complete and verification
     passes, call submit_result with a concise commit message. If the task is an epic,
     needs a human design decision, or would touch many files, call submit_result with


### PR DESCRIPTION
## Summary
- Both coder Agent CRs gain a grounding rule: GitHub Actions by version tag (`@v5`), never write commit SHAs/URLs/version numbers from memory (TODO comment if unverifiable), prefer runner-preinstalled tools (yq/jq/helm) over pip/npm alternatives.

Learned from dispatch#550: the coder invented an `azure/setup-helm` SHA (imitating the pin-by-SHA house style) and pip-installed the jq-wrapper `yq` over the runner's mikefarah one. Renovate converts tags to pinned SHAs later, so tags lose nothing.