### PR TITLE
fix(kopiur): project snapshot credentials

### DIFF
--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   compression:
     compressor: zstd
+  credentialProjection:
+    enabled: true
   identity:
     hostname: ${KOPIUR_HOSTNAME}
     username: ${KOPIUR_USERNAME:=${APP}}


### PR DESCRIPTION
Enable credential projection on the shared SnapshotPolicy component so backup movers can use the storage-owned ClusterRepository secret from workload namespaces. Restores already opted into projection; native snapshots otherwise remain Pending with `MissingCredentialsSecret`.

Validated with `flate test all --path ./kubernetes/clusters/main` (419 passed) and a local Atuin Flux render.