### PR TITLE
feat(kopiur): add shared restore path

### DIFF
--- a/kubernetes/apps/base/kopiur-system/kopiur/helmrelease.yaml
+++ b/kubernetes/apps/base/kopiur-system/kopiur/helmrelease.yaml
@@ -10,6 +10,9 @@ spec:
     name: kopiur
   interval: 15m
   values:
+    features:
+      credentialProjection:
+        enabled: true
     installScope: cluster
     monitoring:
       dashboards:

--- a/kubernetes/apps/base/storage/kopiur-repository/repository.yaml
+++ b/kubernetes/apps/base/storage/kopiur-repository/repository.yaml
@@ -1,10 +1,12 @@
 ---
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/repository_v1alpha1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/clusterrepository_v1alpha1.json
 apiVersion: kopiur.home-operations.com/v1alpha1
-kind: Repository
+kind: ClusterRepository
 metadata:
   name: volsync
 spec:
+  allowedNamespaces:
+    all: true
   backend:
     filesystem:
       path: /repository
@@ -17,10 +19,13 @@ spec:
     refreshInterval: 1h
   create:
     enabled: false
+  credentialProjection:
+    allowed: true
   encryption:
     passwordSecretRef:
       key: KOPIA_PASSWORD
       name: kopiur-volsync-repository
+      namespace: storage
   maintenance:
     enabled: false
   mode: ReadOnly

--- a/kubernetes/components/kopiur/restore/kustomization.yaml
+++ b/kubernetes/components/kopiur/restore/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./restore.yaml

--- a/kubernetes/components/kopiur/restore/restore.yaml
+++ b/kubernetes/components/kopiur/restore/restore.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/restore_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: ${APP}-kopiur-restore
+spec:
+  credentialProjection:
+    enabled: true
+  policy:
+    onMissingSnapshot: Fail
+  repository:
+    kind: ClusterRepository
+    name: volsync
+  source:
+    identity:
+      hostname: ${KOPIUR_HOSTNAME}
+      offset: ${KOPIUR_OFFSET:=0}
+      sourcePath: ${KOPIUR_SOURCE_PATH:=/data}
+      username: ${KOPIUR_USERNAME:=${APP}}
+  target:
+    pvc:
+      accessModes:
+        - ${KOPIUR_ACCESSMODES:=ReadWriteOnce}
+      capacity: ${KOPIUR_CAPACITY:=5Gi}
+      name: ${APP}-kopiur-restore
+      storageClassName: ${KOPIUR_STORAGECLASS:=ceph-block}


### PR DESCRIPTION
Convert the adopted VolSync repository to a read-only ClusterRepository so existing snapshots are discoverable from their application namespaces, and add a reusable identity-based restore component.

Credential projection is enabled explicitly so restore jobs can use the storage-owned secret; this grants the Kopiur operator cross-namespace Secret write RBAC for temporary projected credentials. Kopiur remains read-only with maintenance disabled.

Validated with `flate test all` for main (420), utility (156), and test (78).