### PR TITLE
[codex] route game servers through Towonel

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ _... managed with Flux, Renovate, and GitHub Actions_ <img src="https://fonts.gs
 
 [![Home-Internet](https://img.shields.io/endpoint?url=https%3A%2F%2Fhealthchecks.io%2Fbadge%2Ff0288b6a-305e-4084-b492-bb0a54%2FKkxSOeO1-2.shields&style=for-the-badge&logo=ubiquiti&logoColor=white&label=Home%20Internet)](https://status.jory.dev)&nbsp;&nbsp;
 [![Status-Page](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus.jory.dev%2Fapi%2Fv1%2Fendpoints%2Fmain-external_gatus%2Fhealth%2Fbadge.shields&style=for-the-badge&logo=statuspage&logoColor=white&label=Status%20Page)](https://status.jory.dev/endpoints/main-external_gatus)&nbsp;&nbsp;
+[![Columbina](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus.jory.dev%2Fapi%2Fv1%2Fendpoints%2Fcluster_columbina-gatus%2Fhealth%2Fbadge.shields&style=for-the-badge&logo=statuspage&logoColor=white&label=Columbina)](https://status.jory.dev/endpoints/cluster_columbina-gatus)&nbsp;&nbsp;
 [![Plex](https://img.shields.io/endpoint?url=https%3A%2F%2Fstatus.jory.dev%2Fapi%2Fv1%2Fendpoints%2Fmain-external_plex%2Fhealth%2Fbadge.shields&style=for-the-badge&logo=plex&logoColor=white&label=Plex)](https://status.jory.dev/endpoints/main-external_plex)
 
 </div>
@@ -58,7 +59,7 @@ There is a template over at [onedr0p/cluster-template](https://github.com/onedr0
 
 ### Core Components
 
-- **Networking & Service Mesh**: [cilium](https://github.com/cilium/cilium) provides eBPF-based networking, while [envoy](https://gateway.envoyproxy.io/) powers service-to-service communication with L7 proxying and traffic management. [cloudflared](https://github.com/cloudflare/cloudflared) secures ingress traffic via Cloudflare, and [external-dns](https://github.com/kubernetes-sigs/external-dns) keeps DNS records in sync automatically.
+- **Networking & Service Mesh**: [cilium](https://github.com/cilium/cilium) provides eBPF-based networking, while [envoy](https://gateway.envoyproxy.io/) powers service-to-service communication with L7 proxying and traffic management. [Towonel](https://github.com/eleboucher/towonel) fronts public ingress through a small OVH VPS, and [external-dns](https://github.com/kubernetes-sigs/external-dns) keeps DNS records in sync automatically.
 - **Security & Secrets**: [cert-manager](https://github.com/cert-manager/cert-manager) automates SSL/TLS certificate management. For secrets, I use [external-secrets](https://github.com/external-secrets/external-secrets) with [1Password Connect](https://github.com/1Password/connect) to inject secrets into Kubernetes, and [sops](https://github.com/getsops/sops) to store and manage encrypted secrets in Git.
 - **Storage & Data Protection**: [rook](https://github.com/rook/rook) provides distributed storage for persistent volumes, with [volsync](https://github.com/backube/volsync) handling backups and restores. [spegel](https://github.com/spegel-org/spegel) improves reliability by running a stateless, cluster-local OCI image mirror.
 - **Automation & CI/CD**: [actions-runner-controller](https://github.com/actions/actions-runner-controller) runs self-hosted GitHub Actions runners directly in the cluster for continuous integration workflows. For IaC, I use [tofu-controller](https://github.com/weaveworks/tf-controller) as additional Flux component used to run Terraform from within a Kubernetes cluster.
@@ -109,7 +110,8 @@ The alternative solution to these two problems would be to host a Kubernetes clu
 | [Cloudflare](https://www.cloudflare.com/)   | Domain, DNS, WAF and R2 bucket (S3 Compatible endpoint)           | ~$40/yr        |
 | [GitHub](https://github.com/)               | Hosting this repository and continuous integration/deployments    | Free           |
 | [Healthchecks.io](https://healthchecks.io/) | Monitoring internet connectivity and external facing applications | Free           |
-|                                             |                                                                   | Total: ~$10/mo |
+| [OVHcloud](https://www.ovhcloud.com/)       | VPS edge for Towonel and out-of-cluster status monitoring         | ~$6/mo         |
+|                                             |                                                                   | Total: ~$16/mo |
 
 ---
 

--- a/docker/columbina/03-gatus/config/config.yaml
+++ b/docker/columbina/03-gatus/config/config.yaml
@@ -58,5 +58,10 @@ ui:
     - name: Utility Status
       link: https://status-utility.jory.dev
 
+remote:
+  instances:
+    - endpoint-prefix: main-
+      url: https://status.jory.dev/api/v1/endpoints/statuses
+
 web:
   port: 8080

--- a/kubernetes/apps/base/games/enshrouded/dnsendpoint.yaml
+++ b/kubernetes/apps/base/games/enshrouded/dnsendpoint.yaml
@@ -8,7 +8,7 @@ spec:
   endpoints:
     - dnsName: "enshrouded.jory.dev"
       recordType: CNAME
-      targets: ["ipv4.jory.dev"]
+      targets: ["towonel.jory.dev"]
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
           value: "false"

--- a/kubernetes/apps/base/games/enshrouded/helmrelease.yaml
+++ b/kubernetes/apps/base/games/enshrouded/helmrelease.yaml
@@ -65,6 +65,12 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: 10.69.10.34
+          towonel.io/gameport.public-port: "27015"
+          towonel.io/gameport.udp: "true"
+          towonel.io/queryport.public-port: "15637"
+          towonel.io/queryport.udp: "true"
+          towonel.io/tunnel: enable
+          towonel.io/tunnel-ref: network/towonel-main
         ports:
           gameport:
             enabled: true

--- a/kubernetes/apps/base/games/minecraft/cobbleverse/dnsendpoint.yaml
+++ b/kubernetes/apps/base/games/minecraft/cobbleverse/dnsendpoint.yaml
@@ -8,7 +8,7 @@ spec:
   endpoints:
     - dnsName: "cobbleverse.jory.dev"
       recordType: CNAME
-      targets: ["ipv4.jory.dev"]
+      targets: ["towonel.jory.dev"]
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
           value: "false"

--- a/kubernetes/apps/base/games/minecraft/jellycraft/dnsendpoint.yaml
+++ b/kubernetes/apps/base/games/minecraft/jellycraft/dnsendpoint.yaml
@@ -8,7 +8,7 @@ spec:
   endpoints:
     - dnsName: "jellycraft.jory.dev"
       recordType: CNAME
-      targets: ["ipv4.jory.dev"]
+      targets: ["towonel.jory.dev"]
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
           value: "false"

--- a/kubernetes/apps/base/games/minecraft/mc-router/dnsendpoint.yaml
+++ b/kubernetes/apps/base/games/minecraft/mc-router/dnsendpoint.yaml
@@ -8,7 +8,7 @@ spec:
   endpoints:
     - dnsName: "mc.jory.dev"
       recordType: CNAME
-      targets: ["ipv4.jory.dev"]
+      targets: ["towonel.jory.dev"]
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
           value: "false"

--- a/kubernetes/apps/base/games/minecraft/mc-router/helmrelease.yaml
+++ b/kubernetes/apps/base/games/minecraft/mc-router/helmrelease.yaml
@@ -23,3 +23,8 @@ spec:
           external-dns.alpha.kubernetes.io/hostname: mc.jory.dev,
             takocraft.jory.dev, create.jory.dev, vibecraft.jory.dev,
             jellycraft.jory.dev, cobbleverse.jory.dev
+          external-dns.alpha.kubernetes.io/target: towonel.jory.dev
+          towonel.io/minecraft.public-port: "25565"
+          towonel.io/minecraft.tcp: "true"
+          towonel.io/tunnel: enable
+          towonel.io/tunnel-ref: network/towonel-main

--- a/kubernetes/apps/base/games/valheim/dnsendpoint.yaml
+++ b/kubernetes/apps/base/games/valheim/dnsendpoint.yaml
@@ -8,7 +8,7 @@ spec:
   endpoints:
     - dnsName: "valheim.jory.dev"
       recordType: CNAME
-      targets: ["ipv4.jory.dev"]
+      targets: ["towonel.jory.dev"]
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
           value: "false"

--- a/kubernetes/apps/base/games/valheim/helmrelease.yaml
+++ b/kubernetes/apps/base/games/valheim/helmrelease.yaml
@@ -69,6 +69,14 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: 10.69.10.42
+          towonel.io/auth.public-port: "2457"
+          towonel.io/auth.udp: "true"
+          towonel.io/gameplay.public-port: "2456"
+          towonel.io/gameplay.udp: "true"
+          towonel.io/tunnel: enable
+          towonel.io/tunnel-ref: network/towonel-main
+          towonel.io/voip.public-port: "2458"
+          towonel.io/voip.udp: "true"
         ports:
           http:
             port: 80

--- a/kubernetes/apps/main/observability/gatus-config.yaml
+++ b/kubernetes/apps/main/observability/gatus-config.yaml
@@ -28,6 +28,15 @@ endpoints:
     extra-labels:
       cluster: utility
 
+  - name: columbina-gatus
+    group: cluster
+    url: "https://columbina-gatus.jory.dev"
+    interval: 1m
+    conditions:
+      - "[STATUS] == 200"
+    extra-labels:
+      cluster: columbina
+
   - name: Cloudflare
     group: connectivity
     url: icmp://1.1.1.1
@@ -68,11 +77,15 @@ ui:
       link: https://github.com/joryirving/home-ops
     - name: Utility Status
       link: https://status-utility.jory.dev
+    - name: Columbina Status
+      link: https://columbina-gatus.jory.dev
 
 remote:
   instances:
     - endpoint-prefix: ""
       url: "https://status-utility.jory.dev/api/v1/endpoints/statuses"
+    - endpoint-prefix: columbina-
+      url: "https://columbina-gatus.jory.dev/api/v1/endpoints/statuses"
 
 web:
   port: ${GATUS_WEB_PORT}


### PR DESCRIPTION
Routes the active direct game services through Towonel L4 exposure while keeping the existing LoadBalancer services in place for rollback/testing. Also wires main and Columbina Gatus to observe each other and updates the README to reflect the VPS edge.

Validation:
- parsed edited YAML with `yq`
- rendered the `mc-router` chart to confirm the service port name is `minecraft`
- skipped `flate` per request; CI should cover full render validation