### PR TITLE
fix(kopiur): run matter mover as root

### DIFF
--- a/kubernetes/apps/utility/home-automation/matter-server.yaml
+++ b/kubernetes/apps/utility/home-automation/matter-server.yaml
@@ -13,6 +13,8 @@ spec:
     substitute:
       APP: matter-server
       KOPIUR_HOSTNAME: home-automation
+      KOPIUR_PGID: 0
+      KOPIUR_PUID: 0
       KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
       KOPIUR_STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}


### PR DESCRIPTION
Run the Matter Server Kopiur mover as `0:0` so native snapshots can read its root-owned mode-600 state files. The restored application is healthy, but its first scheduled Kopiur snapshot failed with `PermissionDenied` under the default `1000:100` mover.

Validated with `flate test all --path ./kubernetes/clusters/utility` (154 passed).