### PR TITLE
feat(llm): move toolhive and repo-wiki onto scoped litellm keys

### DIFF
--- a/kubernetes/apps/base/llm/repo-wiki/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/repo-wiki/externalsecret.yaml
@@ -12,7 +12,7 @@ spec:
     name: *name
     template:
       data:
-        OPENAI_API_KEY: "{{ .LITELLM_MASTER_KEY }}"
+        OPENAI_API_KEY: "{{ .LITELLM_REPO_WIKI_API_KEY }}"
         GITHUB_TOKEN: "{{ .GITHUB_TOKEN }}"
   dataFrom:
     - extract:

--- a/kubernetes/apps/base/llm/toolhive/config/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/externalsecret.yaml
@@ -12,7 +12,7 @@ spec:
     name: *name
     template:
       data:
-        OPENAI_API_KEY: "{{ .LITELLM_MASTER_KEY }}"
+        OPENAI_API_KEY: "{{ .LITELLM_TOOLHIVE_API_KEY }}"
   dataFrom:
     - extract:
         key: litellm


### PR DESCRIPTION
## Summary
- Last two master-key consumers swap to their minted per-consumer keys (scopes verified via /v1/models: toolhive → toolhive-embed, repo-wiki → self-hosted).

## Verification
- Both keys authenticated against litellm and list exactly the expected models.

🤖 Authored by Claude (Fable 5).