### PR TITLE
feat(kopiur): migrate main backups

### DIFF
--- a/kubernetes/apps/main/downloads/autobrr.yaml
+++ b/kubernetes/apps/main/downloads/autobrr.yaml
@@ -6,12 +6,13 @@ metadata:
   name: &app autobrr
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/downloads/autobrr
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/bazarr.yaml
+++ b/kubernetes/apps/main/downloads/bazarr.yaml
@@ -7,12 +7,13 @@ metadata:
 spec:
   components:
     - ../../../../components/zeroscaler
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/downloads/bazarr
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/brrpolice.yaml
+++ b/kubernetes/apps/main/downloads/brrpolice.yaml
@@ -7,12 +7,13 @@ metadata:
 spec:
   components:
     - ../../../../components/zeroscaler
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/downloads/brrpolice
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/kapowarr.yaml
+++ b/kubernetes/apps/main/downloads/kapowarr.yaml
@@ -7,12 +7,13 @@ metadata:
 spec:
   components:
     - ../../../../components/zeroscaler
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/downloads/kapowarr
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/metube.yaml
+++ b/kubernetes/apps/main/downloads/metube.yaml
@@ -7,12 +7,13 @@ metadata:
 spec:
   components:
     - ../../../../components/zeroscaler
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/downloads/metube
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/mylar.yaml
+++ b/kubernetes/apps/main/downloads/mylar.yaml
@@ -7,12 +7,13 @@ metadata:
 spec:
   components:
     - ../../../../components/zeroscaler
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/downloads/mylar
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/pinchflat.yaml
+++ b/kubernetes/apps/main/downloads/pinchflat.yaml
@@ -7,12 +7,13 @@ metadata:
 spec:
   components:
     - ../../../../components/zeroscaler
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/downloads/pinchflat
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: downloads
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/downloads/qbittorrent.yaml
+++ b/kubernetes/apps/main/downloads/qbittorrent.yaml
@@ -7,12 +7,13 @@ metadata:
 spec:
   components:
     - ../../../../components/zeroscaler
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/downloads/qbittorrent
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: downloads
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/downloads/qui.yaml
+++ b/kubernetes/apps/main/downloads/qui.yaml
@@ -6,12 +6,13 @@ metadata:
   name: &app qui
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/downloads/qui
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/recyclarr.yaml
+++ b/kubernetes/apps/main/downloads/recyclarr.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app recyclarr
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   dependsOn:
     - name: radarr
     - name: sonarr
@@ -15,6 +15,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: downloads
   targetNamespace: downloads
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/sabnzbd.yaml
+++ b/kubernetes/apps/main/downloads/sabnzbd.yaml
@@ -7,12 +7,13 @@ metadata:
 spec:
   components:
     - ../../../../components/zeroscaler
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/downloads/sabnzbd
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: downloads
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/games/enshrouded.yaml
+++ b/kubernetes/apps/main/games/enshrouded.yaml
@@ -6,15 +6,16 @@ metadata:
   name: &app enshrouded
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/games/enshrouded
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 50Gi
-      VOLSYNC_UID: "10000"
-      VOLSYNC_GID: "10000"
+      KOPIUR_HOSTNAME: games
+      KOPIUR_CAPACITY: 50Gi
+      KOPIUR_PUID: "10000"
+      KOPIUR_PGID: "10000"
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/games/minecraft.yaml
+++ b/kubernetes/apps/main/games/minecraft.yaml
@@ -23,13 +23,14 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../../components/volsync
+    - ../../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/games/minecraft/cobbleverse
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 50Gi
+      KOPIUR_HOSTNAME: games
+      KOPIUR_CAPACITY: 50Gi
   wait: false
   prune: true
   sourceRef:
@@ -47,13 +48,14 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../../components/volsync
+    - ../../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/games/minecraft/jellycraft
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 15Gi
+      KOPIUR_HOSTNAME: games
+      KOPIUR_CAPACITY: 15Gi
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/games/romm.yaml
+++ b/kubernetes/apps/main/games/romm.yaml
@@ -8,7 +8,7 @@ spec:
   components:
     - ../../../../components/dragonfly
     - ../../../../components/postgres
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   healthCheckExprs:
     - apiVersion: postgresql.cnpg.io/v1
       kind: Cluster
@@ -19,7 +19,8 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 25Gi
+      KOPIUR_HOSTNAME: games
+      KOPIUR_CAPACITY: 25Gi
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/games/valheim.yaml
+++ b/kubernetes/apps/main/games/valheim.yaml
@@ -6,13 +6,14 @@ metadata:
   name: &app valheim
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/games/valheim
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 10Gi
+      KOPIUR_HOSTNAME: games
+      KOPIUR_CAPACITY: 10Gi
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/llm/comfyui.yaml
+++ b/kubernetes/apps/main/llm/comfyui.yaml
@@ -7,14 +7,15 @@ metadata:
 spec:
   components:
     - ../../../../../components/gpu
-    - ../../../../../components/volsync
+    - ../../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/llm/comfyui/app
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: llm
       CLUSTER: ${CLUSTER}
-      VOLSYNC_CAPACITY: 200Gi
+      KOPIUR_CAPACITY: 200Gi
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/llm/hermes.yaml
+++ b/kubernetes/apps/main/llm/hermes.yaml
@@ -6,14 +6,15 @@ metadata:
   name: &app hermes
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/llm/hermes
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: llm
       CLUSTER: ${CLUSTER}
-      VOLSYNC_CAPACITY: 20Gi
+      KOPIUR_CAPACITY: 20Gi
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/llm/litellm.yaml
+++ b/kubernetes/apps/main/llm/litellm.yaml
@@ -8,7 +8,7 @@ spec:
   components:
     - ../../../../../components/dragonfly
     - ../../../../../components/postgres
-    - ../../../../../components/volsync
+    - ../../../../../components/kopiur/backup
   dependsOn:
     - name: llmkube
   healthCheckExprs:
@@ -25,10 +25,11 @@ spec:
   postBuild:
     substitute:
       APP: litellm
-      VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_ACCESSMODES: ReadWriteMany
-      VOLSYNC_STORAGECLASS: ceph-filesystem
-      VOLSYNC_SNAPSHOTCLASS: csi-ceph-filesystem
+      KOPIUR_HOSTNAME: llm
+      KOPIUR_CAPACITY: 1Gi
+      KOPIUR_ACCESSMODES: ReadWriteMany
+      KOPIUR_STORAGECLASS: ceph-filesystem
+      KOPIUR_SNAPSHOTCLASS: csi-ceph-filesystem
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/llm/memini.yaml
+++ b/kubernetes/apps/main/llm/memini.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app memini
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
     - ../../../../components/gpu
   dependsOn:
     - name: llmkube
@@ -15,8 +15,9 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: llm
       CLUSTER: ${CLUSTER}
-      VOLSYNC_CAPACITY: 10Gi
+      KOPIUR_CAPACITY: 10Gi
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/llm/open-webui.yaml
+++ b/kubernetes/apps/main/llm/open-webui.yaml
@@ -8,7 +8,7 @@ spec:
   components:
     - ../../../../components/dragonfly
     - ../../../../components/postgres
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   dependsOn:
     - name: searxng
   healthCheckExprs:
@@ -25,6 +25,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: llm
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/llm/openclaw.yaml
+++ b/kubernetes/apps/main/llm/openclaw.yaml
@@ -5,14 +5,15 @@ metadata:
   name: &app openclaw
 spec:
   components:
-    - ../../../../../components/volsync
+    - ../../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/llm/openclaw/app
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: llm
       CLUSTER: ${CLUSTER}
-      VOLSYNC_CAPACITY: 50Gi
+      KOPIUR_CAPACITY: 50Gi
   wait: false
   prune: true
   sourceRef:
@@ -27,12 +28,13 @@ metadata:
   name: &app extended-memory
 spec:
   components:
-    - ../../../../../components/volsync
+    - ../../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/llm/openclaw/extended-memory
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: llm
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/llm/repo-wiki.yaml
+++ b/kubernetes/apps/main/llm/repo-wiki.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app repo-wiki
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   dependsOn:
     - name: litellm
   interval: 1h
@@ -14,6 +14,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: llm
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/llm/toolhive.yaml
+++ b/kubernetes/apps/main/llm/toolhive.yaml
@@ -178,7 +178,7 @@ metadata:
   name: &name memory-mcp
 spec:
   components:
-    - ../../../../../../components/volsync
+    - ../../../../../../components/kopiur/backup
   dependsOn:
     - name: toolhive
   interval: 1h
@@ -186,6 +186,7 @@ spec:
   postBuild:
     substitute:
       APP: *name
+      KOPIUR_HOSTNAME: llm
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/ersatztv.yaml
+++ b/kubernetes/apps/main/media/ersatztv.yaml
@@ -9,12 +9,13 @@ spec:
     - ../../../../components/gpu
     - ../../../../components/igpu-spread
     - ../../../../components/zeroscaler
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/media/ersatztv
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: media
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/kavita.yaml
+++ b/kubernetes/apps/main/media/kavita.yaml
@@ -7,12 +7,13 @@ metadata:
 spec:
   components:
     - ../../../../components/zeroscaler
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/media/kavita
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: media
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/komga.yaml
+++ b/kubernetes/apps/main/media/komga.yaml
@@ -7,14 +7,15 @@ metadata:
 spec:
   components:
     - ../../../../components/zeroscaler
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/media/komga
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: media
       CLUSTER: ${CLUSTER}
-      VOLSYNC_CAPACITY: 20Gi
+      KOPIUR_CAPACITY: 20Gi
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/kyoo.yaml
+++ b/kubernetes/apps/main/media/kyoo.yaml
@@ -8,7 +8,7 @@ spec:
   components:
     - ../../../../components/gpu
     - ../../../../components/postgres
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   healthCheckExprs:
     - apiVersion: postgresql.cnpg.io/v1
       kind: Cluster
@@ -19,9 +19,10 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: media
       CLUSTER: ${CLUSTER}
       SSLMODE: allow
-      VOLSYNC_CAPACITY: 50Gi
+      KOPIUR_CAPACITY: 50Gi
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/maintainerr.yaml
+++ b/kubernetes/apps/main/media/maintainerr.yaml
@@ -6,12 +6,13 @@ metadata:
   name: &app maintainerr
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/media/maintainerr
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: media
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/media/plex.yaml
+++ b/kubernetes/apps/main/media/plex.yaml
@@ -5,13 +5,14 @@ metadata:
   name: &app agregarr
 spec:
   components:
-    - ../../../../../components/volsync
+    - ../../../../../components/kopiur/backup
     - ../../../../../components/zeroscaler
   interval: 1h
   path: ./kubernetes/apps/base/media/plex/agregarr
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: media
   wait: false
   prune: true
   sourceRef:
@@ -28,15 +29,16 @@ spec:
   components:
     - ../../../../../components/gpu
     - ../../../../../components/igpu-spread
-    - ../../../../../components/volsync
+    - ../../../../../components/kopiur/backup
     - ../../../../../components/zeroscaler
   interval: 1h
   path: ./kubernetes/apps/base/media/plex/app
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: media
       CLUSTER: ${CLUSTER}
-      VOLSYNC_CAPACITY: 50Gi
+      KOPIUR_CAPACITY: 50Gi
   wait: false
   prune: true
   sourceRef:
@@ -116,7 +118,7 @@ metadata:
   name: &app plex-trakt-sync
 spec:
   components:
-    - ../../../../../components/volsync
+    - ../../../../../components/kopiur/backup
   dependsOn:
     - name: plex
   interval: 1h
@@ -124,7 +126,8 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 500Mi
+      KOPIUR_HOSTNAME: media
+      KOPIUR_CAPACITY: 500Mi
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/seerr.yaml
+++ b/kubernetes/apps/main/media/seerr.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/postgres
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   healthCheckExprs:
     - apiVersion: postgresql.cnpg.io/v1
       kind: Cluster
@@ -18,6 +18,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: media
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/stash.yaml
+++ b/kubernetes/apps/main/media/stash.yaml
@@ -9,14 +9,15 @@ spec:
     - ../../../../components/gpu
     - ../../../../components/igpu-spread
     - ../../../../components/zeroscaler
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/media/stash
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: media
       CLUSTER: ${CLUSTER}
-      VOLSYNC_CAPACITY: 50Gi
+      KOPIUR_CAPACITY: 50Gi
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/tautulli.yaml
+++ b/kubernetes/apps/main/media/tautulli.yaml
@@ -6,12 +6,13 @@ metadata:
   name: &app tautulli
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/media/tautulli
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: media
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/media/wizarr.yaml
+++ b/kubernetes/apps/main/media/wizarr.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &app wizarr
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   dependsOn:
     - name: plex
     - name: seerr
@@ -15,6 +15,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: media
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/your-spotify.yaml
+++ b/kubernetes/apps/main/media/your-spotify.yaml
@@ -6,12 +6,13 @@ metadata:
   name: &app your-spotify
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/media/your-spotify
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: media
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/self-hosted/actual.yaml
+++ b/kubernetes/apps/main/self-hosted/actual.yaml
@@ -6,12 +6,13 @@ metadata:
   name: &app actual
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/actual
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: self-hosted
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/self-hosted/manyfold.yaml
+++ b/kubernetes/apps/main/self-hosted/manyfold.yaml
@@ -7,14 +7,15 @@ metadata:
 spec:
   components:
     - ../../../../components/dragonfly
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/manyfold
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: self-hosted
       CLUSTER: ${CLUSTER}
-      VOLSYNC_CAPACITY: 15Gi
+      KOPIUR_CAPACITY: 15Gi
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/self-hosted/paperless.yaml
+++ b/kubernetes/apps/main/self-hosted/paperless.yaml
@@ -9,7 +9,7 @@ spec:
     - ../../../../components/dragonfly
     - ../../../../components/zeroscaler
     - ../../../../components/postgres
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   healthCheckExprs:
     - apiVersion: dragonflydb.io/v1alpha1
       kind: Dragonfly
@@ -24,8 +24,9 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: self-hosted
       CLUSTER: ${CLUSTER}
-      VOLSYNC_CAPACITY: 15Gi
+      KOPIUR_CAPACITY: 15Gi
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/self-hosted/picoshare.yaml
+++ b/kubernetes/apps/main/self-hosted/picoshare.yaml
@@ -6,13 +6,14 @@ metadata:
   name: &app picoshare
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/picoshare
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 50Gi
+      KOPIUR_HOSTNAME: self-hosted
+      KOPIUR_CAPACITY: 50Gi
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/self-hosted/spoolman.yaml
+++ b/kubernetes/apps/main/self-hosted/spoolman.yaml
@@ -6,12 +6,13 @@ metadata:
   name: &app spoolman
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/spoolman
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: self-hosted
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/workadventure/synapse.yaml
+++ b/kubernetes/apps/main/workadventure/synapse.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/postgres
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   healthCheckExprs:
     - apiVersion: postgresql.cnpg.io/v1
       kind: Cluster
@@ -18,8 +18,9 @@ spec:
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: workadventure
       CLUSTER: ${CLUSTER}
-      VOLSYNC_CAPACITY: 10Gi
+      KOPIUR_CAPACITY: 10Gi
   wait: false
   prune: true
   sourceRef:


### PR DESCRIPTION
Migrates all 44 remaining active VolSync consumers on main to the shared Kopiur backup/restore component. Existing Kopia identities remain `<app>@<namespace>:/data`; capacities are preserved, including Litellm CephFS/RWX and Enshrouded UID/GID 10000. Atuin is already migrated and is not changed here.

Do not merge without the coordinated main-cluster cutover: suspend and scale down affected applications, trigger and verify final VolSync snapshots, merge, delete only the 44 old PVCs, then reconcile and validate every Kopiur Restore before resuming workloads.

Validated with `flate test all --path ./kubernetes/clusters/main` (419 passed). Audit confirms 45 active Kopiur component references including Atuin, matching 45 `KOPIUR_HOSTNAME` substitutions, and zero active VolSync component references. Atuin native Kopiur snapshot `569a03aa6165337695813c9004ca56d0` succeeded before preparing this batch.