### PR TITLE
feat(matter): migrate to matterjs server

### DIFF
--- a/kubernetes/apps/base/home-automation/matter-server/helmrelease.yaml
+++ b/kubernetes/apps/base/home-automation/matter-server/helmrelease.yaml
@@ -21,12 +21,13 @@ spec:
           }]
       hostUsers: false
       securityContext:
-        runAsNonRoot: false # Must be run as root user
-        runAsUser: 0 # Must be run as root user
-        runAsGroup: 0
-        fsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
-        supplementalGroups: [34]
+        seccompProfile:
+          type: RuntimeDefault
     controllers:
       matter-server:
         annotations:
@@ -34,8 +35,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/home-assistant-libs/python-matter-server
-              tag: 8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
+              repository: ghcr.io/matter-js/matterjs-server
+              tag: 1.3.3@sha256:ac537ba44a2edaaf785b818f8b7ce75cdf736539401462046f0042670bee4063
             env:
               TZ: America/Edmonton
               MATTER_SERVER__INSTANCE_NAME: "{{ .Release.Name }}"
@@ -46,7 +47,22 @@ spec:
               - --storage-path=/data
               - --primary-interface=net1
               - --log-level=debug
-              - --log-level-sdk=detail
+              - --production-mode
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
             resources:
               limits:
                 memory: 1Gi


### PR DESCRIPTION
Replace the final Python Matter Server pin with matter.js Server 1.3.3.

The rollout keeps the existing `net1` Multus attachment, PVC, Matter fabric, port, service, and Home Assistant WebSocket endpoint. It also switches the container to UID/GID 1000, adds `/health` probes, and preserves the 1Gi memory limit for the migration.

`flate test all --path ./kubernetes/clusters/utility` passes the Matter Server Kustomization and HelmRelease; the command still reports unrelated existing `ocharted.jory.dev` credential failures. The live cluster was not migrated from this branch because Flux only reconciles the pushed Git source; review/merge this PR before rollout.