### PR TITLE
fix(llm): coder-revision editFreeTurnsLimit under stuckLoopDetection

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -22,7 +22,8 @@ spec:
   temperature: "0.2"
   maxTurns: 80
   maxRetries: 3
-  editFreeTurnsLimit: 12
+  stuckLoopDetection:
+    editFreeTurnsLimit: 12
   requestTurnTimeoutSeconds: 1800
   requestTimeoutSeconds: 7200
   bashTimeoutSeconds: 60


### PR DESCRIPTION
#8026's `coder-revision` Agent put `editFreeTurnsLimit` at `spec.editFreeTurnsLimit`, but the 0.8.28 Agent CRD has it at `spec.stuckLoopDetection.editFreeTurnsLimit`. The bad field failed the `foreman` Kustomization server dry-run (`field not declared in schema`), which blocked that ks and the dependent `foreman-dispatch-bridge` ks — so none of the go-live (bridge 0.6.2, gate flip, PR_FIX, coder-revision) actually applied.

Moves the field under `stuckLoopDetection`. Verified with `kubectl apply --dry-run=server` against the live CRD — now passes.

## Verification
- `kubectl apply --dry-run=server -f coder-revision.yaml` → created (server dry run), no schema error.

🤖 Authored by Claude (Fable 5).