### PR TITLE
fix(kopiur): override repository health

### DIFF
--- a/kubernetes/apps/main/storage/kopiur-repository.yaml
+++ b/kubernetes/apps/main/storage/kopiur-repository.yaml
@@ -7,6 +7,12 @@ metadata:
 spec:
   dependsOn:
     - name: kopiur
+  healthCheckExprs:
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      current: has(status.observedGeneration) && status.observedGeneration == metadata.generation && has(status.phase) && status.phase == 'Ready'
+      failed: has(status.observedGeneration) && status.observedGeneration == metadata.generation && has(status.phase) && status.phase in ['Degraded', 'Failed']
+      inProgress: '!has(status.observedGeneration) || status.observedGeneration != metadata.generation || !has(status.phase) || status.phase in [''Pending'', ''Initializing'']'
+      kind: ClusterRepository
   interval: 1h
   path: ./kubernetes/apps/base/storage/kopiur-repository
   prune: true

--- a/kubernetes/apps/utility/storage/kopiur-repository.yaml
+++ b/kubernetes/apps/utility/storage/kopiur-repository.yaml
@@ -7,6 +7,12 @@ metadata:
 spec:
   dependsOn:
     - name: kopiur
+  healthCheckExprs:
+    - apiVersion: kopiur.home-operations.com/v1alpha1
+      current: has(status.observedGeneration) && status.observedGeneration == metadata.generation && has(status.phase) && status.phase == 'Ready'
+      failed: has(status.observedGeneration) && status.observedGeneration == metadata.generation && has(status.phase) && status.phase in ['Degraded', 'Failed']
+      inProgress: '!has(status.observedGeneration) || status.observedGeneration != metadata.generation || !has(status.phase) || status.phase in [''Pending'', ''Initializing'']'
+      kind: ClusterRepository
   interval: 1h
   path: ./kubernetes/apps/base/storage/kopiur-repository
   prune: true


### PR DESCRIPTION
Use Kopiur's current-generation lifecycle phase for Flux health evaluation. This keeps genuine `Degraded` and `Failed` repositories blocking while avoiding the stale suspended conditions tracked in home-operations/kopiur#245.

Validated with `flate test all` for main (415 passed) and utility (154 passed), plus server-side dry runs against both clusters.
