### PR TITLE
feat(kopiur): deploy operator fleetwide

### DIFF
--- a/kubernetes/apps/base/kopiur-system/kopiur/helmrelease.yaml
+++ b/kubernetes/apps/base/kopiur-system/kopiur/helmrelease.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://helmreleases.home-operations.com/kopiur.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kopiur
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: kopiur
+  interval: 15m
+  values:
+    installScope: cluster
+    monitoring:
+      dashboards:
+        enabled: false
+      prometheusRule:
+        enabled: false
+      serviceMonitor:
+        enabled: false
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi

--- a/kubernetes/apps/base/kopiur-system/kopiur/kustomization.yaml
+++ b/kubernetes/apps/base/kopiur-system/kopiur/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/kopiur-system/kopiur/ocirepository.yaml
+++ b/kubernetes/apps/base/kopiur-system/kopiur/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kopiur
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.7.2
+  url: oci://ghcr.io/home-operations/charts/kopiur

--- a/kubernetes/apps/main/kopiur-system/kopiur.yaml
+++ b/kubernetes/apps/main/kopiur-system/kopiur.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur
+spec:
+  dependsOn:
+    - name: snapshot-controller
+      namespace: storage
+  interval: 1h
+  path: ./kubernetes/apps/base/kopiur-system/kopiur
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/kubernetes/apps/main/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/main/kopiur-system/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kopiur-system
+components:
+  - ../../../components/namespace
+replacements:
+  - path: ../../../components/replacements/ks.yaml
+resources:
+  - ./kopiur.yaml

--- a/kubernetes/apps/test/kopiur-system/README.md
+++ b/kubernetes/apps/test/kopiur-system/README.md
@@ -1,0 +1,64 @@
+# Kopiur test canary
+
+This is an isolated Kopiur canary for the `test` cluster. It uses two local
+hostpath PVCs: one source claim and one Kopia repository claim. It has no
+schedule, maintenance, or dependency on VolSync or production backup storage.
+
+## Prerequisite
+
+The `kopiur-test` item in the Kubernetes 1Password vault contains a dedicated
+random `KOPIA_PASSWORD`. It does not reuse the production VolSync password.
+External Secrets creates the `kopiur-canary-repository` Secret from that item.
+
+## Validation
+
+After Flux reconciles, wait for the seed job and repository:
+
+```bash
+kubectl --context test -n kopiur-system wait --for=condition=complete job/kopiur-canary-seed --timeout=5m
+kubectl --context test -n kopiur-system wait --for=condition=Ready repository/kopiur-canary --timeout=5m
+```
+
+Create a one-shot backup. It is deliberately outside the reconciled manifests
+so each run creates a new Snapshot:
+
+```bash
+kubectl --context test -n kopiur-system create -f - <<'EOF'
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Snapshot
+metadata:
+  generateName: kopiur-canary-
+spec:
+  policyRef:
+    name: kopiur-canary
+  deletionPolicy: Retain
+EOF
+kubectl --context test -n kopiur-system get snapshots
+```
+
+Wait for the generated Snapshot to reach `Succeeded`, then restore it to a new
+PVC (replace `SNAPSHOT_NAME`):
+
+```bash
+kubectl --context test -n kopiur-system apply -f - <<'EOF'
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: kopiur-canary-restore
+spec:
+  source:
+    snapshotRef:
+      name: SNAPSHOT_NAME
+  target:
+    pvc:
+      name: kopiur-canary-restored
+      storageClassName: local-hostpath
+      capacity: 1Gi
+      accessModes: [ReadWriteOnce]
+EOF
+kubectl --context test -n kopiur-system wait --for=jsonpath='{.status.phase}'=Succeeded restore/kopiur-canary-restore --timeout=5m
+kubectl --context test -n kopiur-system run kopiur-canary-verify --rm -i --restart=Never --image=ghcr.io/joryirving/busybox:1.38.0@sha256:4134704517da2f7d8392082461df5e065bf50da4d3b496376b9e5f033f31cb33 --overrides='{"spec":{"containers":[{"name":"verify","image":"ghcr.io/joryirving/busybox:1.38.0@sha256:4134704517da2f7d8392082461df5e065bf50da4d3b496376b9e5f033f31cb33","command":["/bin/sh","-ec","cd /data && sha256sum -c payload.sha256 && test \"$(cat payload)\" = \"kopiur test canary payload v1\""],"volumeMounts":[{"name":"data","mountPath":"/data"}]}],"volumes":[{"name":"data","persistentVolumeClaim":{"claimName":"kopiur-canary-restored"}}]}}'
+```
+
+Remove the `Restore` and restored PVC before repeating the restore with a new
+Snapshot. Keep the repository PVC until you intentionally retire the canary.

--- a/kubernetes/apps/test/kopiur-system/app.yaml
+++ b/kubernetes/apps/test/kopiur-system/app.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur
+spec:
+  dependsOn:
+    - name: snapshot-controller
+      namespace: storage
+  interval: 1h
+  path: ./kubernetes/apps/base/kopiur-system/kopiur
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/kubernetes/apps/test/kopiur-system/canary.yaml
+++ b/kubernetes/apps/test/kopiur-system/canary.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur-canary
+spec:
+  dependsOn:
+    - name: kopiur
+  interval: 1h
+  path: ./kubernetes/apps/test/kopiur-system/canary
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/test/kopiur-system/canary/externalsecret.yaml
+++ b/kubernetes/apps/test/kopiur-system/canary/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopiur-canary-repository
+spec:
+  dataFrom:
+    - extract:
+        key: kopiur-test
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: kopiur-canary-repository
+    template:
+      data:
+        KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"

--- a/kubernetes/apps/test/kopiur-system/canary/kustomization.yaml
+++ b/kubernetes/apps/test/kopiur-system/canary/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kopiur-system
+resources:
+  - ./externalsecret.yaml
+  - ./pvc.yaml
+  - ./seed-job.yaml
+  - ./repository.yaml
+  - ./snapshotpolicy.yaml

--- a/kubernetes/apps/test/kopiur-system/canary/pvc.yaml
+++ b/kubernetes/apps/test/kopiur-system/canary/pvc.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kopiur-canary-source
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: local-hostpath
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kopiur-canary-repository
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: local-hostpath

--- a/kubernetes/apps/test/kopiur-system/canary/repository.yaml
+++ b/kubernetes/apps/test/kopiur-system/canary/repository.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/repository_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Repository
+metadata:
+  name: kopiur-canary
+spec:
+  backend:
+    filesystem:
+      path: /repository
+      volume:
+        pvc:
+          name: kopiur-canary-repository
+  create:
+    enabled: true
+  encryption:
+    passwordSecretRef:
+      key: KOPIA_PASSWORD
+      name: kopiur-canary-repository
+  maintenance:
+    enabled: false

--- a/kubernetes/apps/test/kopiur-system/canary/seed-job.yaml
+++ b/kubernetes/apps/test/kopiur-system/canary/seed-job.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kopiur-canary-seed
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      containers:
+        - command:
+            - /bin/sh
+            - -ec
+            - |
+              printf '%s\\n' 'kopiur test canary payload v1' > /data/payload
+              sha256sum /data/payload > /data/payload.sha256
+              cat /data/payload.sha256
+          image: ghcr.io/joryirving/busybox:1.38.0@sha256:4134704517da2f7d8392082461df5e065bf50da4d3b496376b9e5f033f31cb33
+          name: seed
+          volumeMounts:
+            - mountPath: /data
+              name: source
+      restartPolicy: Never
+      volumes:
+        - name: source
+          persistentVolumeClaim:
+            claimName: kopiur-canary-source

--- a/kubernetes/apps/test/kopiur-system/canary/snapshotpolicy.yaml
+++ b/kubernetes/apps/test/kopiur-system/canary/snapshotpolicy.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: kopiur-canary
+spec:
+  repository:
+    name: kopiur-canary
+  retention:
+    keepLatest: 2
+  sources:
+    - pvc:
+        name: kopiur-canary-source

--- a/kubernetes/apps/test/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/test/kopiur-system/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kopiur-system
+components:
+  - ../../../components/namespace
+replacements:
+  - path: ../../../components/replacements/ks.yaml
+resources:
+  - ./app.yaml
+  - ./canary.yaml

--- a/kubernetes/apps/utility/kopiur-system/kopiur.yaml
+++ b/kubernetes/apps/utility/kopiur-system/kopiur.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur
+spec:
+  dependsOn:
+    - name: snapshot-controller
+      namespace: storage
+  interval: 1h
+  path: ./kubernetes/apps/base/kopiur-system/kopiur
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/kubernetes/apps/utility/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/utility/kopiur-system/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kopiur-system
+components:
+  - ../../../components/namespace
+replacements:
+  - path: ../../../components/replacements/ks.yaml
+resources:
+  - ./kopiur.yaml


### PR DESCRIPTION
Deploy Kopiur 0.7.2 to main, utility, and test ahead of the staged VolSync migration. Main and utility receive only the operator; test also gets an isolated local-hostpath backup/restore canary with a dedicated 1Password credential.

Validated with `flate test all` for main (419 resources), utility (156), and test (78).