### PR TITLE
fix(llm): bump coder editFreeTurnsLimit 12 → 24

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -28,7 +28,7 @@ spec:
   maxTurns: 80
   maxRetries: 3
   stuckLoopDetection:
-    editFreeTurnsLimit: 12
+    editFreeTurnsLimit: 24
   requestTurnTimeoutSeconds: 1800
   requestTimeoutSeconds: 7200
   bashTimeoutSeconds: 60

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -23,7 +23,7 @@ spec:
   maxTurns: 80
   maxRetries: 3
   stuckLoopDetection:
-    editFreeTurnsLimit: 12
+    editFreeTurnsLimit: 24
   requestTurnTimeoutSeconds: 1800
   requestTimeoutSeconds: 7200
   bashTimeoutSeconds: 60

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -23,7 +23,7 @@ spec:
   maxTurns: 80
   maxRetries: 3
   stuckLoopDetection:
-    editFreeTurnsLimit: 12
+    editFreeTurnsLimit: 24
   requestTurnTimeoutSeconds: 1800
   requestTimeoutSeconds: 7200
   bashTimeoutSeconds: 60


### PR DESCRIPTION
Interim mitigation for the dominant coder stuck-loop (EditFreeStreak) failure — gives the coder more read/plan room before force-termination. Not the root fix (that's LLMKube #982: count bash mutations as edits); buys headroom meanwhile. Server-dry-run validated on all three coder agents.