### PR TITLE
feat(foreman): enable context7 MCP on all agents

### DIFF
--- a/.agents/instructions/foreman.instructions.md
+++ b/.agents/instructions/foreman.instructions.md
@@ -56,6 +56,13 @@ per-Agent `execution.image`).
 | `gate` | none (deterministic) | free | Job (per-task) | **idle in gateless mode** (`VERIFY_ENABLED=false`); was `GATEPROFILE_MAP.image` per language |
 | `reviewer` | `self-hosted` (local) | free | InProcess (fleet) | — |
 
+Every LLM agent (all coders + both reviewers) has `spec.mcp` enabled with the
+hosted context7 server (`resolve-library-id`, `query-docs`) for up-to-date
+library docs mid-task; auth rides the `CONTEXT7_API_KEY` header from the
+`foreman-agent` Secret (1Password `context7` item, `OPENCODE_API_KEY`
+field). `gate`/`gate-fork` have no MCP (deterministic, no LLM loop). Adding
+another MCP server = add a `servers` entry per agent + any header secret.
+
 **Cost model.** Everything runs on **local** models (nvidia / self-hosted) except
 `coder-frontier` (**MiniMax, cloud**), which is the escalation tier only. The
 groomer defaults ready work to the `local` lane; `frontier` is reached only by

--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -19,6 +19,18 @@ spec:
     - grep
     - bash
     - submit_result
+  mcp:
+    enabled: true
+    servers:
+      - name: foreman-agent
+        transport: http
+        url: https://mcp.context7.com/mcp
+        headers:
+          - name: CONTEXT7_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: foreman-agent
+                key: CONTEXT7_API_KEY
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
@@ -25,6 +25,18 @@ spec:
     - grep
     - bash
     - submit_result
+  mcp:
+    enabled: true
+    servers:
+      - name: foreman-agent
+        transport: http
+        url: https://mcp.context7.com/mcp
+        headers:
+          - name: CONTEXT7_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: foreman-agent
+                key: CONTEXT7_API_KEY
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
@@ -19,6 +19,18 @@ spec:
     - grep
     - bash
     - submit_result
+  mcp:
+    enabled: true
+    servers:
+      - name: foreman-agent
+        transport: http
+        url: https://mcp.context7.com/mcp
+        headers:
+          - name: CONTEXT7_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: foreman-agent
+                key: CONTEXT7_API_KEY
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
@@ -19,6 +19,18 @@ spec:
     - grep
     - bash
     - submit_result
+  mcp:
+    enabled: true
+    servers:
+      - name: foreman-agent
+        transport: http
+        url: https://mcp.context7.com/mcp
+        headers:
+          - name: CONTEXT7_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: foreman-agent
+                key: CONTEXT7_API_KEY
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -19,6 +19,18 @@ spec:
     - grep
     - bash
     - submit_result
+  mcp:
+    enabled: true
+    servers:
+      - name: foreman-agent
+        transport: http
+        url: https://mcp.context7.com/mcp
+        headers:
+          - name: CONTEXT7_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: foreman-agent
+                key: CONTEXT7_API_KEY
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -19,6 +19,18 @@ spec:
     - grep
     - bash
     - submit_result
+  mcp:
+    enabled: true
+    servers:
+      - name: foreman-agent
+        transport: http
+        url: https://mcp.context7.com/mcp
+        headers:
+          - name: CONTEXT7_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: foreman-agent
+                key: CONTEXT7_API_KEY
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
@@ -24,6 +24,18 @@ spec:
     - bash
     - fetch_issue
     - submit_result
+  mcp:
+    enabled: true
+    servers:
+      - name: foreman-agent
+        transport: http
+        url: https://mcp.context7.com/mcp
+        headers:
+          - name: CONTEXT7_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: foreman-agent
+                key: CONTEXT7_API_KEY
   temperature: "0.35"
   maxTurns: 80
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -22,6 +22,18 @@ spec:
     - bash
     - fetch_issue
     - submit_result
+  mcp:
+    enabled: true
+    servers:
+      - name: foreman-agent
+        transport: http
+        url: https://mcp.context7.com/mcp
+        headers:
+          - name: CONTEXT7_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: foreman-agent
+                key: CONTEXT7_API_KEY
   temperature: "0.35"
   maxTurns: 80
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/foreman/externalsecret.yaml
@@ -15,11 +15,14 @@ spec:
       data:
         GITHUB_TOKEN: "{{ .GITHUB_TOKEN }}"
         LITELLM_API_KEY: "{{ .LITELLM_FOREMAN_API_KEY }}"
+        CONTEXT7_API_KEY: "{{ .OPENCODE_API_KEY }}"
   dataFrom:
     - extract:
         key: github-miso
     - extract:
         key: litellm
+    - extract:
+        key: context7
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1


### PR DESCRIPTION
Gives every LLM Foreman agent access to context7 (resolve-library-id, query-docs) so coders and reviewers can pull current library docs mid-task instead of hallucinating stale APIs.

- New externalsecret-context7.yaml: CONTEXT7_API_KEY from the 1Password context7 item (OPENCODE_API_KEY field, a separate key from openclaw's).
- spec.mcp on all 8 LLM agents (coders + reviewers) pointing at the hosted https://mcp.context7.com/mcp endpoint; auth via the CONTEXT7_API_KEY header injected from the secret. gate/gate-fork stay MCP-free (deterministic, no LLM loop).
- Ops doc notes the capability and the fleet-restart caveat.

Requires LLMKube >= 0.9.13 MCP support (deployed). After Flux reconciles: kubectl -n llm rollout restart deployment/foreman-agent deployment/foreman-llmkube-agent so InProcess agents reload their spec; Job-mode coders pick it up on next spawn.

Validation: kustomize build + flate test all (llm/foreman ✓; the 16 unrelated ocharted proxy auth failures are pre-existing on this workstation).