### PR TITLE
feat(kube-system): automate etcd defrag

### DIFF
--- a/kubernetes/apps/base/kube-system/etcd-defrag/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/etcd-defrag/helmrelease.yaml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: etcd-defrag
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: etcd-defrag
+  interval: 1h
+  values:
+    defaultPodOptions:
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+      securityContext:
+        runAsGroup: 0
+        runAsNonRoot: false
+        runAsUser: 0
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+    controllers:
+      etcd-defrag:
+        type: cronjob
+        cronjob:
+          concurrencyPolicy: Forbid
+          failedJobsHistory: 1
+          schedule: "0 3 * * 0"
+          successfulJobsHistory: 1
+          timeZone: America/Edmonton
+        containers:
+          app:
+            image:
+              repository: ghcr.io/ahrtr/etcd-defrag
+              tag: v0.42.0@sha256:22521435b870c41f0faca42197e0b4caf37822370ebd7ec84df492d21488ede9
+            args:
+              - --auto-disalarm
+              - --cacert=/certs/ca.crt
+              - --cert=/certs/server.crt
+              - --cluster
+              - --defrag-rule=dbQuotaUsage > 0.5 || dbSizeFree > 100*1024*1024
+              - --disalarm-threshold=0.8
+              - --endpoints=https://127.0.0.1:2379
+              - --key=/certs/server.key
+              - --move-leader
+              - --wait-between-defrags=30s
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              privileged: true
+    persistence:
+      certs:
+        type: hostPath
+        hostPath: /system/secrets/etcd
+        globalMounts:
+          - path: /certs
+            readOnly: true
+      tmpfs:
+        type: emptyDir
+        advancedMounts:
+          etcd-defrag:
+            app:
+              - path: /tmp
+                subPath: tmp

--- a/kubernetes/apps/base/kube-system/etcd-defrag/kustomization.yaml
+++ b/kubernetes/apps/base/kube-system/etcd-defrag/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/kube-system/etcd-defrag/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-system/etcd-defrag/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: etcd-defrag
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/main/kube-system/etcd-defrag.yaml
+++ b/kubernetes/apps/main/kube-system/etcd-defrag.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: etcd-defrag
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/kube-system/etcd-defrag
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/kubernetes/apps/main/kube-system/kustomization.yaml
+++ b/kubernetes/apps/main/kube-system/kustomization.yaml
@@ -10,6 +10,7 @@ replacements:
 resources:
   - ./cilium.yaml
   - ./coredns.yaml
+  - ./etcd-defrag.yaml
   - ./irqbalance.yaml
   - ./intel-gpu-resource-driver.yaml
   - ./k8s-gpu-dra-driver.yaml


### PR DESCRIPTION
Adds a scheduled, threshold-gated etcd defrag job for the main cluster so this maintenance no longer needs to be run manually.

The job runs weekly on a control-plane node, uses Talos' local etcd certificates, and defrags all cluster members safely.

Validated with `flate test all --path ./kubernetes/clusters/main`.