### PR TITLE
fix(llm): coder edit/commit contract + editFreeTurnsLimit

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -27,6 +27,8 @@ spec:
   temperature: "0.2"
   maxTurns: 80
   maxRetries: 3
+  stuckLoopDetection:
+    editFreeTurnsLimit: 12
   requestTurnTimeoutSeconds: 1800
   requestTimeoutSeconds: 7200
   bashTimeoutSeconds: 60
@@ -43,7 +45,16 @@ spec:
     the problem to be subtler than it looks, and prefer root-cause fixes over
     surface patches. Read the issue and the relevant files, then make the smallest
     correct change. Every behavior change needs a test (add a regression test for
-    a bug). Match the surrounding code style. Ground every external fact in something
+    a bug). Match the surrounding code style.
+    Make every file change with the write_file and str_replace tools only — never
+    edit files through the bash tool (no sed/echo/tee/heredocs/git apply). Edits
+    made via bash are invisible to the harness, count as no progress, and will trip
+    the stuck-loop detector. Do NOT run git add, git commit, or git push: leave your
+    changes uncommitted in the working tree — the harness stages, commits, DCO-signs,
+    and pushes them for you using the message you pass to submit_result. If you
+    commit the work yourself the harness sees a clean tree and records it as "no
+    changes."
+    Ground every external fact in something
     you can read: reference GitHub Actions by version tag (uses: azure/setup-helm@v5)
     and NEVER write commit SHAs, URLs, or version numbers from memory — if you cannot
     verify a value from the repo, leave a TODO comment instead. Prefer tools

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -41,6 +41,13 @@ spec:
     against it rather than guessing. Preserve the parts of the prior attempt the reviewer
     did not object to. Every behaviour change still needs a test. Match the surrounding
     code style.
+    Make every file change with the write_file and str_replace tools only — never edit
+    files through the bash tool (no sed/echo/tee/heredocs/git apply). Edits made via bash
+    are invisible to the harness, count as no progress, and will trip the stuck-loop
+    detector. Do NOT run git add, git commit, or git push: leave your changes uncommitted
+    in the working tree — the harness stages, commits, DCO-signs, and pushes them for you
+    using the message you pass to submit_result. If you commit the work yourself the
+    harness sees a clean tree and records it as "no changes."
     Ground every external fact in something you can read: reference GitHub Actions by
     version tag (uses: azure/setup-helm@v5) and NEVER write commit SHAs, URLs, or version
     numbers from memory — if you cannot verify a value from the repo, leave a TODO comment

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -22,6 +22,8 @@ spec:
   temperature: "0.2"
   maxTurns: 80
   maxRetries: 3
+  stuckLoopDetection:
+    editFreeTurnsLimit: 12
   requestTurnTimeoutSeconds: 1800
   requestTimeoutSeconds: 7200
   bashTimeoutSeconds: 60
@@ -37,6 +39,14 @@ spec:
     Read the issue and the relevant files, then make the smallest correct change.
     Every behavior change needs a test (add a regression test for a bug). Match the
     surrounding code style.
+    Make every file change with the write_file and str_replace tools only — never
+    edit files through the bash tool (no sed/echo/tee/heredocs/git apply). Edits
+    made via bash are invisible to the harness, count as no progress, and will trip
+    the stuck-loop detector. Do NOT run git add, git commit, or git push: leave your
+    changes uncommitted in the working tree — the harness stages, commits, DCO-signs,
+    and pushes them for you using the message you pass to submit_result. If you
+    commit the work yourself the harness sees a clean tree and records it as "no
+    changes."
     Ground every external fact in something you can read: reference GitHub Actions
     by version tag (uses: azure/setup-helm@v5) and NEVER write commit SHAs, URLs, or
     version numbers from memory — if you cannot verify a value from the repo, leave a


### PR DESCRIPTION
## Summary
- Teach all three coder agents (coder, coder-frontier, coder-revision) the harness edit/commit contract in their systemPrompt.
- Pin `stuckLoopDetection.editFreeTurnsLimit: 12` on `coder` and `coder-frontier` (were inheriting an aggressive default; matches `coder-revision`).

## Why
Coder GO-yield is ~27%. Investigation showed ~64% of non-GO outcomes are the coder fighting the harness, not model IQ:
- **"model emitted GO but produced no diff"** — the coder runs `git commit` itself, which empties the working tree, so the executor's `HasChanges` (`git status --porcelain`) sees nothing → false NO-GO. Real work discarded.
- **"stuck-loop: EditFreeStreak"** — the coder edits via bash (`sed`/`echo`), which doesn't reset the edit-free streak (only `str_replace`/`write_file` do) → force-terminated INCOMPLETE mid-edit.

The prompt now forbids bash edits and self-commits, and states the harness commits + DCO-signs + pushes using the `submit_result` message. The `editFreeTurnsLimit` bump gives legitimate read/plan exploration room before the detector fires.

The upstream harness should also tolerate these (count committed-ahead-of-base as changes; count bash mutations) — separate LLMKube PR — but this recovers yield now without waiting on a release.

## Verification
- `kubectl apply --dry-run=server` on all three manifests: schema-valid (editFreeTurnsLimit correctly under `stuckLoopDetection`).
