### PR TITLE
fix(kopiur): quote matter mover IDs

### DIFF
--- a/kubernetes/apps/utility/home-automation/matter-server.yaml
+++ b/kubernetes/apps/utility/home-automation/matter-server.yaml
@@ -13,8 +13,8 @@ spec:
     substitute:
       APP: matter-server
       KOPIUR_HOSTNAME: home-automation
-      KOPIUR_PGID: 0
-      KOPIUR_PUID: 0
+      KOPIUR_PGID: "0"
+      KOPIUR_PUID: "0"
       KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
       KOPIUR_STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}


### PR DESCRIPTION
Quote the Matter mover UID/GID substitutions so Kubernetes preserves them in the Kustomization string map. The unquoted numeric values from #8258 were pruned, leaving the live policy at `1000:100`.

Validated with `flate test all --path ./kubernetes/clusters/utility` (157 passed).
