### PR TITLE
fix(foreman): flatten MCP header valueFrom to match CRD schema

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -28,9 +28,8 @@ spec:
         headers:
           - name: CONTEXT7_API_KEY
             valueFrom:
-              secretKeyRef:
-                name: foreman-agent
-                key: CONTEXT7_API_KEY
+              name: foreman-agent
+              key: CONTEXT7_API_KEY
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
@@ -34,9 +34,8 @@ spec:
         headers:
           - name: CONTEXT7_API_KEY
             valueFrom:
-              secretKeyRef:
-                name: foreman-agent
-                key: CONTEXT7_API_KEY
+              name: foreman-agent
+              key: CONTEXT7_API_KEY
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
@@ -28,9 +28,8 @@ spec:
         headers:
           - name: CONTEXT7_API_KEY
             valueFrom:
-              secretKeyRef:
-                name: foreman-agent
-                key: CONTEXT7_API_KEY
+              name: foreman-agent
+              key: CONTEXT7_API_KEY
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
@@ -28,9 +28,8 @@ spec:
         headers:
           - name: CONTEXT7_API_KEY
             valueFrom:
-              secretKeyRef:
-                name: foreman-agent
-                key: CONTEXT7_API_KEY
+              name: foreman-agent
+              key: CONTEXT7_API_KEY
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -28,9 +28,8 @@ spec:
         headers:
           - name: CONTEXT7_API_KEY
             valueFrom:
-              secretKeyRef:
-                name: foreman-agent
-                key: CONTEXT7_API_KEY
+              name: foreman-agent
+              key: CONTEXT7_API_KEY
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -28,9 +28,8 @@ spec:
         headers:
           - name: CONTEXT7_API_KEY
             valueFrom:
-              secretKeyRef:
-                name: foreman-agent
-                key: CONTEXT7_API_KEY
+              name: foreman-agent
+              key: CONTEXT7_API_KEY
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
@@ -33,9 +33,8 @@ spec:
         headers:
           - name: CONTEXT7_API_KEY
             valueFrom:
-              secretKeyRef:
-                name: foreman-agent
-                key: CONTEXT7_API_KEY
+              name: foreman-agent
+              key: CONTEXT7_API_KEY
   temperature: "0.35"
   maxTurns: 80
   maxRetries: 3

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -31,9 +31,8 @@ spec:
         headers:
           - name: CONTEXT7_API_KEY
             valueFrom:
-              secretKeyRef:
-                name: foreman-agent
-                key: CONTEXT7_API_KEY
+              name: foreman-agent
+              key: CONTEXT7_API_KEY
   temperature: "0.35"
   maxTurns: 80
   maxRetries: 3


### PR DESCRIPTION
The MCPHeader CRD type uses corev1.SecretKeySelector directly as valueFrom — name and key are fields on valueFrom itself, not nested under a secretKeyRef wrapper. The extra secretKeyRef: level made Flux reject every agent apply with 'field not declared in schema'.

One-line delete per agent (8 files), no other changes.