### PR TITLE
feat(ai-review): advertise konflate MCP tools to the native loop

### DIFF
--- a/.agents/instructions/pr-review.instructions.md
+++ b/.agents/instructions/pr-review.instructions.md
@@ -35,4 +35,13 @@ Do not include internal planner/tool-harness diagnostics such as missing `reques
 
 Missing OCI revision/source labels are a non-blocking caveat for same-tag digest refreshes when repository, tag, and created timestamp evidence are consistent.
 
+### Konflate rendered-diff tools
+
+A Konflate MCP server is configured. Konflate renders Helm charts and Kustomizations into their final Kubernetes manifests, so its rendered diff shows the actual cluster impact of a PR — not just the raw git changes. A rendered-diff summary is usually already injected into the corpus by the konflate evidence provider; use the MCP tools when you need more than the summary provides.
+
+- `mcp__konflate__get_pr_summary` — pass the current PR `number`. Blast radius (added/changed/removed resources), caution lint (data-loss, immutable-field, RBAC, suspend/prune), image changes, render failures. Cheap and high-value; call this first if the evidence section is missing or stale.
+- `mcp__konflate__get_pr_diff` — pass the current PR `number`. The full rendered manifest diff (Kubernetes YAML at PR head vs merge-base). Use it when the raw git diff hides the real change — e.g. a HelmRelease version bump or a one-line `values` change that fans out across many resources.
+
+Konflate signals in the review: surface cautions as caveats or blockers by severity; treat render failures as blockers (the manifests may not apply cleanly). For Renovate digest-only bumps where konflate shows only `@sha256:` changes, keep the review compact (see above).
+
 Check upstream for breaking changes. As the PR-Reviewer that's part of your job.

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -106,6 +106,12 @@ jobs:
           tool_allowed_gh_api_repos: "*"
           tool_request_timeout_sec: "15"
           tool_enable_for_forks: "false"
+          # Read-only konflate MCP tools for the native loop (advertised as
+          # mcp__konflate__get_pr_summary / get_pr_diff / list_pull_requests).
+          # Complements the evidence provider below: the provider injects the
+          # rendered-diff summary deterministically; MCP lets the model do
+          # follow-up digging (e.g. pull the full rendered diff on demand).
+          tool_mcp_servers: "konflate=https://konflate.jory.dev/mcp"
           system_prompt_file: .agents/instructions/pr-review.instructions.md
           system_prompt_mode: append
           standards_file_candidates: "AGENTS.md"


### PR DESCRIPTION
## Summary
- Adds `tool_mcp_servers: konflate=https://konflate.jory.dev/mcp` to the AI review step — the evidence provider keeps injecting the rendered-diff summary deterministically; MCP adds on-demand follow-up (`get_pr_diff` when the summary flags something).
- New Konflate section in `pr-review.instructions.md` steering the model with the **advertised** tool names (`mcp__konflate__…`, double underscores — the form the misospace/pr-reviewer-action code registers; its input docs had them wrong until misospace/pr-reviewer-action#390).

## Verification
- Workflow YAML parses; the external MCP URL was validated with the action's own client (connects through Cloudflare, 3 tools pass the read-verb filter and advertise).