### PR TITLE
fix: add node LAN CIDR to ocharted auth bypass

### DIFF
--- a/kubernetes/apps/base/kube-tools/ocharted/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-tools/ocharted/helmrelease.yaml
@@ -19,6 +19,7 @@ spec:
       bypassNetworks:
         - 10.42.0.0/16
         - 10.69.10.0/24
+        - 10.69.1.0/24
     deploymentAnnotations:
       reloader.stakater.com/auto: "true"
     config:


### PR DESCRIPTION
ocharted logs show:

```
{"xff":["10.69.1.23"],"auth":"denied"}
```

The XFF chain contains the Talos node IP (10.69.1.x), not just the pod CIDR. Cilium L2 LB traffic is forwarded by the node, so the node IP appears in XFF. Add `10.69.1.0/24` to bypassNetworks.

Full bypass list now:
- `10.42.0.0/16` — pod CIDR (envoy proxy, source-controller)
- `10.69.10.0/24` — Cilium L2 LB VIP range (envoy-external gateway)
- `10.69.1.0/24` — node LAN (Talos nodes forwarding L2 LB traffic)