### PR TITLE
refactor: migrate charts-mirror OCIRepositories to ocharted

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -19,6 +19,15 @@
   flux: {
     managerFilePatterns: ["/^kubernetes/.+\\.yaml(?:\\.j2)?$/"],
   },
+  hostRules: [
+    {
+      description: "Authenticate against the ocharted OCI registry",
+      matchHost: "ocharted.jory.dev",
+      hostType: "docker",
+      username: "{{ secrets.OCHARTED_USERNAME }}",
+      password: "{{ secrets.OCHARTED_PASSWORD }}",
+    },
+  ],
   forkProcessing: "disabled",
   kubernetes: {
     managerFilePatterns: ["/^kubernetes/.+\\.yaml(?:\\.j2)?$/"],

--- a/bootstrap/helmfile.d/00-crds.yaml
+++ b/bootstrap/helmfile.d/00-crds.yaml
@@ -10,7 +10,7 @@ helmDefaults:
 releases:
   - name: cloudflare-dns
     namespace: network
-    chart: oci://ghcr.io/home-operations/charts-mirror/external-dns
+    chart: oci://ocharted.jory.dev/kubernetes-sigs.github.io/external-dns/external-dns
     version: 1.21.1
 
   - name: external-secrets

--- a/kubernetes/apps/base/flux-system/headlamp/ocirepository.yaml
+++ b/kubernetes/apps/base/flux-system/headlamp/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 0.44.0
-  url: oci://ghcr.io/home-operations/charts-mirror/headlamp
+  url: oci://ocharted.jory.dev/kubernetes-sigs.github.io/headlamp/headlamp

--- a/kubernetes/apps/base/kube-system/metrics-server/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-system/metrics-server/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 3.13.1
-  url: oci://ghcr.io/home-operations/charts-mirror/metrics-server
+  url: oci://ocharted.jory.dev/kubernetes-sigs.github.io/metrics-server/metrics-server

--- a/kubernetes/apps/base/kube-system/nvidia-device-plugin/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-system/nvidia-device-plugin/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 0.19.3
-  url: oci://ghcr.io/home-operations/charts-mirror/nvidia-device-plugin
+  url: oci://ocharted.jory.dev/nvidia.github.io/k8s-device-plugin/nvidia-device-plugin

--- a/kubernetes/apps/base/kube-tools/descheduler/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-tools/descheduler/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 0.36.0
-  url: oci://ghcr.io/home-operations/charts-mirror/descheduler
+  url: oci://ocharted.jory.dev/kubernetes-sigs.github.io/descheduler/descheduler

--- a/kubernetes/apps/base/network/cloudflare-dns/ocirepository.yaml
+++ b/kubernetes/apps/base/network/cloudflare-dns/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 1.21.1
-  url: oci://ghcr.io/home-operations/charts-mirror/external-dns
+  url: oci://ocharted.jory.dev/kubernetes-sigs.github.io/external-dns/external-dns

--- a/kubernetes/apps/base/network/unifi-dns/ocirepository.yaml
+++ b/kubernetes/apps/base/network/unifi-dns/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 1.21.1
-  url: oci://ghcr.io/home-operations/charts-mirror/external-dns
+  url: oci://ocharted.jory.dev/kubernetes-sigs.github.io/external-dns/external-dns

--- a/kubernetes/apps/base/rook-ceph/ceph-csi-drivers/ocirepository.yaml
+++ b/kubernetes/apps/base/rook-ceph/ceph-csi-drivers/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 1.0.4
-  url: oci://ghcr.io/home-operations/charts-mirror/ceph-csi-drivers
+  url: oci://ocharted.jory.dev/ceph.github.io/ceph-csi-operator/ceph-csi-drivers


### PR DESCRIPTION
## Summary

Migrates all remaining  references to the ocharted proxy deployed in #8640. Chart versions are unchanged — only the registry URL changes.

Depends on ocharted being healthy on utility (merged in #8640).

## Migrated OCIRepositories

| App | New URL |
|---|---|
| metrics-server |  |
| nvidia-device-plugin |  |
| external-dns (unifi-dns) |  |
| external-dns (cloudflare-dns) |  |
| descheduler |  |
| headlamp |  |
| ceph-csi-drivers |  |
| bootstrap CRDs (external-dns) | same as external-dns above |

## Renovate

Added  for  () so Renovate can authenticate and discover chart versions through the proxy. Requires  and  secrets in the Renovate platform config.

## Notes

- ocharted sits only in Flux's update path (not runtime), so running HelmReleases are unaffected during cutover — OCIRepositories simply retry until ocharted is reachable
- The pod CIDR bypass () lets in-cluster Flux pull anonymously through the public hostname

## Test plan
- [ ] Each OCIRepository reconciles successfully through ocharted
- [ ] Renovate discovers chart versions via the hostRule