### PR TITLE
fix(matter): accept thread route advertisements

### DIFF
--- a/kubernetes/apps/base/home-automation/matter-server/helmrelease.yaml
+++ b/kubernetes/apps/base/home-automation/matter-server/helmrelease.yaml
@@ -21,6 +21,10 @@ spec:
           }]
       hostUsers: false
       securityContext:
+        sysctls:
+          # Accept Thread OMR route advertisements on the Multus interface.
+          - name: net.ipv6.conf.net1.accept_ra_rt_info_max_plen
+            value: "64"
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000


### PR DESCRIPTION
Add the IPv6 Router Advertisement route-information sysctl for the Matter Server's Multus `net1` interface.

The matter.js migration is already merged, but the live pod currently reports `accept_ra_rt_info_max_plen=0` and lacks the route-information acceptance setting. This allows the pod to receive Thread OMR route advertisements from the border-router path instead of relying only on the default IPv6 route.

Validation: `git diff --check` passes. The utility `flate` run remains affected by the repository's unrelated `ocharted.jory.dev` credential failures; the Matter Server manifest is the only changed resource.