### PR TITLE
feat(coturn): route voice through towonel

### DIFF
--- a/ansible/columbina/playbook.yaml
+++ b/ansible/columbina/playbook.yaml
@@ -127,6 +127,12 @@
           proto: udp
         - port: "27015"
           proto: udp
+        - port: "3478"
+          proto: tcp
+        - port: "3478"
+          proto: udp
+        - port: "49160:49179"
+          proto: udp
 
     - name: Enable UFW
       community.general.ufw:

--- a/docker/columbina/01-towonel/docker-compose.yaml
+++ b/docker/columbina/01-towonel/docker-compose.yaml
@@ -52,6 +52,9 @@ services:
       - "2458:2458/udp"
       - "15637:15637/udp"
       - "27015:27015/udp"
+      - "3478:3478/tcp"
+      - "3478:3478/udp"
+      - "49160-49179:49160-49179/udp"
     restart: unless-stopped
     user: "10001:10001"
     volumes:

--- a/kubernetes/apps/base/workadventure/coturn/dnsendpoint.yaml
+++ b/kubernetes/apps/base/workadventure/coturn/dnsendpoint.yaml
@@ -8,7 +8,7 @@ spec:
   endpoints:
     - dnsName: "turn.jory.dev"
       recordType: CNAME
-      targets: ["ipv4.jory.dev"]
+      targets: ["towonel.jory.dev"]
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
           value: "false"

--- a/kubernetes/apps/base/workadventure/coturn/externalsecret.yaml
+++ b/kubernetes/apps/base/workadventure/coturn/externalsecret.yaml
@@ -14,7 +14,13 @@ spec:
     template:
       engineVersion: v2
       data:
+        TOWONEL_VPS_IP: "{{ .TOWONEL_VPS_IP }}"
         TURN_STATIC_AUTH_SECRET: "{{ .WORKADVENTURE_TURN_AUTH_SECRET }}"
+  data:
+    - secretKey: TOWONEL_VPS_IP
+      remoteRef:
+        key: towonel-tunnel
+        property: TOWONEL_VPS_IP
   dataFrom:
     - extract:
         key: workadventure

--- a/kubernetes/apps/base/workadventure/coturn/helmrelease.yaml
+++ b/kubernetes/apps/base/workadventure/coturn/helmrelease.yaml
@@ -25,14 +25,13 @@ spec:
               - -c
               - |
                 set -e
-                EXTERNAL_IP=$(getent hosts ipv4.jory.dev | awk '{print $1}')
-                if [ -z "$EXTERNAL_IP" ]; then
-                  echo "ERROR: could not resolve ipv4.jory.dev" >&2
+                if [ -z "$TOWONEL_VPS_IP" ]; then
+                  echo "ERROR: TOWONEL_VPS_IP is empty" >&2
                   exit 1
                 fi
-                echo "[entrypoint] external-ip=$EXTERNAL_IP"
+                echo "[entrypoint] external-ip=$TOWONEL_VPS_IP"
                 exec turnserver -c /etc/coturn/turnserver.conf \
-                  --external-ip "$EXTERNAL_IP" \
+                  --external-ip "$TOWONEL_VPS_IP" \
                   --static-auth-secret "$TURN_STATIC_AUTH_SECRET"
             envFrom:
               - secretRef:
@@ -59,6 +58,52 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: 10.69.10.45
+          towonel.io/relay-49160.public-port: "49160"
+          towonel.io/relay-49160.udp: "true"
+          towonel.io/relay-49161.public-port: "49161"
+          towonel.io/relay-49161.udp: "true"
+          towonel.io/relay-49162.public-port: "49162"
+          towonel.io/relay-49162.udp: "true"
+          towonel.io/relay-49163.public-port: "49163"
+          towonel.io/relay-49163.udp: "true"
+          towonel.io/relay-49164.public-port: "49164"
+          towonel.io/relay-49164.udp: "true"
+          towonel.io/relay-49165.public-port: "49165"
+          towonel.io/relay-49165.udp: "true"
+          towonel.io/relay-49166.public-port: "49166"
+          towonel.io/relay-49166.udp: "true"
+          towonel.io/relay-49167.public-port: "49167"
+          towonel.io/relay-49167.udp: "true"
+          towonel.io/relay-49168.public-port: "49168"
+          towonel.io/relay-49168.udp: "true"
+          towonel.io/relay-49169.public-port: "49169"
+          towonel.io/relay-49169.udp: "true"
+          towonel.io/relay-49170.public-port: "49170"
+          towonel.io/relay-49170.udp: "true"
+          towonel.io/relay-49171.public-port: "49171"
+          towonel.io/relay-49171.udp: "true"
+          towonel.io/relay-49172.public-port: "49172"
+          towonel.io/relay-49172.udp: "true"
+          towonel.io/relay-49173.public-port: "49173"
+          towonel.io/relay-49173.udp: "true"
+          towonel.io/relay-49174.public-port: "49174"
+          towonel.io/relay-49174.udp: "true"
+          towonel.io/relay-49175.public-port: "49175"
+          towonel.io/relay-49175.udp: "true"
+          towonel.io/relay-49176.public-port: "49176"
+          towonel.io/relay-49176.udp: "true"
+          towonel.io/relay-49177.public-port: "49177"
+          towonel.io/relay-49177.udp: "true"
+          towonel.io/relay-49178.public-port: "49178"
+          towonel.io/relay-49178.udp: "true"
+          towonel.io/relay-49179.public-port: "49179"
+          towonel.io/relay-49179.udp: "true"
+          towonel.io/tunnel: enable
+          towonel.io/tunnel-ref: network/towonel-main
+          towonel.io/turn-tcp.public-port: "3478"
+          towonel.io/turn-tcp.tcp: "true"
+          towonel.io/turn-udp.public-port: "3478"
+          towonel.io/turn-udp.udp: "true"
         ports:
           turn-tcp:
             port: 3478


### PR DESCRIPTION
Routes coturn's TCP/UDP listener and bounded relay range through Columbina so the existing home firewall forwards can be removed. Coturn now advertises the VPS address from 1Password, while `turn.jory.dev` follows the Towonel edge.

Validated with YAML parsing, `kubectl kustomize`, `docker compose config`, and `git diff --check`. After merge, rerun the Columbina Ansible playbook to apply the UFW rules before removing the old firewall forwards.