### PR TITLE
feat(hermes): add Composio MCP server

### DIFF
--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -64,6 +64,8 @@ data:
     mcp_servers:
       toolhive:
         url: http://vmcp-mcp-gateway-internal.llm:4483/mcp
+      composio:
+        url: https://connect.composio.dev/mcp
     auxiliary:
       vision:
         provider: litellm


### PR DESCRIPTION
Add Composio HTTP MCP server to hermes ConfigMap. Validated YAML syntax + endpoint reachability from live pod. Awaits Flux sync + pod restart for live testing.
