### PR TITLE
feat(atuin): migrate restore to kopiur

### DIFF
--- a/kubernetes/apps/main/self-hosted/atuin.yaml
+++ b/kubernetes/apps/main/self-hosted/atuin.yaml
@@ -6,12 +6,13 @@ metadata:
   name: &app atuin
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/atuin
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: self-hosted
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/components/kopiur/backup/kustomization.yaml
+++ b/kubernetes/components/kopiur/backup/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./pvc.yaml
+  - ./restore.yaml
+  - ./snapshotpolicy.yaml
+patches:
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+    patch: |-
+      - op: add
+        path: /spec/dependsOn/-
+        value:
+          name: kopiur
+          namespace: storage
+      - op: add
+        path: /spec/dependsOn/-
+        value:
+          name: ${STORAGE_HR:=rook-ceph-cluster}
+          namespace: ${STORAGE_NS:=rook-ceph}

--- a/kubernetes/components/kopiur/backup/pvc.yaml
+++ b/kubernetes/components/kopiur/backup/pvc.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${APP}
+spec:
+  accessModes:
+    - ${KOPIUR_ACCESSMODES:=ReadWriteOnce}
+  dataSourceRef:
+    apiGroup: kopiur.home-operations.com
+    kind: Restore
+    name: ${APP}
+  resources:
+    requests:
+      storage: ${KOPIUR_CAPACITY:=5Gi}
+  storageClassName: ${KOPIUR_STORAGECLASS:=ceph-block}

--- a/kubernetes/components/kopiur/backup/restore.yaml
+++ b/kubernetes/components/kopiur/backup/restore.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/restore_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: ${APP}
+spec:
+  credentialProjection:
+    enabled: true
+  policy:
+    onMissingSnapshot: Fail
+  source:
+    fromPolicy:
+      name: ${APP}
+      offset: 0
+  target:
+    populator: {}

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: ${APP}
+spec:
+  compression:
+    compressor: zstd
+  identity:
+    hostname: ${KOPIUR_HOSTNAME}
+    username: ${KOPIUR_USERNAME:=${APP}}
+  mover:
+    securityContext:
+      runAsGroup: ${KOPIUR_PGID:=100}
+      runAsUser: ${KOPIUR_PUID:=1000}
+  repository:
+    kind: ClusterRepository
+    name: volsync
+  retention:
+    keepDaily: 7
+    keepHourly: 24
+    keepLatest: 3
+  sources:
+    - pvc:
+        name: ${APP}
+      sourcePathOverride: ${KOPIUR_SOURCE_PATH:=/data}
+  volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS:=csi-ceph-blockpool}


### PR DESCRIPTION
Adds the reusable Kopiur backup/PVC component and migrates Atuin from the VolSync restore component while preserving its existing `atuin@self-hosted:/data` Kopia identity. No Kopiur schedule is enabled while the adopted repository remains read-only.

Do not merge without the cutover sequence: suspend the Atuin Flux Kustomization, scale Atuin down, trigger and verify a final VolSync snapshot, merge, delete the old `atuin` PVC, then resume/reconcile Atuin so the Restore populator creates the replacement PVC.

Smoke evidence: Kopiur restored snapshot `c43fc02294de1b4a` to a temporary Ceph PVC; the 49.8 MB SQLite database contained seven tables and passed `PRAGMA integrity_check`. Temporary resources were removed.

Validated with `flate test all --path ./kubernetes/clusters/main` (420 passed) and a local Flux render confirming the legacy identity, Restore-backed PVC, and storage dependencies.