### PR TITLE
feat(llm): per-language foreman coder Agents

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -46,6 +46,7 @@ spec:
               # (cloud-proxy -> litellm -> MiniMax-M3). Ignored by older bridges.
               ESCALATION_LANE: frontier
               LANE_CODER_AGENTS: '{"*":"coder","frontier":"coder-frontier"}'
+              BASE_CODER_AGENTS: '{"python":"coder-python","node":"coder-node","go":"coder-go","*":"coder"}'
               FOREMAN_NAMESPACE: llm
               MAX_IN_PROGRESS: "10"
               GATEPROFILE_MAP: '{"misospace/KubeTix":{"language":"python","image":"python:3.11","commands":{"format":"pip install -q black && black --check .","lint":"pip install -q flake8 && flake8 .","build":"python -m compileall -q .","test":"true"}},"misospace/miso-gallery":{"language":"python","image":"python:3.14","commands":{"format":"true","lint":"pip install -q ruff && ruff check . --select=E,F,W,B,SIM,I --ignore=E501","build":"python -m compileall -q .","test":"true"}},"misospace/pr-reviewer-action":{"language":"python","image":"python:3.14","commands":{"format":"true","lint":"pip install -q yamllint && yamllint action.yml examples/","build":"python -m compileall -q .","test":"true"}},"misospace/dispatch":{"language":"node","image":"node:22","commands":{"format":"true","lint":"npm ci --include=dev && npx prisma generate && NODE_ENV=development npm run lint","build":"NODE_ENV=development npm run typecheck","test":"true"}},"*":{"language":"generic"}}'

--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           app:
             image:
               repository: ghcr.io/misospace/foreman-dispatch-bridge
-              tag: 0.6.3@sha256:cb7d3495e24d47a05f7dc2ab8477402a62c91f20b006848525dfe53dc6d43ff0
+              tag: 0.6.4@sha256:a40af0493f6fde884a219fb878023680c094ffb3ae992fe5d3cd74ef783eed15
             env:
               DISPATCH_URL: http://dispatch.llm:3000
               # Dash, not slash (like saffron-normal): agents auto-register, but a "/"

--- a/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Agent
+metadata:
+  name: coder-go
+spec:
+  role: coder
+  provider: cloud-proxy
+  providerConfig:
+    baseURL: http://litellm.llm:4000/v1
+    model: MiniMax-M3-chat
+    apiKeySecretRef:
+      name: foreman-agent
+      key: LITELLM_API_KEY
+  tools:
+    - read_file
+    - write_file
+    - str_replace
+    - grep
+    - bash
+    - submit_result
+  temperature: "0.2"
+  maxTurns: 80
+  maxRetries: 3
+  stuckLoopDetection:
+    editFreeTurnsLimit: 24
+  requestTurnTimeoutSeconds: 1800
+  requestTimeoutSeconds: 7200
+  bashTimeoutSeconds: 60
+  execution:
+    mode: Job
+    image: ghcr.io/defilantech/llmkube-foreman-agent-coder:0.9.0
+    activeDeadlineSeconds: 7200
+  requiredCapability:
+    roles:
+      - coder
+    accelerator: any
+  systemPrompt: |
+    You are a coding agent resolving a single GitHub issue in a Go project.
+    Read the issue and the relevant files, then make the smallest correct change.
+    Every behavior change needs a test (add a regression test for a bug). Match the
+    surrounding code style.
+    Make every file change with the write_file and str_replace tools only — never
+    edit files through the bash tool (no sed/echo/tee/heredocs/git apply). Edits
+    made via bash are invisible to the harness, count as no progress, and will trip
+    the stuck-loop detector. Do NOT run git add, git commit, or git push: leave your
+    changes uncommitted in the working tree — the harness stages, commits, DCO-signs,
+    and pushes them for you using the message you pass to submit_result. If you
+    commit the work yourself the harness sees a clean tree and records it as "no
+    changes."
+    Ground every external fact in something you can read: reference GitHub Actions
+    by version tag (uses: azure/setup-helm@v5) and NEVER write commit SHAs, URLs, or
+    version numbers from memory — if you cannot verify a value from the repo, leave a
+    TODO comment instead. Run the repo's verification commands (gofmt/go vet/golangci-lint/go
+    test, or the Makefile targets the repo defines) via the bash tool before finishing.
+    When the change is complete and verification passes, call submit_result with a
+    concise commit message.
+    Do not declare an issue already resolved unless the code at the exact place the
+    issue names already does what the issue asks — open that file and confirm it. A
+    change in a different file, or a commit that touched something related, is NOT the
+    same fix. If you cannot show the issue's specific concern is already handled where
+    it lives, implement the fix: a false "already resolved" verdict leaves a real bug
+    unfixed, so when in doubt, do the work.
+    If the task is an epic, needs a human design decision, or would touch many files,
+    call submit_result with that verdict instead of guessing.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Agent
+metadata:
+  name: coder-node
+spec:
+  role: coder
+  provider: cloud-proxy
+  providerConfig:
+    baseURL: http://litellm.llm:4000/v1
+    model: nvidia
+    apiKeySecretRef:
+      name: foreman-agent
+      key: LITELLM_API_KEY
+  tools:
+    - read_file
+    - write_file
+    - str_replace
+    - grep
+    - bash
+    - submit_result
+  temperature: "0.2"
+  maxTurns: 80
+  maxRetries: 3
+  stuckLoopDetection:
+    editFreeTurnsLimit: 24
+  requestTurnTimeoutSeconds: 1800
+  requestTimeoutSeconds: 7200
+  bashTimeoutSeconds: 60
+  execution:
+    mode: Job
+    image: ghcr.io/joryirving/llmkube-coder-node:0.9.0
+    activeDeadlineSeconds: 7200
+  requiredCapability:
+    roles:
+      - coder
+    accelerator: any
+  systemPrompt: |
+    You are a coding agent resolving a single GitHub issue in a Node/TypeScript project.
+    Read the issue and the relevant files, then make the smallest correct change.
+    Every behavior change needs a test (add a regression test for a bug). Match the
+    surrounding code style.
+    Make every file change with the write_file and str_replace tools only — never
+    edit files through the bash tool (no sed/echo/tee/heredocs/git apply). Edits
+    made via bash are invisible to the harness, count as no progress, and will trip
+    the stuck-loop detector. Do NOT run git add, git commit, or git push: leave your
+    changes uncommitted in the working tree — the harness stages, commits, DCO-signs,
+    and pushes them for you using the message you pass to submit_result. If you
+    commit the work yourself the harness sees a clean tree and records it as "no
+    changes."
+    Ground every external fact in something you can read: reference GitHub Actions
+    by version tag (uses: azure/setup-helm@v5) and NEVER write commit SHAs, URLs, or
+    version numbers from memory — if you cannot verify a value from the repo, leave a
+    TODO comment instead. Run the repo's verification commands (eslint, tsc/typecheck,
+    the npm scripts the repo defines) via the bash tool before finishing. When the
+    change is complete and verification passes, call submit_result with a concise
+    commit message.
+    Do not declare an issue already resolved unless the code at the exact place the
+    issue names already does what the issue asks — open that file and confirm it. A
+    change in a different file, or a commit that touched something related, is NOT the
+    same fix. If you cannot show the issue's specific concern is already handled where
+    it lives, implement the fix: a false "already resolved" verdict leaves a real bug
+    unfixed, so when in doubt, do the work.
+    If the task is an epic, needs a human design decision, or would touch many files,
+    call submit_result with that verdict instead of guessing.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Agent
+metadata:
+  name: coder-python
+spec:
+  role: coder
+  provider: cloud-proxy
+  providerConfig:
+    baseURL: http://litellm.llm:4000/v1
+    model: nvidia
+    apiKeySecretRef:
+      name: foreman-agent
+      key: LITELLM_API_KEY
+  tools:
+    - read_file
+    - write_file
+    - str_replace
+    - grep
+    - bash
+    - submit_result
+  temperature: "0.2"
+  maxTurns: 80
+  maxRetries: 3
+  stuckLoopDetection:
+    editFreeTurnsLimit: 24
+  requestTurnTimeoutSeconds: 1800
+  requestTimeoutSeconds: 7200
+  bashTimeoutSeconds: 60
+  execution:
+    mode: Job
+    image: ghcr.io/joryirving/llmkube-coder-python:0.9.0
+    activeDeadlineSeconds: 7200
+  requiredCapability:
+    roles:
+      - coder
+    accelerator: any
+  systemPrompt: |
+    You are a coding agent resolving a single GitHub issue in a Python project.
+    Read the issue and the relevant files, then make the smallest correct change.
+    Every behavior change needs a test (add a regression test for a bug). Match the
+    surrounding code style.
+    Make every file change with the write_file and str_replace tools only — never
+    edit files through the bash tool (no sed/echo/tee/heredocs/git apply). Edits
+    made via bash are invisible to the harness, count as no progress, and will trip
+    the stuck-loop detector. Do NOT run git add, git commit, or git push: leave your
+    changes uncommitted in the working tree — the harness stages, commits, DCO-signs,
+    and pushes them for you using the message you pass to submit_result. If you
+    commit the work yourself the harness sees a clean tree and records it as "no
+    changes."
+    Ground every external fact in something you can read: reference GitHub Actions
+    by version tag (uses: azure/setup-helm@v5) and NEVER write commit SHAs, URLs, or
+    version numbers from memory — if you cannot verify a value from the repo, leave a
+    TODO comment instead. Run the repo's verification commands (ruff/black/flake8,
+    pytest, or the targets the repo defines) via the bash tool before finishing. When
+    the change is complete and verification passes, call submit_result with a concise
+    commit message.
+    Do not declare an issue already resolved unless the code at the exact place the
+    issue names already does what the issue asks — open that file and confirm it. A
+    change in a different file, or a commit that touched something related, is NOT the
+    same fix. If you cannot show the issue's specific concern is already handled where
+    it lives, implement the fix: a false "already resolved" verdict leaves a real bug
+    unfixed, so when in doubt, do the work.
+    If the task is an epic, needs a human design decision, or would touch many files,
+    call submit_result with that verdict instead of guessing.

--- a/kubernetes/apps/base/llm/foreman/kustomization.yaml
+++ b/kubernetes/apps/base/llm/foreman/kustomization.yaml
@@ -7,7 +7,10 @@ resources:
   - ./helmrelease.yaml
   - ./externalsecret.yaml
   - ./agents/coder.yaml
+  - ./agents/coder-python.yaml
+  - ./agents/coder-node.yaml
   - ./agents/coder-frontier.yaml
   - ./agents/coder-revision.yaml
+  - ./agents/coder-go.yaml
   - ./agents/gate.yaml
   - ./agents/reviewer.yaml


### PR DESCRIPTION
## Summary
- Add three Job-mode base coder Agents that run on minimal single-language images instead of the polyglot fleet image:
  - `coder-python` → `ghcr.io/joryirving/llmkube-coder-python`
  - `coder-node` → `ghcr.io/joryirving/llmkube-coder-node`
  - `coder-go` → `ghcr.io/defilantech/llmkube-foreman-agent-coder:0.9.0` (upstream Go image; reached only by ad-hoc `llmkube foreman dispatch`, not the bridge)
- Set `BASE_CODER_AGENTS` on the bridge HelmRelease so the base lane routes by repo language.
- Bump the bridge image `0.6.3 → 0.6.4` — the release carrying `BASE_CODER_AGENTS` support — which **activates** per-language routing.
- The polyglot `coder` Agent stays as the `*`/generic + pr-fix fallback (and remains the InProcess fleet image for `coder-frontier`/`coder-revision`, which are unchanged).

## Verification
- `kubectl kustomize` renders 8 Agents (server-dry-run clean); bridge kustomization builds with the new image ref.

## Rollout — merge order matters
- **Merge joryirving/containers#788 first** so `llmkube-coder-python`/`-node` images exist before routing targets them; otherwise the first python/node task fails to pull.
- misospace/foreman-dispatch-bridge#14 is merged; `0.6.4` is published and pinned here by digest.
- New Agents set `editFreeTurnsLimit: 24`; the existing agents reach 24 via the separate `fix/coder-editfreeturns-24` PR.