### PR TITLE
feat: deploy ocharted on utility cluster

### DIFF
--- a/kubernetes/apps/base/kube-tools/ocharted/externalsecret.yaml
+++ b/kubernetes/apps/base/kube-tools/ocharted/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ocharted
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: ocharted-secret
+    template:
+      data:
+        auth: "{{ .OCHARTED_USERNAME }}:{{ .OCHARTED_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: ocharted

--- a/kubernetes/apps/base/kube-tools/ocharted/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-tools/ocharted/helmrelease.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ocharted
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ocharted
+  interval: 15m
+  dependsOn: []
+  values:
+    config:
+      upstreamAllowlist:
+        - "*.github.io"
+      logLevel: info
+      logFormat: json
+    httpRoute:
+      enabled: true
+      parentRefs:
+        - name: envoy-internal
+          namespace: network
+      hostnames:
+        - "${SUBDOMAIN}.jory.dev"
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 512Mi

--- a/kubernetes/apps/base/kube-tools/ocharted/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-tools/ocharted/helmrelease.yaml
@@ -11,6 +11,15 @@ spec:
   interval: 15m
   dependsOn: []
   values:
+    replicaCount: 2
+    podDisruptionBudget:
+      enabled: true
+    auth:
+      existingSecret: ocharted-secret
+      bypassNetworks:
+        - 10.42.0.0/16
+    deploymentAnnotations:
+      reloader.stakater.com/auto: "true"
     config:
       upstreamAllowlist:
         - "*.github.io"
@@ -18,17 +27,20 @@ spec:
       logFormat: json
     httpRoute:
       enabled: true
-      parentRefs:
-        - name: envoy-internal
-          namespace: network
+      annotations:
+        gatus.home-operations.com/endpoint: |-
+          path: /healthz
+          conditions: ["[STATUS] == 200"]
       hostnames:
-        - "${SUBDOMAIN}.jory.dev"
+        - "{{ .Release.Name }}.jory.dev"
+      parentRefs:
+        - name: envoy-external
+          namespace: network
     monitoring:
       serviceMonitor:
         enabled: true
     resources:
       requests:
         cpu: 10m
-        memory: 64Mi
       limits:
         memory: 512Mi

--- a/kubernetes/apps/base/kube-tools/ocharted/kustomization.yaml
+++ b/kubernetes/apps/base/kube-tools/ocharted/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/kube-tools/ocharted/kustomization.yaml
+++ b/kubernetes/apps/base/kube-tools/ocharted/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/base/kube-tools/ocharted/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-tools/ocharted/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ocharted
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.3
+  url: oci://ghcr.io/home-operations/charts/ocharted

--- a/kubernetes/apps/utility/kube-tools/kustomization.yaml
+++ b/kubernetes/apps/utility/kube-tools/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 replacements:
   - path: ../../../components/replacements/ks.yaml
 resources:
+  - ./ocharted.yaml
   - ./reloader.yaml
   - ./tuppr.yaml
   - ./utility-cluster-rbac.yaml

--- a/kubernetes/apps/utility/kube-tools/ocharted.yaml
+++ b/kubernetes/apps/utility/kube-tools/ocharted.yaml
@@ -10,7 +10,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      SUBDOMAIN: ocharted
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/utility/kube-tools/ocharted.yaml
+++ b/kubernetes/apps/utility/kube-tools/ocharted.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ocharted
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/kube-tools/ocharted
+  postBuild:
+    substitute:
+      APP: *app
+      SUBDOMAIN: ocharted
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
## Summary

Deploy [ocharted](https://github.com/home-operations/ocharted) — a stateless OCI registry proxy — in `kube-tools` on the **utility cluster**, exposed publicly with basic auth so both Flux and Renovate can reach it.

Pattern adapted from [onedr0p/home-ops#11406](https://github.com/onedr0p/home-ops/pull/11406).

## Changes

- **Chart**: `oci://ghcr.io/home-operations/charts/ocharted` v0.1.3
- **Namespace**: `kube-tools` (utility cluster only)
- **Exposure**: HTTPRoute on `envoy-external` at `ocharted.jory.dev`
- **Auth**: Basic auth via ExternalSecret (1Password `ocharted` item)
  - `bypassNetworks: [10.42.0.0/16]` — in-cluster Flux pulls anonymously, external clients must authenticate
- **HA**: 2 replicas + PodDisruptionBudget
- `reloader.stakater.com/auto` annotation to roll pods on credential rotation
- Gatus health probe on `/healthz`
- `upstreamAllowlist: ["*.github.io"]` — SSRF guard
- ServiceMonitor enabled

## Requires before merge

- 1Password item `ocharted` in the kubernetes vault with `OCHARTED_USERNAME` and `OCHARTED_PASSWORD` fields

## Follow-up

Once ocharted is validated on utility, charts-mirror OCIRepository URLs can be migrated to `oci://ocharted.jory.dev/<upstream-host>/<chart>`. Renovate will also need a `hostRule` for `ocharted.jory.dev` with the credentials.

## Test plan
- [ ] Flux reconciles ocharted HelmRelease successfully
- [ ] ExternalSecret populates `ocharted-secret` from 1Password
- [ ] HTTPRoute attaches to `envoy-external` gateway
- [ ] `ocharted.jory.dev` resolves via external-dns
- [ ] `helm pull oci://ocharted.jory.dev/kubernetes-sigs.github.io/metrics-server/metrics-server --version 3.13.1` works (authenticated)
- [ ] In-cluster Flux pulls anonymously via pod CIDR bypass