### PR TITLE
fix(openclaw): add Accept header to toolhive MCP server config

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -409,7 +409,10 @@ data:
         servers: {
           toolhive: {
             url: "http://vmcp-mcp-gateway-internal.llm:4483/mcp",
-            transport: "streamable-http"
+            transport: "streamable-http",
+            headers: {
+              Accept: "application/json, text/event-stream",
+            },
           },
           context7: {
             url: "https://mcp.context7.com/mcp",


### PR DESCRIPTION
Toolhive MCP connection fails with 'Invalid session ID' on every heartbeat (~46 errors/day). The Accept header for streamable-http content negotiation was added to the PVC copy of openclaw.json but not the ConfigMap, so it reverts on pod restart.

This puts the fix in the source of truth.