### PR TITLE
fix: add LB VIP CIDR to ocharted auth bypass

### DIFF
--- a/kubernetes/apps/base/kube-tools/ocharted/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-tools/ocharted/helmrelease.yaml
@@ -18,6 +18,7 @@ spec:
       existingSecret: ocharted-secret
       bypassNetworks:
         - 10.42.0.0/16
+        - 10.69.10.0/24
     deploymentAnnotations:
       reloader.stakater.com/auto: "true"
     config:


### PR DESCRIPTION
Konflate and Flux source-controller hit ocharted through the envoy-external LoadBalancer VIP (10.69.10.x), which isn't in the pod CIDR bypass (10.42.0.0/16). Add 10.69.10.0/24 to bypassNetworks so in-cluster traffic via the gateway is anonymous.

Root cause: split DNS resolves ocharted.jory.dev → 10.69.10.132 (utility envoy-external LB). ocharted sees the LB VIP as the TCP peer, which isn't in 10.42.0.0/16, so the bypass fails and it returns 401.

Fixes konflate render failures in #8642.