### PR TITLE
fix(alerts): remediate actionable incidents

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/miso-chat/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/miso-chat/helmrelease.yaml
@@ -44,6 +44,10 @@ spec:
             subPath: device.json
     route:
       app:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            path: /api/health
+            conditions: ["[STATUS] == 200"]
         hostnames: ["miso-chat.jory.dev"]
         parentRefs:
           - name: envoy-external

--- a/kubernetes/apps/base/observability/exporters/drm-exporter-amd/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/drm-exporter-amd/helmrelease.yaml
@@ -51,3 +51,20 @@ spec:
       - key: llm-workload
         operator: Exists
         effect: NoSchedule
+  # Force one rollout to clear stale DRA/CDI allocation on existing pods.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: DaemonSet
+              name: drm-exporter-amd
+            patch: |
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: drm-exporter-amd
+              spec:
+                template:
+                  metadata:
+                    annotations:
+                      drm-exporter.home-operations.com/restartedAt: "2026-08-04"

--- a/kubernetes/apps/base/observability/victoria-logs/app/kustomization.yaml
+++ b/kubernetes/apps/base/observability/victoria-logs/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./grafanadatasource.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/base/observability/victoria-logs/app/pvc.yaml
+++ b/kubernetes/apps/base/observability/victoria-logs/app/pvc.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/v1/persistentvolumeclaim.json
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: server-volume-victoria-logs-server-0
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Gi
+  storageClassName: ceph-block
+  volumeMode: Filesystem

--- a/kubernetes/apps/utility/home-automation/matter-server.yaml
+++ b/kubernetes/apps/utility/home-automation/matter-server.yaml
@@ -12,8 +12,8 @@ spec:
   postBuild:
     substitute:
       APP: matter-server
-      KOPIUR_PGID: "0"
-      KOPIUR_PUID: "0"
+      KOPIUR_PGID: "1000"
+      KOPIUR_PUID: "1000"
       KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
       KOPIUR_STORAGECLASS: local-hostpath
       STORAGE_HR: ${STORAGE_HR}


### PR DESCRIPTION
Fix the actionable alerts currently firing in main and utility while leaving Autobrr IRC monitoring alerts untouched.

- Probe Miso Chat's `/api/health` endpoint from Gatus.
- Run matter-server backup movers as UID/GID 1000 so they can read application-owned files.
- Manage the Victoria Logs PVC declaratively at 200Gi.
- Roll the AMD DRM exporter once to clear its stale DRA/CDI allocation.

Validation: `git diff --check` passes; the relevant Kustomizations and HelmReleases render successfully. Full `flate test all` remains blocked by pre-existing `ocharted.jory.dev` basic-auth failures for unrelated OCI sources.