### PR TITLE
feat(kopiur): migrate utility backups

### DIFF
--- a/kubernetes/apps/utility/home-automation/home-assistant.yaml
+++ b/kubernetes/apps/utility/home-automation/home-assistant.yaml
@@ -6,16 +6,17 @@ metadata:
   name: home-assistant
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/home-automation/home-assistant
   postBuild:
     substitute:
       APP: home-assistant
+      KOPIUR_HOSTNAME: home-automation
+      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
+      KOPIUR_STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}
       STORAGE_NS: ${STORAGE_NS}
-      VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
-      VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/home-automation/matter-server.yaml
+++ b/kubernetes/apps/utility/home-automation/matter-server.yaml
@@ -6,16 +6,17 @@ metadata:
   name: &app matter-server
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/home-automation/matter-server
   postBuild:
     substitute:
       APP: matter-server
+      KOPIUR_HOSTNAME: home-automation
+      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
+      KOPIUR_STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}
       STORAGE_NS: ${STORAGE_NS}
-      VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
-      VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/home-automation/zigbee.yaml
+++ b/kubernetes/apps/utility/home-automation/zigbee.yaml
@@ -6,18 +6,19 @@ metadata:
   name: zigbee
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
     # - ../../../../components/zeroscaler
   interval: 1h
   path: ./kubernetes/apps/base/home-automation/zigbee
   postBuild:
     substitute:
       APP: zigbee
+      KOPIUR_HOSTNAME: home-automation
+      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
+      KOPIUR_STORAGECLASS: local-hostpath
       ZEROSCALER_JOB_NAME: zigbee_probe
       STORAGE_HR: ${STORAGE_HR}
       STORAGE_NS: ${STORAGE_NS}
-      VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
-      VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/self-hosted/acars.yaml
+++ b/kubernetes/apps/utility/self-hosted/acars.yaml
@@ -6,17 +6,18 @@ metadata:
   name: &app acars
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/acars
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: self-hosted
+      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
+      KOPIUR_STORAGECLASS: local-hostpath
       STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}
       STORAGE_NS: ${STORAGE_NS}
-      VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
-      VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
     substituteFrom:
       - kind: Secret
         name: acarsdrama

--- a/kubernetes/apps/utility/self-hosted/free-game-notifier.yaml
+++ b/kubernetes/apps/utility/self-hosted/free-game-notifier.yaml
@@ -6,17 +6,19 @@ metadata:
   name: &app free-game-notifier
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/free-game-notifier
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: self-hosted
+      KOPIUR_ON_MISSING_SNAPSHOT: Continue
+      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
+      KOPIUR_STORAGECLASS: local-hostpath
       STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}
       STORAGE_NS: ${STORAGE_NS}
-      VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
-      VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/self-hosted/meshcentral.yaml
+++ b/kubernetes/apps/utility/self-hosted/meshcentral.yaml
@@ -6,16 +6,17 @@ metadata:
   name: &app meshcentral
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/meshcentral
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: self-hosted
+      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
+      KOPIUR_STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}
       STORAGE_NS: ${STORAGE_NS}
-      VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
-      VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/self-hosted/scanservjs.yaml
+++ b/kubernetes/apps/utility/self-hosted/scanservjs.yaml
@@ -6,16 +6,17 @@ metadata:
   name: &app scanservjs
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/scanservjs
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: self-hosted
+      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
+      KOPIUR_STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}
       STORAGE_NS: ${STORAGE_NS}
-      VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
-      VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/self-hosted/thelounge.yaml
+++ b/kubernetes/apps/utility/self-hosted/thelounge.yaml
@@ -6,16 +6,17 @@ metadata:
   name: &app thelounge
 spec:
   components:
-    - ../../../../components/volsync
+    - ../../../../components/kopiur/backup
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/thelounge
   postBuild:
     substitute:
       APP: *app
+      KOPIUR_HOSTNAME: self-hosted
+      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
+      KOPIUR_STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}
       STORAGE_NS: ${STORAGE_NS}
-      VOLSYNC_SNAPSHOTCLASS: ${VOLSYNC_SNAPSHOTCLASS}
-      VOLSYNC_STORAGECLASS: ${VOLSYNC_STORAGECLASS}
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/components/kopiur/backup/restore.yaml
+++ b/kubernetes/components/kopiur/backup/restore.yaml
@@ -8,7 +8,7 @@ spec:
   credentialProjection:
     enabled: true
   policy:
-    onMissingSnapshot: Fail
+    onMissingSnapshot: ${KOPIUR_ON_MISSING_SNAPSHOT:=Fail}
   source:
     fromPolicy:
       name: ${APP}


### PR DESCRIPTION
Convert all eight utility VolSync consumers to Kopiur using `local-hostpath` and `csi-local-hostpath`, while preserving their existing Kopia identities.

`free-game-notifier` currently has an empty PVC and therefore no snapshot; it alone uses `onMissingSnapshot: Continue` so its replacement PVC can start empty. All other restores remain fail-closed.

Validated with `flate test all --path ./kubernetes/clusters/utility` (157 passed).
