### PR TITLE
fix(kopiur): align backup mover ids

### DIFF
--- a/kubernetes/apps/main/llm/hermes.yaml
+++ b/kubernetes/apps/main/llm/hermes.yaml
@@ -13,6 +13,8 @@ spec:
     substitute:
       APP: *app
       KOPIUR_CAPACITY: 20Gi
+      KOPIUR_PGID: "10000"
+      KOPIUR_PUID: "10000"
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/home-automation/home-assistant.yaml
+++ b/kubernetes/apps/utility/home-automation/home-assistant.yaml
@@ -36,6 +36,8 @@ spec:
   postBuild:
     substitute:
       APP: trmnl-ha
+      KOPIUR_PGID: "0"
+      KOPIUR_PUID: "0"
       KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
       KOPIUR_STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}


### PR DESCRIPTION
Hermes and trmnl-ha Kopiur jobs cannot traverse their read-only staged snapshots because the default mover identity does not match the source ownership. Run each mover with its workload's existing UID/GID so hourly backups can read the snapshot data.\n\nValidated with `flate test all` for main (421 resources) and utility (154 resources). Compatible with the explicit security-context precedence introduced by Kopiur 0.9.0 in #8618.