### PR TITLE
feat(openclaw): add litellm/vision to models allowlist

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -48,6 +48,7 @@ data:
             "litellm/mimo-v2.5-pro": { alias: "mimo-agent", params: { cache_prompt: true } },
             "litellm/mimo-v2.5": { alias: "mimo-v2.5", params: { cache_prompt: true } },
             "litellm/qwen3.7-plus": { alias: "qwen-plus", params: { cache_prompt: true } },
+            "litellm/vision": { alias: "vision", params: { cache_prompt: true } },
             "openai/gpt-5.5": { alias: "gpt" },
             "openai/gpt-5.4": { alias: "gpt-cheap" },
             "openai/gpt-5.4-mini": { alias: "gpt-mini" },


### PR DESCRIPTION
## What

Adds `litellm/vision` (Qwen3.5-9B) to the `agents.defaults.models` allowlist in the OpenClaw ConfigMap.

## Why

The `vision` model is already configured as a litellm provider model and used as the `imageModel.primary`, but was missing from the allowlist. This caused cron jobs with `model: vision` to be rejected:

> cron payload.model 'vision' rejected by agents.defaults.models allowlist: litellm/vision is not in [...]

## Test

- [x] Runtime config patched and verified — `openclaw config get agents.defaults.models` shows `litellm/vision` with alias `vision`
- [ ] Flux reconciles this ConfigMap change cleanly