### PR TITLE
feat(llm): bump foreman-dispatch-bridge to 0.6.1

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           app:
             image:
               repository: ghcr.io/misospace/foreman-dispatch-bridge
-              tag: 0.6.0@sha256:52d88be75fac2aea8880b1a7a1f6a509a83c63179667cf8740c8b9064bc1ae28
+              tag: 0.6.1@sha256:8178df7d89a962a1a085933413c5f77b4dad57440b11bc046ec728fad73f3afc
             env:
               DISPATCH_URL: http://dispatch.llm:3000
               # Dash, not slash (like saffron-normal): agents auto-register, but a "/"


### PR DESCRIPTION
## Summary
- Bridge 0.6.0 → 0.6.1 (digest from the registry's Docker-Content-Digest header): retry Workloads (attempt > 1) now set `spec.allowOverwrite`, so re-runs force-with-lease their own stale branch instead of dying PUSH-FAILED (misospace/foreman-dispatch-bridge#1).

## Verification
- Release CI green on v0.6.1; 54 unit tests passed upstream.
- After deploy: I'll clear the 4 PUSH-FAILED tombstones (kubetix 144/164, gallery 273/278) + unclaim their issues; they re-run and self-heal on attempt 2.

🤖 Authored by Claude (Fable 5).