### PR TITLE
feat(kopiur): add cluster identity defaults

### DIFF
--- a/kubernetes/apps/base/storage/kopiur-repository/repository.yaml
+++ b/kubernetes/apps/base/storage/kopiur-repository/repository.yaml
@@ -15,6 +15,7 @@ spec:
           path: /mnt/daena/kubernetes/volsync
           server: voyager.internal
   catalog:
+    fallbackNamespace: storage
     periodicRefresh: true
     refreshInterval: 1h
   create:
@@ -26,6 +27,9 @@ spec:
       key: KOPIA_PASSWORD
       name: kopiur-volsync-repository
       namespace: storage
+  identityDefaults:
+    hostnameExpr: "'${CLUSTER}'"
+    usernameExpr: "namespace + '-' + policyName"
   maintenance:
     enabled: true
     namespace: storage


### PR DESCRIPTION
Sets the ClusterRepository identity defaults to namespace-policy@cluster and routes otherwise unplaced discovered snapshots to storage. This intentionally lands before removing the policy overrides so Flux cannot pin policies against stale repository defaults; current backup behavior remains unchanged. Validated with flate for main and utility plus server-side admission dry-runs on both clusters.