### PR TITLE
feat(llm): foreman loop go-live — real gates + revision coder + PR-fix actuator

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -47,17 +47,8 @@ spec:
               ESCALATION_LANE: frontier
               LANE_CODER_AGENTS: '{"*":"coder","frontier":"coder-frontier"}'
               FOREMAN_NAMESPACE: llm
-              # Stamp a generic (no-op) gateProfile on every Workload. This
-              # SUPPRESSES Foreman's Go default gate — critical because none of
-              # these repos are Go, and the coder's in-pod fast self-gate runs in
-              # the Go-only coder image (no node/python), so a real language gate
-              # would fail "command not found", exhaust retries, and downgrade the
-              # coder GO to INCOMPLETE (no PR). Generic + no commands = the self-gate
-              # and the clean-room verify Job both no-op, so the coder pushes and
-              # verification falls to the Ornith reviewer + each repo's CI + the
-              # external PR reviewer. Real per-language gates await the upstream
-              # self-gate fix (defer-to-Job on missing runtime).
-              GATEPROFILE_MAP: '{"*":{"language":"generic"}}'
+              GATEPROFILE_MAP: '{"misospace/KubeTix":{"language":"python","image":"python:3.11","commands":{"format":"pip install -q black && black --check .","lint":"pip install -q flake8 && flake8 .","build":"python -m compileall -q .","test":"true"}},"misospace/miso-gallery":{"language":"python","image":"python:3.14","commands":{"format":"true","lint":"pip install -q ruff && ruff check . --select=E,F,W,B,SIM,I --ignore=E501","build":"python -m compileall -q .","test":"true"}},"misospace/pr-reviewer-action":{"language":"python","image":"python:3.14","commands":{"format":"true","lint":"pip install -q yamllint && yamllint action.yml examples/","build":"python -m compileall -q .","test":"true"}},"misospace/dispatch":{"language":"node","image":"node:22","commands":{"format":"true","lint":"npm ci --include=dev && npx prisma generate && NODE_ENV=development npm run lint","build":"NODE_ENV=development npm run typecheck","test":"true"}},"*":{"language":"generic"}}'
+              REVISION_CODER_AGENTS: '{"*":"coder-revision"}'
             envFrom:
               - secretRef:
                   name: foreman-dispatch-bridge

--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           app:
             image:
               repository: ghcr.io/misospace/foreman-dispatch-bridge
-              tag: 0.6.1@sha256:8178df7d89a962a1a085933413c5f77b4dad57440b11bc046ec728fad73f3afc
+              tag: 0.6.2@sha256:6fd81671f76b8ca0f6c45817016f61310f3c7f45f3cac88ef453199a260a4819
             env:
               DISPATCH_URL: http://dispatch.llm:3000
               # Dash, not slash (like saffron-normal): agents auto-register, but a "/"
@@ -49,6 +49,9 @@ spec:
               FOREMAN_NAMESPACE: llm
               GATEPROFILE_MAP: '{"misospace/KubeTix":{"language":"python","image":"python:3.11","commands":{"format":"pip install -q black && black --check .","lint":"pip install -q flake8 && flake8 .","build":"python -m compileall -q .","test":"true"}},"misospace/miso-gallery":{"language":"python","image":"python:3.14","commands":{"format":"true","lint":"pip install -q ruff && ruff check . --select=E,F,W,B,SIM,I --ignore=E501","build":"python -m compileall -q .","test":"true"}},"misospace/pr-reviewer-action":{"language":"python","image":"python:3.14","commands":{"format":"true","lint":"pip install -q yamllint && yamllint action.yml examples/","build":"python -m compileall -q .","test":"true"}},"misospace/dispatch":{"language":"node","image":"node:22","commands":{"format":"true","lint":"npm ci --include=dev && npx prisma generate && NODE_ENV=development npm run lint","build":"NODE_ENV=development npm run typecheck","test":"true"}},"*":{"language":"generic"}}'
               REVISION_CODER_AGENTS: '{"*":"coder-revision"}'
+              PR_FIX_ENABLED: "true"
+              PR_FIX_MAX_ATTEMPTS: "3"
+              PR_FIX_LANE_AGENTS: '{"NORMAL":"coder","ESCALATED":"coder-frontier"}'
             envFrom:
               - secretRef:
                   name: foreman-dispatch-bridge

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Agent
+metadata:
+  name: coder-revision
+spec:
+  role: coder
+  provider: cloud-proxy
+  providerConfig:
+    baseURL: http://litellm.llm:4000/v1
+    model: nvidia
+    apiKeySecretRef:
+      name: foreman-agent
+      key: LITELLM_API_KEY
+  tools:
+    - read_file
+    - write_file
+    - str_replace
+    - grep
+    - bash
+    - submit_result
+  temperature: "0.2"
+  maxTurns: 80
+  maxRetries: 3
+  editFreeTurnsLimit: 12
+  requestTurnTimeoutSeconds: 1800
+  requestTimeoutSeconds: 7200
+  bashTimeoutSeconds: 60
+  requiredCapability:
+    roles:
+      - coder
+    accelerator: any
+  systemPrompt: |
+    You are a coding agent revising a prior attempt at a single GitHub issue after
+    a reviewer returned changes. The workspace already contains that prior attempt,
+    checked out on its branch — do not start over; read the existing diff against the
+    base branch first, then apply the reviewer's findings as targeted edits on top of it.
+    Treat the reviewer feedback as the spec: address every finding, and where a finding
+    cites a file or symbol as the source of truth, read that file and verify your change
+    against it rather than guessing. Preserve the parts of the prior attempt the reviewer
+    did not object to. Every behaviour change still needs a test. Match the surrounding
+    code style.
+    Ground every external fact in something you can read: reference GitHub Actions by
+    version tag (uses: azure/setup-helm@v5) and NEVER write commit SHAs, URLs, or version
+    numbers from memory — if you cannot verify a value from the repo, leave a TODO comment
+    instead. Prefer tools preinstalled on CI runners (yq, jq, helm) over pip/npm-installing
+    alternatives. Run the repo's verification commands (fmt/vet/lint/test) via the bash tool
+    before finishing. When the revision is complete and verification passes, call
+    submit_result with a concise commit message describing what changed since the prior
+    attempt. If a finding needs a human design decision or would touch many files, call
+    submit_result with that verdict instead of guessing.

--- a/kubernetes/apps/base/llm/foreman/kustomization.yaml
+++ b/kubernetes/apps/base/llm/foreman/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - ./externalsecret.yaml
   - ./agents/coder.yaml
   - ./agents/coder-frontier.yaml
+  - ./agents/coder-revision.yaml
   - ./agents/gate.yaml
   - ./agents/reviewer.yaml


### PR DESCRIPTION
0.8.28 is live (agents on `coder:0.8.28`) and bridge 0.6.2 is published, so this is now the **complete, atomic go-live** — one merge lights up the whole loop. (Folded the bridge bump + actuator-enable in here rather than a second PR, since they edit the same helmrelease as the gate flip.)

## What activates on merge
- **Real per-repo lint gates** (GATEPROFILE_MAP): KubeTix/gallery/pr-reviewer = python, dispatch = node; lint + syntax build, tests deferred to CI. With #958's self-gate-defer, a lint failure becomes NO-GO → feedback retry *before* a PR opens. Fixes the "PRs failing basic lint" problem.
- **Bridge 0.6.2** (`0.6.2@sha256:6fd816…`, digest from the registry HEAD): fix-queue actuator + revisionCoderAgentRef stamping.
- **Revision profile**: `coder-revision` Agent + `REVISION_CODER_AGENTS` — a review-NO-GO iteration now runs the revision-tuned coder (editFreeTurnsLimit 12) instead of the issue-fix profile. Clears the `RevisionUnderIssueFixProfile` warning.
- **PR-fix actuator**: `PR_FIX_ENABLED: true` — the bridge drains dispatch's PR-fix queue into fix Workloads (CHANGES_REQUESTED / red CI). Queue is empty today, so it's a no-op until items appear (or the gallery PRs are seeded via enqueue).

## Depends on (all met)
- foreman ≥ 0.8.28 deployed ✓ (#8032)
- bridge 0.6.2 image published ✓

## Verification
- kustomize builds; GATEPROFILE_MAP + PR_FIX_LANE_AGENTS valid JSON; bridge tests 79/79 on the 0.6.2 tag; gate commands mirror each repo's CI. First live gate + first queued fix are the real tests.

🤖 Authored by Claude (Fable 5).