### PR TITLE
chore(foreman): drop the --foreman-namespace postRenderer (chart 0.8.27 renders it)

### DIFF
--- a/kubernetes/apps/base/llm/foreman/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/foreman/helmrelease.yaml
@@ -16,21 +16,6 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
-  # The agent submits gate Jobs into --foreman-namespace, which defaults to
-  # "foreman-system" — a namespace this cluster doesn't have (and the gate-cache
-  # PVC lives in llm anyway), so every verify task died with GATE-ERROR and
-  # cascade-failed its review. The chart doesn't expose the flag yet, so patch
-  # it in until upstream adds an agent.foremanNamespace value.
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: Deployment
-              name: foreman-agent
-            patch: |
-              - op: add
-                path: /spec/template/spec/containers/0/args/-
-                value: --foreman-namespace=llm
   values:
     agent:
       # Shared executors: run coder/verifier/reviewer tasks and reach the


### PR DESCRIPTION
## Summary
- Remove the Flux postRenderer workaround from #7974 — chart 0.8.27 (deployed) renders `--foreman-namespace` itself via LLMKube#939, defaulting to the release namespace. The agent currently has the arg twice (verified in-cluster; last-wins, same value).