### PR TITLE
feat(openclaw): pin plugins.allow + acknowledge clawhub risk for memini 0.7.8

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -255,6 +255,7 @@ data:
         },
       },
       plugins: {
+        allow: ["discord", "lossless-claw", "memini", "searxng", "composio", "openclaw-better-gateway"],
         entries: {
           discord: { enabled: true },
           comfy: {

--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -52,7 +52,7 @@ spec:
                 # renovate: datasource=github-tags depName=eleboucher/memini
                 MEMINI_PLUGIN_VERSION=0.7.8
                 if [ "$(cat "$HOME/.openclaw/extensions/memini/.clawver" 2>/dev/null)" != "$MEMINI_PLUGIN_VERSION" ]; then
-                  if node dist/index.js plugins install "clawhub:@eleboucher/memini@$MEMINI_PLUGIN_VERSION" --pin --force; then
+                  if node dist/index.js plugins install "clawhub:@eleboucher/memini@$MEMINI_PLUGIN_VERSION" --pin --force --acknowledge-clawhub-risk; then
                     printf '%s' "$MEMINI_PLUGIN_VERSION" > "$HOME/.openclaw/extensions/memini/.clawver"
                   else
                     echo "WARN: memini plugin install failed; starting with whatever is present"


### PR DESCRIPTION
## Summary
- `plugins.allow`: explicit six-plugin allowlist (`discord, lossless-claw, memini, searxng, composio, openclaw-better-gateway`) — closes the auto-load hole doctor flagged. `openclaw-mcp-bridge` deliberately excluded (moved to native MCP); `agentmemory` extension already removed from the PVC (dead backend).
- memini install: add `--acknowledge-clawhub-risk` — ClawHub marks 0.7.8 `suspicious`, so the version-guarded startup install has silently failed since the pin landed, leaving the pod on **0.7.5**. With the flag, the pinned 0.7.8 (incl. the memini#30 empty-recall fix) actually installs.

## Notes
- Reloader auto-rolls the pod on the configmap change; the next start performs the 0.7.8 install.
- Verify after rollout: `cat ~/.openclaw/extensions/memini/.clawver` → `0.7.8`, and doctor's plugins warning gone.