### PR TITLE
refactor(kopiur): use repository identities

### DIFF
--- a/kubernetes/apps/main/downloads/autobrr.yaml
+++ b/kubernetes/apps/main/downloads/autobrr.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/bazarr.yaml
+++ b/kubernetes/apps/main/downloads/bazarr.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/brrpolice.yaml
+++ b/kubernetes/apps/main/downloads/brrpolice.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/kapowarr.yaml
+++ b/kubernetes/apps/main/downloads/kapowarr.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/metube.yaml
+++ b/kubernetes/apps/main/downloads/metube.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/mylar.yaml
+++ b/kubernetes/apps/main/downloads/mylar.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/pinchflat.yaml
+++ b/kubernetes/apps/main/downloads/pinchflat.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: downloads
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/downloads/qbittorrent.yaml
+++ b/kubernetes/apps/main/downloads/qbittorrent.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: downloads
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/downloads/qui.yaml
+++ b/kubernetes/apps/main/downloads/qui.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: downloads
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/recyclarr.yaml
+++ b/kubernetes/apps/main/downloads/recyclarr.yaml
@@ -15,7 +15,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: downloads
   targetNamespace: downloads
   wait: false
   prune: true

--- a/kubernetes/apps/main/downloads/sabnzbd.yaml
+++ b/kubernetes/apps/main/downloads/sabnzbd.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: downloads
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/games/enshrouded.yaml
+++ b/kubernetes/apps/main/games/enshrouded.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: games
       KOPIUR_CAPACITY: 50Gi
       KOPIUR_PUID: "10000"
       KOPIUR_PGID: "10000"

--- a/kubernetes/apps/main/games/minecraft.yaml
+++ b/kubernetes/apps/main/games/minecraft.yaml
@@ -29,7 +29,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: games
       KOPIUR_CAPACITY: 50Gi
   wait: false
   prune: true
@@ -54,7 +53,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: games
       KOPIUR_CAPACITY: 15Gi
   wait: false
   prune: true

--- a/kubernetes/apps/main/games/romm.yaml
+++ b/kubernetes/apps/main/games/romm.yaml
@@ -19,7 +19,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: games
       KOPIUR_CAPACITY: 25Gi
   wait: false
   prune: true

--- a/kubernetes/apps/main/games/valheim.yaml
+++ b/kubernetes/apps/main/games/valheim.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: games
       KOPIUR_CAPACITY: 10Gi
   wait: false
   prune: true

--- a/kubernetes/apps/main/llm/comfyui.yaml
+++ b/kubernetes/apps/main/llm/comfyui.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: llm
       CLUSTER: ${CLUSTER}
       KOPIUR_CAPACITY: 200Gi
   wait: false

--- a/kubernetes/apps/main/llm/hermes.yaml
+++ b/kubernetes/apps/main/llm/hermes.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: llm
       CLUSTER: ${CLUSTER}
       KOPIUR_CAPACITY: 20Gi
   wait: false

--- a/kubernetes/apps/main/llm/litellm.yaml
+++ b/kubernetes/apps/main/llm/litellm.yaml
@@ -25,7 +25,6 @@ spec:
   postBuild:
     substitute:
       APP: litellm
-      KOPIUR_HOSTNAME: llm
       KOPIUR_CAPACITY: 1Gi
       KOPIUR_ACCESSMODES: ReadWriteMany
       KOPIUR_STORAGECLASS: ceph-filesystem

--- a/kubernetes/apps/main/llm/memini.yaml
+++ b/kubernetes/apps/main/llm/memini.yaml
@@ -15,7 +15,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: llm
       CLUSTER: ${CLUSTER}
       KOPIUR_CAPACITY: 10Gi
   wait: false

--- a/kubernetes/apps/main/llm/open-webui.yaml
+++ b/kubernetes/apps/main/llm/open-webui.yaml
@@ -25,7 +25,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: llm
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/llm/openclaw.yaml
+++ b/kubernetes/apps/main/llm/openclaw.yaml
@@ -11,7 +11,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: llm
       CLUSTER: ${CLUSTER}
       KOPIUR_CAPACITY: 50Gi
   wait: false
@@ -34,7 +33,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: llm
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/llm/repo-wiki.yaml
+++ b/kubernetes/apps/main/llm/repo-wiki.yaml
@@ -14,7 +14,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: llm
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/ersatztv.yaml
+++ b/kubernetes/apps/main/media/ersatztv.yaml
@@ -15,7 +15,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: media
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/kavita.yaml
+++ b/kubernetes/apps/main/media/kavita.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: media
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/komga.yaml
+++ b/kubernetes/apps/main/media/komga.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: media
       CLUSTER: ${CLUSTER}
       KOPIUR_CAPACITY: 20Gi
   wait: false

--- a/kubernetes/apps/main/media/kyoo.yaml
+++ b/kubernetes/apps/main/media/kyoo.yaml
@@ -19,7 +19,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: media
       CLUSTER: ${CLUSTER}
       SSLMODE: allow
       KOPIUR_CAPACITY: 50Gi

--- a/kubernetes/apps/main/media/maintainerr.yaml
+++ b/kubernetes/apps/main/media/maintainerr.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: media
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/media/plex.yaml
+++ b/kubernetes/apps/main/media/plex.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: media
   wait: false
   prune: true
   sourceRef:
@@ -36,7 +35,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: media
       CLUSTER: ${CLUSTER}
       KOPIUR_CAPACITY: 50Gi
   wait: false
@@ -126,7 +124,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: media
       KOPIUR_CAPACITY: 500Mi
   wait: false
   prune: true

--- a/kubernetes/apps/main/media/seerr.yaml
+++ b/kubernetes/apps/main/media/seerr.yaml
@@ -18,7 +18,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: media
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/stash.yaml
+++ b/kubernetes/apps/main/media/stash.yaml
@@ -15,7 +15,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: media
       CLUSTER: ${CLUSTER}
       KOPIUR_CAPACITY: 50Gi
   wait: false

--- a/kubernetes/apps/main/media/tautulli.yaml
+++ b/kubernetes/apps/main/media/tautulli.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: media
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/media/wizarr.yaml
+++ b/kubernetes/apps/main/media/wizarr.yaml
@@ -15,7 +15,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: media
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/media/your-spotify.yaml
+++ b/kubernetes/apps/main/media/your-spotify.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: media
       KOPIUR_PGID: "100"
       KOPIUR_PUID: "999"
   wait: false

--- a/kubernetes/apps/main/self-hosted/actual.yaml
+++ b/kubernetes/apps/main/self-hosted/actual.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: self-hosted
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/self-hosted/atuin.yaml
+++ b/kubernetes/apps/main/self-hosted/atuin.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: self-hosted
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/self-hosted/manyfold.yaml
+++ b/kubernetes/apps/main/self-hosted/manyfold.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: self-hosted
       CLUSTER: ${CLUSTER}
       KOPIUR_CAPACITY: 15Gi
   wait: false

--- a/kubernetes/apps/main/self-hosted/paperless.yaml
+++ b/kubernetes/apps/main/self-hosted/paperless.yaml
@@ -24,7 +24,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: self-hosted
       CLUSTER: ${CLUSTER}
       KOPIUR_CAPACITY: 15Gi
   wait: false

--- a/kubernetes/apps/main/self-hosted/picoshare.yaml
+++ b/kubernetes/apps/main/self-hosted/picoshare.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: self-hosted
       KOPIUR_CAPACITY: 50Gi
   wait: false
   prune: true

--- a/kubernetes/apps/main/self-hosted/spoolman.yaml
+++ b/kubernetes/apps/main/self-hosted/spoolman.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: self-hosted
       CLUSTER: ${CLUSTER}
   wait: false
   prune: true

--- a/kubernetes/apps/main/workadventure/synapse.yaml
+++ b/kubernetes/apps/main/workadventure/synapse.yaml
@@ -18,7 +18,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: workadventure
       CLUSTER: ${CLUSTER}
       KOPIUR_CAPACITY: 10Gi
   wait: false

--- a/kubernetes/apps/utility/home-automation/home-assistant.yaml
+++ b/kubernetes/apps/utility/home-automation/home-assistant.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: home-assistant
-      KOPIUR_HOSTNAME: home-automation
       KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
       KOPIUR_STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}

--- a/kubernetes/apps/utility/home-automation/matter-server.yaml
+++ b/kubernetes/apps/utility/home-automation/matter-server.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: matter-server
-      KOPIUR_HOSTNAME: home-automation
       KOPIUR_PGID: "0"
       KOPIUR_PUID: "0"
       KOPIUR_SNAPSHOTCLASS: csi-local-hostpath

--- a/kubernetes/apps/utility/home-automation/zigbee.yaml
+++ b/kubernetes/apps/utility/home-automation/zigbee.yaml
@@ -13,7 +13,6 @@ spec:
   postBuild:
     substitute:
       APP: zigbee
-      KOPIUR_HOSTNAME: home-automation
       KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
       KOPIUR_STORAGECLASS: local-hostpath
       ZEROSCALER_JOB_NAME: zigbee_probe

--- a/kubernetes/apps/utility/self-hosted/acars.yaml
+++ b/kubernetes/apps/utility/self-hosted/acars.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: self-hosted
       KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
       KOPIUR_STORAGECLASS: local-hostpath
       STORAGECLASS: local-hostpath

--- a/kubernetes/apps/utility/self-hosted/free-game-notifier.yaml
+++ b/kubernetes/apps/utility/self-hosted/free-game-notifier.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: self-hosted
       KOPIUR_ON_MISSING_SNAPSHOT: Continue
       KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
       KOPIUR_STORAGECLASS: local-hostpath

--- a/kubernetes/apps/utility/self-hosted/meshcentral.yaml
+++ b/kubernetes/apps/utility/self-hosted/meshcentral.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: self-hosted
       KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
       KOPIUR_STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}

--- a/kubernetes/apps/utility/self-hosted/scanservjs.yaml
+++ b/kubernetes/apps/utility/self-hosted/scanservjs.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: self-hosted
       KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
       KOPIUR_STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}

--- a/kubernetes/apps/utility/self-hosted/thelounge.yaml
+++ b/kubernetes/apps/utility/self-hosted/thelounge.yaml
@@ -12,7 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_HOSTNAME: self-hosted
       KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
       KOPIUR_STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -4,14 +4,13 @@ apiVersion: kopiur.home-operations.com/v1alpha1
 kind: SnapshotPolicy
 metadata:
   name: ${APP}
+  annotations:
+    kopiur.home-operations.com/allow-identity-change: "true"
 spec:
   compression:
     compressor: zstd
   credentialProjection:
     enabled: true
-  identity:
-    hostname: ${KOPIUR_HOSTNAME}
-    username: ${KOPIUR_USERNAME:=${APP}}
   mover:
     securityContext:
       runAsGroup: ${KOPIUR_PGID:=100}
@@ -27,5 +26,4 @@ spec:
   sources:
     - pvc:
         name: ${APP}
-      sourcePathOverride: ${KOPIUR_SOURCE_PATH:=/data}
   volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS:=csi-ceph-blockpool}


### PR DESCRIPTION
Moves backup policies to the ClusterRepository identity defaults and Kopiur's native /pvc/<name> source path, removing 52 repeated hostname substitutions. This intentionally starts namespace-app@cluster histories; legacy app@namespace:/data snapshots remain available through the standalone restore-by-identity component. The identity-change acknowledgement is temporary and should be removed after the new snapshots succeed. Validated with flate for main and utility.