### PR TITLE
feat(network): add towonel tunnel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .bin
 .claude
+.codex-opencode
 .DS_Store
 .nanocoder
 .private

--- a/ansible/columbina/README.md
+++ b/ansible/columbina/README.md
@@ -1,0 +1,32 @@
+# Columbina
+
+Bootstrap the OVH VPS that fronts the Kubernetes `towonel-agent` workloads.
+
+```bash
+ansible-galaxy collection install -r ansible/towonel/requirements.yaml
+ansible-playbook -i ansible/towonel/inventory.yaml ansible/towonel/playbook.yaml
+```
+
+After `towonel.jory.dev` resolves to the VPS and the hub is healthy, create the
+agent invite on the VPS:
+
+```bash
+ssh ubuntu@148.113.195.107
+sudo docker exec towonel-hub towonel invite create --name home-ops --hostnames '*.jory.dev'
+```
+
+Store the resulting token in 1Password:
+
+- item: `towonel-tunnel`
+- property: `invite_token`
+
+Also keep the VPS addresses in the same item:
+
+- `TOWONEL_VPS_IP`: `148.113.195.107`
+- `TOWONEL_VPS_IPV6`: `2607:5300:229:c9c::1`
+
+Important state lives in `/opt/towonel/data`. Back up at least:
+
+- `operator.key`
+- `invite_hash.key`
+- `hub.db`

--- a/ansible/columbina/inventory.yaml
+++ b/ansible/columbina/inventory.yaml
@@ -1,0 +1,9 @@
+---
+all:
+  hosts:
+    columbina:
+      ansible_host: 148.113.195.107
+      ansible_user: ubuntu
+      ansible_port: 22
+      towonel_ipv4: 148.113.195.107
+      towonel_ipv6: 2607:5300:229:c9c::1

--- a/ansible/columbina/playbook.yaml
+++ b/ansible/columbina/playbook.yaml
@@ -1,0 +1,136 @@
+---
+- name: Bootstrap Towonel VPS
+  hosts: all
+  become: true
+  gather_facts: true
+  vars:
+    towonel_hostname: columbina
+    towonel_domain: towonel.jory.dev
+    towonel_acme_email: ops@jory.dev
+    towonel_config_dir: /opt/towonel
+    towonel_data_dir: /opt/towonel/data
+
+  tasks:
+    - name: Check host connectivity
+      ansible.builtin.ping:
+
+    - name: Set hostname
+      ansible.builtin.hostname:
+        name: "{{ towonel_hostname }}"
+
+    - name: Install base packages
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - curl
+          - ipset
+          - jq
+          - ufw
+        state: present
+        update_cache: true
+
+    - name: Install Docker
+      ansible.builtin.shell: curl -fsSL https://get.docker.com | sh
+      args:
+        executable: /bin/bash
+        creates: /usr/bin/docker
+
+    - name: Create Towonel directories
+      ansible.builtin.file:
+        path: "{{ item.path }}"
+        state: directory
+        owner: "{{ item.owner }}"
+        group: "{{ item.group }}"
+        mode: "{{ item.mode }}"
+      loop:
+        - path: "{{ towonel_config_dir }}"
+          owner: root
+          group: root
+          mode: "0755"
+        - path: "{{ towonel_config_dir }}/caddy"
+          owner: root
+          group: root
+          mode: "0755"
+        - path: "{{ towonel_data_dir }}"
+          owner: "10001"
+          group: "10001"
+          mode: "0750"
+
+    - name: Create Docker edge network
+      community.docker.docker_network:
+        name: edge
+        driver: bridge
+        state: present
+
+    - name: Copy Docker Compose file
+      ansible.builtin.copy:
+        src: ../../docker/towonel/docker-compose.yaml
+        dest: "{{ towonel_config_dir }}/docker-compose.yaml"
+        owner: root
+        group: root
+        mode: "0644"
+      register: compose_file
+
+    - name: Render Caddyfile
+      ansible.builtin.template:
+        src: caddy/Caddyfile.j2
+        dest: "{{ towonel_config_dir }}/caddy/Caddyfile"
+        owner: root
+        group: root
+        mode: "0644"
+      register: caddyfile
+
+    - name: Render compose environment
+      ansible.builtin.template:
+        src: env.j2
+        dest: "{{ towonel_config_dir }}/.env"
+        owner: root
+        group: root
+        mode: "0600"
+      register: compose_env
+
+    - name: Allow SSH
+      community.general.ufw:
+        rule: allow
+        port: "22"
+        proto: tcp
+
+    - name: Allow Towonel public ports
+      community.general.ufw:
+        rule: allow
+        port: "{{ item.port }}"
+        proto: "{{ item.proto }}"
+      loop:
+        - port: "80"
+          proto: tcp
+        - port: "443"
+          proto: tcp
+        - port: "51820"
+          proto: udp
+
+    - name: Enable UFW
+      community.general.ufw:
+        state: enabled
+        policy: deny
+
+    - name: Run Docker Compose
+      community.docker.docker_compose_v2:
+        project_src: "{{ towonel_config_dir }}"
+        files:
+          - docker-compose.yaml
+        pull: always
+        state: present
+
+    - name: Wait for Towonel container to become healthy
+      community.docker.docker_container_info:
+        name: towonel-hub
+      register: towonel_container
+      until: towonel_container.container.State.Health.Status == "healthy"
+      retries: 30
+      delay: 5
+
+    - name: Show invite creation command
+      ansible.builtin.debug:
+        msg: >-
+          Create the Kubernetes agent invite after DNS resolves:
+          docker exec towonel-hub towonel invite create --name home-ops --hostnames '*.jory.dev'

--- a/ansible/columbina/requirements.yaml
+++ b/ansible/columbina/requirements.yaml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: community.docker
+  - name: community.general
+

--- a/ansible/columbina/templates/caddy/Caddyfile.j2
+++ b/ansible/columbina/templates/caddy/Caddyfile.j2
@@ -1,0 +1,62 @@
+{
+  email {$CADDY_ACME_EMAIL}
+  http_port 8080
+  https_port 8443
+
+  layer4 {
+    :443 {
+      matching_timeout 15s
+      @local tls sni {$VPS_LOCAL_HOSTS}
+      route @local {
+        proxy {
+          proxy_protocol v2
+          upstream 127.0.0.1:8443
+        }
+      }
+      @tls tls
+      route @tls {
+        proxy {
+          proxy_protocol v2
+          upstream towonel-hub:4443
+        }
+      }
+    }
+    :80 {
+      @local_http http host {$VPS_LOCAL_HOSTS}
+      route @local_http {
+        proxy {
+          proxy_protocol v2
+          upstream 127.0.0.1:8080
+        }
+      }
+    }
+  }
+
+  servers :8443 {
+    listener_wrappers {
+      proxy_protocol {
+        timeout 2s
+        allow 127.0.0.1/32
+      }
+      tls
+    }
+  }
+  servers :8080 {
+    listener_wrappers {
+      proxy_protocol {
+        timeout 2s
+        allow 127.0.0.1/32
+      }
+    }
+  }
+
+  log default {
+    output stdout
+    format json
+  }
+}
+
+{{ towonel_domain }} {
+  reverse_proxy towonel-hub:8443
+}
+

--- a/ansible/columbina/templates/env.j2
+++ b/ansible/columbina/templates/env.j2
@@ -1,0 +1,3 @@
+CADDY_ACME_EMAIL={{ towonel_acme_email }}
+TOWONEL_DOMAIN={{ towonel_domain }}
+

--- a/docker/columbina/docker-compose.yaml
+++ b/docker/columbina/docker-compose.yaml
@@ -1,0 +1,68 @@
+---
+name: towonel
+
+services:
+  towonel-hub:
+    container_name: towonel-hub
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 512M
+    environment:
+      RUST_LOG: info
+      TOWONEL_HUB_ALLOW_PRIVILEGED_PORTS: "true"
+      TOWONEL_HUB_ENABLED: "true"
+      TOWONEL_HUB_PUBLIC_URL: https://${TOWONEL_DOMAIN}
+      TOWONEL_EDGE_ENABLED: "true"
+      TOWONEL_EDGE_HEALTH_LISTEN_ADDR: 0.0.0.0:9092
+      TOWONEL_EDGE_IROH_PORT: "51820"
+      TOWONEL_EDGE_LISTEN_ADDR: 0.0.0.0:4443
+      TOWONEL_EDGE_PROXY_PROTOCOL: "true"
+    expose:
+      - "4443"
+      - "8443"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://127.0.0.1:8443/v1/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
+    # renovate: datasource=docker depName=codeberg.org/towonel/towonel-node
+    image: codeberg.org/towonel/towonel-node:1.0.1
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    ports:
+      - "51820:51820/udp"
+    restart: unless-stopped
+    user: "10001:10001"
+    volumes:
+      - /opt/towonel/data:/data
+
+  caddy:
+    container_name: caddy-l4
+    environment:
+      CADDY_ACME_EMAIL: ${CADDY_ACME_EMAIL}
+      VPS_LOCAL_HOSTS: ${TOWONEL_DOMAIN}
+    image: ghcr.io/bjw-s-labs/caddy-l4:2.11.4
+    ports:
+      - "80:80"
+      - "443:443"
+    restart: unless-stopped
+    volumes:
+      - /opt/towonel/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-config:/config
+      - caddy-data:/data
+
+volumes:
+  caddy-config:
+  caddy-data:
+
+networks:
+  default:
+    name: edge
+    external: true
+

--- a/kubernetes/apps/base/network/envoy-gateway/config/envoy.yaml
+++ b/kubernetes/apps/base/network/envoy-gateway/config/envoy.yaml
@@ -143,6 +143,8 @@ spec:
   http2:
     onInvalidMessage: TerminateStream
   http3: {}
+  proxyProtocol:
+    optional: true
   targetSelectors:
     - group: gateway.networking.k8s.io
       kind: Gateway

--- a/kubernetes/apps/base/network/towonel-agent-config/externalsecret.yaml
+++ b/kubernetes/apps/base/network/towonel-agent-config/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name towonel-agent-config
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    creationPolicy: Owner
+  data:
+    - secretKey: TOWONEL_VPS_IP
+      remoteRef:
+        key: towonel-tunnel
+        property: TOWONEL_VPS_IP
+    - secretKey: TOWONEL_VPS_IPV6
+      remoteRef:
+        key: towonel-tunnel
+        property: TOWONEL_VPS_IPV6

--- a/kubernetes/apps/base/network/towonel-agent-config/kustomization.yaml
+++ b/kubernetes/apps/base/network/towonel-agent-config/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml

--- a/kubernetes/apps/base/network/towonel-agent/dnsendpoint.yaml
+++ b/kubernetes/apps/base/network/towonel-agent/dnsendpoint.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/externaldns.k8s.io/dnsendpoint_v1alpha1.json
+# Parallel record for the Towonel VPS edge. Cloudflared's existing
+# `*.jory.dev` DNSEndpoint is unaffected.
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: towonel-agent
+spec:
+  endpoints:
+    - dnsName: towonel.jory.dev
+      recordType: A
+      targets: ["${TOWONEL_VPS_IP}"]

--- a/kubernetes/apps/base/network/towonel-agent/externalsecret.yaml
+++ b/kubernetes/apps/base/network/towonel-agent/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: towonel-agent
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: towonel-agent-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: TOWONEL_INVITE_TOKEN
+      remoteRef:
+        key: towonel-tunnel
+        property: invite_token

--- a/kubernetes/apps/base/network/towonel-agent/helmrelease.yaml
+++ b/kubernetes/apps/base/network/towonel-agent/helmrelease.yaml
@@ -1,0 +1,118 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: towonel-agent
+# Parallel to cloudflare-tunnel for the jory.dev domain; keep both until cutover.
+# TLS mode: passthrough (Towonel peeks SNI and forwards raw TLS). Origin holds the cert.
+# PROXY v2 header is prepended on passthrough connections; envoy-gateway's
+# ClientTrafficPolicy `proxyProtocol.optional: true` lets it accept them.
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: towonel-agent
+  interval: 15m
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      towonel-agent:
+        type: deployment
+        replicas: ${REPLICAS:=1}
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: codeberg.org/towonel/towonel-agent
+              tag: 1.0.1
+            env:
+              NODE_NAME:
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+              POD_NAMESPACE:
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              RUST_LOG: info
+              TOWONEL_AGENT_HEALTH_LISTEN_ADDR: 0.0.0.0:9090
+              TOWONEL_AGENT_SERVICES: |
+                [
+                  {"hostname":"*.jory.dev","origin":"envoy-external.{{ .Release.Namespace }}.svc.cluster.local:443"}
+                ]
+              # Raw TCP/UDP service placeholders. Format mirrors TOWONEL_AGENT_SERVICES
+              # but with a `listen_port` per service, scoped per tenant on the hub.
+              # Leave as `[]` until a real service is added; the agent reconciles
+              # declared entries against the hub on each boot.
+              # TOWONEL_AGENT_TCP_SERVICES: |
+              #   [
+              #     {"name":"...", "origin":"svc.ns.svc.cluster.local:PORT", "listen_port":PORT}
+              #   ]
+              # TOWONEL_AGENT_UDP_SERVICES: |
+              #   [
+              #     {"name":"...", "origin":"svc.ns.svc.cluster.local:PORT", "listen_port":PORT}
+              #   ]
+              TOWONEL_INVITE_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: towonel-agent-secret
+                    key: TOWONEL_INVITE_TOKEN
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 9090
+                  periodSeconds: 30
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 9090
+                  periodSeconds: 10
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 9090
+                  periodSeconds: 5
+                  failureThreshold: 60
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                cpu: 500m
+                memory: 64Mi
+    service:
+      app:
+        ports:
+          http:
+            port: 9090
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: http

--- a/kubernetes/apps/base/network/towonel-agent/kustomization.yaml
+++ b/kubernetes/apps/base/network/towonel-agent/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./dnsendpoint.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/network/towonel-agent/ocirepository.yaml
+++ b/kubernetes/apps/base/network/towonel-agent/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: towonel-agent
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/main/network/kustomization.yaml
+++ b/kubernetes/apps/main/network/kustomization.yaml
@@ -13,6 +13,8 @@ resources:
   - ./cloudflare-dns.yaml
   - ./cloudflare-tunnel.yaml
   - ./echo.yaml
+  - ./towonel-agent-config.yaml
+  - ./towonel-agent.yaml
   - ./envoy-gateway.yaml
   - ./multus.yaml
   - ./unifi-dns.yaml

--- a/kubernetes/apps/main/network/towonel-agent-config.yaml
+++ b/kubernetes/apps/main/network/towonel-agent-config.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: towonel-agent-config
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/network/towonel-agent-config
+  wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/main/network/towonel-agent.yaml
+++ b/kubernetes/apps/main/network/towonel-agent.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: towonel-agent
+spec:
+  dependsOn:
+    - name: cloudflare-dns
+    - name: towonel-agent-config
+  interval: 1h
+  path: ./kubernetes/apps/base/network/towonel-agent
+  postBuild:
+    substitute:
+      CLUSTER: ${CLUSTER}
+      REPLICAS: "2"
+    substituteFrom:
+      - kind: Secret
+        name: towonel-agent-config
+        optional: false
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/network/kustomization.yaml
+++ b/kubernetes/apps/test/network/kustomization.yaml
@@ -12,5 +12,7 @@ resources:
   - ./cloudflare-dns.yaml
   - ./cloudflare-tunnel.yaml
   - ./echo.yaml
+  - ./towonel-agent-config.yaml
+  - ./towonel-agent.yaml
   - ./envoy-gateway.yaml
   - ./unifi-dns.yaml

--- a/kubernetes/apps/test/network/towonel-agent-config.yaml
+++ b/kubernetes/apps/test/network/towonel-agent-config.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: towonel-agent-config
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/network/towonel-agent-config
+  wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/test/network/towonel-agent.yaml
+++ b/kubernetes/apps/test/network/towonel-agent.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: towonel-agent
+spec:
+  dependsOn:
+    - name: cloudflare-dns
+    - name: towonel-agent-config
+  interval: 1h
+  path: ./kubernetes/apps/base/network/towonel-agent
+  postBuild:
+    substitute:
+      CLUSTER: ${CLUSTER}
+      REPLICAS: "1"
+    substituteFrom:
+      - kind: Secret
+        name: towonel-agent-config
+        optional: false
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/network/kustomization.yaml
+++ b/kubernetes/apps/utility/network/kustomization.yaml
@@ -12,6 +12,8 @@ resources:
   - ./cloudflare-dns.yaml
   - ./cloudflare-tunnel.yaml
   - ./echo.yaml
+  - ./towonel-agent-config.yaml
+  - ./towonel-agent.yaml
   - ./envoy-gateway.yaml
   - ./multus.yaml
   - ./unifi-dns.yaml

--- a/kubernetes/apps/utility/network/towonel-agent-config.yaml
+++ b/kubernetes/apps/utility/network/towonel-agent-config.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: towonel-agent-config
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/network/towonel-agent-config
+  wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/network/towonel-agent.yaml
+++ b/kubernetes/apps/utility/network/towonel-agent.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: towonel-agent
+spec:
+  dependsOn:
+    - name: cloudflare-dns
+    - name: towonel-agent-config
+  interval: 1h
+  path: ./kubernetes/apps/base/network/towonel-agent
+  postBuild:
+    substitute:
+      CLUSTER: ${CLUSTER}
+      REPLICAS: "1"
+    substituteFrom:
+      - kind: Secret
+        name: towonel-agent-config
+        optional: false
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system


### PR DESCRIPTION
Adds a parallel Towonel tunnel path while leaving cloudflared in place. This wires the Kubernetes agent across main/test/utility, stores VPS address substitution through ExternalSecrets, enables optional PROXY protocol on Envoy Gateway for passthrough mode, and adds the Columbina Ansible/Compose bootstrap for the OVH VPS.

Validated with YAML parsing, Docker Compose config rendering, and kustomize builds for main/test network overlays. Earlier flate checks passed for main/test after the Towonel resources were added; utility still has the unrelated existing free-game-notifier YAML anchor failure.