### PR TITLE
feat(openclaw): set web search provider to searxng

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -144,7 +144,7 @@ data:
         agentToAgent: { enabled: true },
         exec: { security: "full", ask: "off", strictInlineEval: false },
         elevated: { enabled: true, allowFrom: { discord: ["$${DISCORD_ADMIN_USER_ID}"] } },
-        web: { search: { enabled: true, openaiCodex: { enabled: true, mode: "cached" } }, fetch: { enabled: true } },
+        web: { search: { enabled: true, provider: "searxng", openaiCodex: { enabled: true, mode: "cached" } }, fetch: { enabled: true } },
       },
       commands: {
         native: "auto",


### PR DESCRIPTION
## What

Sets `tools.web.search.provider: "searxng"` in the OpenClaw ConfigMap.

## Why

The SearXNG plugin is already configured under `plugins.entries.searxng` with `baseUrl: "http://searxng.llm:8080"`, but `tools.web.search.provider` was never set explicitly. Without it, `web_search` auto-detection only checks API-backed providers with keys first (orders 10–75). SearXNG is key-free and ordered last (200), so it never gets selected — causing `web_search` to fail for agents like Miso.

Setting `provider: "searxng"` explicitly pins `web_search` to the self-hosted SearXNG instance.

## Changes

- `kubernetes/apps/base/llm/openclaw/app/configmap.yaml`: added `provider: "searxng"` to `tools.web.search`

## Validation

- [x] Runtime config patched and dry-run validated (schema clean)
- [x] SearXNG plugin installed in pod (`@openclaw/searxng-plugin`)
- [x] `openclaw config get tools.web.search` shows `provider: "searxng"`
- [ ] Gateway restart needed to load plugin + apply config
- [ ] Flux reconciles cleanly