### PR TITLE
fix(searxng): disable scraping-only engines that are consistently blocked

### DIFF
--- a/kubernetes/apps/base/llm/searxng/app/resources/settings.yml
+++ b/kubernetes/apps/base/llm/searxng/app/resources/settings.yml
@@ -44,6 +44,43 @@ enabled_plugins:
   - Tracker URL remover
   - Unit converter plugin
 
+# Disable engines that are consistently blocked due to scraping without API keys
+# Brave: too many requests (no API key configured)
+# DuckDuckGo: CAPTCHA'd
+# KarmaSearch: access denied
+# Startpage: CAPTCHA'd
+engines:
+  - name: brave
+    disabled: true
+  - name: brave.images
+    disabled: true
+  - name: brave.news
+    disabled: true
+  - name: brave.videos
+    disabled: true
+  - name: duckduckgo
+    disabled: true
+  - name: duckduckgo images
+    disabled: true
+  - name: duckduckgo news
+    disabled: true
+  - name: duckduckgo videos
+    disabled: true
+  - name: karmasearch
+    disabled: true
+  - name: karmasearch images
+    disabled: true
+  - name: karmasearch news
+    disabled: true
+  - name: karmasearch videos
+    disabled: true
+  - name: startpage
+    disabled: true
+  - name: startpage images
+    disabled: true
+  - name: startpage news
+    disabled: true
+
 hostnames:
   high_priority:
     - (.*)\/blog\/(.*)


### PR DESCRIPTION
## What

Disables 15 SearXNG engines that are permanently suspended due to scraping without API keys:

- **Brave** (brave, brave.images, brave.news, brave.videos) — too many requests
- **DuckDuckGo** (duckduckgo, duckduckgo images, duckduckgo news, duckduckgo videos) — CAPTCHA'd
- **KarmaSearch** (karmasearch, karmasearch images, karmasearch news, karmasearch videos) — access denied
- **Startpage** (startpage, startpage images, startpage news) — CAPTCHA'd

## Why

Every search query hit all these engines in parallel. They were permanently suspended by SearXNG (auto-retry → blocked again → suspended). Each request was wasted work against 6 engine groups.

## What still works

Google, Bing, Wikipedia, GitHub, Reddit, Stack Overflow, Arch Wiki, Docker Hub, arXiv, PubMed, PyPI, npm, YouTube, SoundCloud, and ~70+ other specialty engines.

## Future

If you want Brave results back, grab a free Brave Search API key (2000 queries/month) and I'll wire it in alongside the scraping-based engines.