### PR TITLE
feat(foreman-dispatch-bridge): image from misospace/foreman-dispatch-bridge (0.6.0)

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           app:
             image:
               repository: ghcr.io/misospace/foreman-dispatch-bridge
-              tag: 0.6.0
+              tag: 0.6.0@sha256:52d88be75fac2aea8880b1a7a1f6a509a83c63179667cf8740c8b9064bc1ae28
             env:
               DISPATCH_URL: http://dispatch.llm:3000
               # Dash, not slash (like saffron-normal): agents auto-register, but a "/"

--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -28,8 +28,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/joryirving/foreman-dispatch-bridge
-              tag: 0.5.0@sha256:673e66d6715ac3292d1a240651d785210457bb144587e4b18d5eb7ac0630b9a6
+              repository: ghcr.io/misospace/foreman-dispatch-bridge
+              tag: 0.6.0
             env:
               DISPATCH_URL: http://dispatch.llm:3000
               # Dash, not slash (like saffron-normal): agents auto-register, but a "/"


### PR DESCRIPTION
## Summary
- Bridge image: `ghcr.io/joryirving/foreman-dispatch-bridge:0.5.1` → `ghcr.io/misospace/foreman-dispatch-bridge:0.6.0` (new repo, fresh history; 0.6.0 == containers 0.5.1 functionally).

Renovate will re-pin the digest on its next run. Own repo = own release cadence + visible to the dispatch pipeline (the loop can maintain its own bridge).