### PR TITLE
feat(toolhive): add unifi network mcp

### DIFF
--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/unifi-network-mcp/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/unifi-network-mcp/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-unifi-network
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        UNIFI_NETWORK_USERNAME: "{{ .OPENCODE_UNIFI_USER }}"
+        UNIFI_NETWORK_PASSWORD: "{{ .OPENCODE_UNIFI_PASS }}"
+  dataFrom:
+    - extract:
+        key: unifi

--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/unifi-network-mcp/kustomization.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/unifi-network-mcp/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/unifi-network-mcp/mcpserver.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/unifi-network-mcp/mcpserver.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: unifi-network-mcp
+spec:
+  image: ghcr.io/sirkirby/unifi-network-mcp:0.25.0@sha256:e8101770ff90056c9487ff80e74364ee47ef92ad9692784a476a078ceb754a5d
+  transport: streamable-http
+  mcpPort: 3000
+  groupRef:
+    name: mcp-tools
+  env:
+    - name: UNIFI_NETWORK_HOST
+      value: unifi.internal
+    - name: UNIFI_NETWORK_SITE
+      value: default
+    - name: UNIFI_NETWORK_VERIFY_SSL
+      value: "false"
+    - name: UNIFI_MCP_HTTP_ENABLED
+      value: "true"
+    - name: UNIFI_MCP_HTTP_TRANSPORT
+      value: streamable-http
+    - name: UNIFI_MCP_HOST
+      value: 0.0.0.0
+    - name: UNIFI_MCP_PORT
+      value: "3000"
+    - name: UNIFI_TOOL_REGISTRATION_MODE
+      value: meta_only
+    - name: UNIFI_POLICY_CREATE
+      value: "false"
+    - name: UNIFI_POLICY_UPDATE
+      value: "false"
+    - name: UNIFI_POLICY_DELETE
+      value: "false"
+    - name: UNIFI_TOOL_PERMISSION_MODE
+      value: confirm
+  secrets:
+    - name: toolhive-unifi-network
+      key: UNIFI_NETWORK_USERNAME
+      targetEnvName: UNIFI_NETWORK_USERNAME
+    - name: toolhive-unifi-network
+      key: UNIFI_NETWORK_PASSWORD
+      targetEnvName: UNIFI_NETWORK_PASSWORD
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi

--- a/kubernetes/apps/main/llm/toolhive.yaml
+++ b/kubernetes/apps/main/llm/toolhive.yaml
@@ -210,3 +210,21 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: unifi-network-mcp
+spec:
+  dependsOn:
+    - name: toolhive
+    - name: toolhive-config
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/unifi-network-mcp
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system


### PR DESCRIPTION
Adds the UniFi Network MCP to the shared ToolHive gateway in read-only, meta-only mode. The existing local OpenCode server stays in place until the ToolHive path is verified after rollout.