### PR TITLE
fix(llm): coder no-false-resolved guard + switch to our llmkube-coder image

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -61,5 +61,12 @@ spec:
     preinstalled on CI runners (yq, jq, helm) over pip/npm-installing alternatives. Run the repo's verification commands
     (fmt/vet/lint/test) via the bash tool before finishing. When the change is
     complete and verification passes, call submit_result with a concise commit
-    message. If the task is an epic, needs a human design decision, or would touch
+    message.
+    Do not declare an issue already resolved unless the code at the exact place the
+    issue names already does what the issue asks — open that file and confirm it. A
+    change in a different file, or a commit that touched something related, is NOT the
+    same fix. If you cannot show the issue's specific concern is already handled where
+    it lives, implement the fix: a false "already resolved" verdict leaves a real bug
+    unfixed, so when in doubt, do the work.
+    If the task is an epic, needs a human design decision, or would touch
     many files, call submit_result with that verdict instead of guessing.

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -53,6 +53,12 @@ spec:
     TODO comment instead. Prefer tools preinstalled on CI runners (yq, jq, helm) over
     pip/npm-installing alternatives. Run the repo's verification commands (fmt/vet/lint/test)
     via the bash tool before finishing. When the change is complete and verification
-    passes, call submit_result with a concise commit message. If the task is an epic,
-    needs a human design decision, or would touch many files, call submit_result with
-    that verdict instead of guessing.
+    passes, call submit_result with a concise commit message.
+    Do not declare an issue already resolved unless the code at the exact place the
+    issue names already does what the issue asks — open that file and confirm it. A
+    change in a different file, or a commit that touched something related, is NOT the
+    same fix. If you cannot show the issue's specific concern is already handled where
+    it lives, implement the fix: a false "already resolved" verdict leaves a real bug
+    unfixed, so when in doubt, do the work.
+    If the task is an epic, needs a human design decision, or would touch many files,
+    call submit_result with that verdict instead of guessing.

--- a/kubernetes/apps/base/llm/foreman/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/foreman/helmrelease.yaml
@@ -26,9 +26,7 @@ spec:
         - coder
         - verifier
       image:
-        # coder image ships the Go toolchain + git the coder self-gate needs;
-        # required because roles include "coder".
-        repository: ghcr.io/defilantech/llmkube-foreman-agent-coder
+        repository: ghcr.io/joryirving/llmkube-coder
       githubToken:
         secretName: foreman-agent
         secretKey: GITHUB_TOKEN


### PR DESCRIPTION
Two coder fixes that deploy together to unblock the loop.

## Changes
1. **Stop false "already-resolved" NO-GOs.** The coder was declining real, unsolved issues by matching an unrelated change (e.g. gallery#256 "bulkdelete folder preflight" → declined as "fixed by PR #301", which touched app.py:855-857, a different concern). Each false NO-GO wedges the issue as a claimed `status/in-progress` tombstone that never gets fixed — this is what ground ~37 gallery issues into dead-ends overnight. Both coder prompts now only declare already-resolved when the exact location the issue names is confirmed fixed; default to implementing when unsure.
2. **Switch the coder image to our own `ghcr.io/joryirving/llmkube-coder`** (containers #786). Built from LLMKube source with a Python + Node self-gate toolchain matching this fleet's targets (was Go-only), so the coder can run `pytest`/`ruff`/`eslint`/`tsc` before submitting instead of shipping unverified changes. Image `:0.9.0` verified published (multi-arch, attested). Tag unset → tracks chart AppVersion (0.9.0), keeping operator + agent in lockstep.

## After merge
Guard + image deploy in ~2 min (new tasks read the Agent CR immediately). Then the wedged in-progress issues get reset (delete tombstone workloads + release claims) so the groomer refeeds them and the fixed coder re-works them into real PRs.

## Verification
- `kubectl apply --dry-run=server` on both coder agents + `kustomize build` of the foreman app: clean.
- `ghcr.io/joryirving/llmkube-coder:0.9.0` exists (sha256:bf5fd909…).
