### PR TITLE
feat(kopiur): add utility repository

### DIFF
--- a/kubernetes/apps/utility/storage/kopiur-repository.yaml
+++ b/kubernetes/apps/utility/storage/kopiur-repository.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kopiur-repository
+spec:
+  dependsOn:
+    - name: kopiur
+  interval: 1h
+  path: ./kubernetes/apps/base/storage/kopiur-repository
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/kubernetes/apps/utility/storage/kustomization.yaml
+++ b/kubernetes/apps/utility/storage/kustomization.yaml
@@ -10,5 +10,6 @@ replacements:
 resources:
   - ./democratic-csi.yaml
   - ./kopiur.yaml
+  - ./kopiur-repository.yaml
   - ./snapshot-controller.yaml
   - ./volsync.yaml


### PR DESCRIPTION
Deploy the shared VolSync Kopia repository configuration to utility so Kopiur can discover and restore the existing backups before app cutover.

Validated with `flate test all --path ./kubernetes/clusters/utility` (157 passed).
