### PR TITLE
feat(openclaw): add direct kubectl MCP server

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -421,6 +421,13 @@ data:
               CONTEXT7_API_KEY: "$${CONTEXT7_API_KEY}",
             },
           },
+          kubectl: {
+            url: "http://kubectl.llm:8080/mcp",
+            transport: "streamable-http",
+            headers: {
+              Accept: "application/json, text/event-stream",
+            },
+          },
         },
       },
       skills: {


### PR DESCRIPTION
ToolHive vmcp gateway is broken (FTS5 disk I/O error 6410). This adds the kubectl MCP server directly to OpenClaw's `mcp.servers` config so agents have read-only cluster access without depending on the vmcp aggregation layer.

The kubectl MCPServer CR already exists and is deployed — this just wires OpenClaw to talk to it directly at `http://kubectl.llm:8080/mcp` instead of going through the vmcp gateway.