### PR TITLE
fix(network): order towonel before envoy routes

### DIFF
--- a/kubernetes/apps/main/network/envoy-gateway.yaml
+++ b/kubernetes/apps/main/network/envoy-gateway.yaml
@@ -22,6 +22,7 @@ spec:
   dependsOn:
     - name: certificates-import
     - name: envoy-gateway
+    - name: towonel-tunnel
   interval: 1h
   path: ./kubernetes/apps/base/network/envoy-gateway/config
   postBuild:

--- a/kubernetes/apps/main/network/towonel-tunnel.yaml
+++ b/kubernetes/apps/main/network/towonel-tunnel.yaml
@@ -6,7 +6,6 @@ metadata:
   name: towonel-tunnel
 spec:
   dependsOn:
-    - name: envoy-config
     - name: towonel-operator
   interval: 1h
   path: ./kubernetes/apps/base/network/towonel-tunnel

--- a/kubernetes/apps/test/network/envoy-gateway.yaml
+++ b/kubernetes/apps/test/network/envoy-gateway.yaml
@@ -23,6 +23,7 @@ spec:
   dependsOn:
     - name: certificates-import
     - name: envoy-gateway
+    - name: towonel-tunnel
   interval: 1h
   path: ./kubernetes/apps/base/network/envoy-gateway/config
   postBuild:

--- a/kubernetes/apps/test/network/towonel-tunnel.yaml
+++ b/kubernetes/apps/test/network/towonel-tunnel.yaml
@@ -6,7 +6,6 @@ metadata:
   name: towonel-tunnel
 spec:
   dependsOn:
-    - name: envoy-config
     - name: towonel-operator
   interval: 1h
   path: ./kubernetes/apps/base/network/towonel-tunnel

--- a/kubernetes/apps/utility/network/envoy-gateway.yaml
+++ b/kubernetes/apps/utility/network/envoy-gateway.yaml
@@ -21,6 +21,7 @@ metadata:
 spec:
   dependsOn:
     - name: envoy-gateway
+    - name: towonel-tunnel
   interval: 1h
   path: ./kubernetes/apps/base/network/envoy-gateway/config
   postBuild:

--- a/kubernetes/apps/utility/network/towonel-tunnel.yaml
+++ b/kubernetes/apps/utility/network/towonel-tunnel.yaml
@@ -6,7 +6,6 @@ metadata:
   name: towonel-tunnel
 spec:
   dependsOn:
-    - name: envoy-config
     - name: towonel-operator
   interval: 1h
   path: ./kubernetes/apps/base/network/towonel-tunnel


### PR DESCRIPTION
Fix the Towonel bootstrap ordering so the per-cluster `TowonelTunnel` exists before `envoy-config` applies Gateway auto-route annotations. Without this, existing HTTPRoutes can be auto-selected once before the tunnel exists and then sit idle until another Gateway/route event nudges the operator.

Live clusters were nudged manually after PR #8061 and now have Ready tunnels/agents; this makes that state reproducible from GitOps.

Validation:
- `flate test all --path ./kubernetes/clusters/main` -> 420 passed
- `flate test all --path ./kubernetes/clusters/test` -> 79 passed
- `flate test all --path ./kubernetes/clusters/utility` -> 158 passed
