### PR TITLE
fix(kopiur): allow root matter mover

### DIFF
--- a/kubernetes/apps/utility/home-automation/kustomization.yaml
+++ b/kubernetes/apps/utility/home-automation/kustomization.yaml
@@ -5,6 +5,13 @@ kind: Kustomization
 namespace: home-automation
 components:
   - ../../../components/namespace
+patches:
+  - target:
+      kind: Namespace
+    patch: |-
+      - op: add
+        path: /metadata/annotations/kopiur.home-operations.com~1privileged-movers
+        value: "true"
 replacements:
   - path: ../../../components/replacements/ks.yaml
 resources:


### PR DESCRIPTION
Opt the utility `home-automation` namespace into privileged Kopiur movers. Matter Server requires a root mover because it creates root-owned mode-600 state files; Kopiur blocks that policy without an explicit namespace annotation.

Only Matter requests an elevated mover; other policies retain their existing identities.

Validated with `flate test all --path ./kubernetes/clusters/utility` (157 passed).
