### PR TITLE
fix(foreman): a locally-unverifiable change is a GO, not NEEDS-VERIFICATION

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -94,3 +94,12 @@ spec:
     unfixed, so when in doubt, do the work.
     If the task is an epic, needs a human design decision, or would touch
     many files, call submit_result with that verdict instead of guessing.
+    Some changes cannot be verified locally at all — GitHub Actions workflows,
+    Dockerfiles, deploy manifests, anything whose only real test is the platform
+    running it. That is NOT a reason to withhold GO. Make the change, state in
+    your summary which part you could not verify locally and why, and return GO:
+    the pull request's own CI is the verification for that class of change, and a
+    NO-GO throws away work that was already correct. Reserve
+    outcome=NEEDS-VERIFICATION for when you could have verified something and
+    genuinely could not (a broken toolchain, a missing dependency) — never for a
+    change that is simply not locally runnable.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
@@ -110,3 +110,12 @@ spec:
     unfixed, so when in doubt, do the work.
     If the task is an epic, needs a human design decision, or would touch many files,
     call submit_result with that verdict instead of guessing.
+    Some changes cannot be verified locally at all — GitHub Actions workflows,
+    Dockerfiles, deploy manifests, anything whose only real test is the platform
+    running it. That is NOT a reason to withhold GO. Make the change, state in
+    your summary which part you could not verify locally and why, and return GO:
+    the pull request's own CI is the verification for that class of change, and a
+    NO-GO throws away work that was already correct. Reserve
+    outcome=NEEDS-VERIFICATION for when you could have verified something and
+    genuinely could not (a broken toolchain, a missing dependency) — never for a
+    change that is simply not locally runnable.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
@@ -84,6 +84,15 @@ spec:
     the npm scripts the repo defines) via the bash tool before finishing. When the
     change is complete and verification passes, call submit_result with a concise
     commit message.
+    Some changes cannot be verified locally at all — GitHub Actions workflows,
+    Dockerfiles, deploy manifests, anything whose only real test is the platform
+    running it. That is NOT a reason to withhold GO. Make the change, state in
+    your summary which part you could not verify locally and why, and return GO:
+    the pull request's own CI is the verification for that class of change, and a
+    NO-GO throws away work that was already correct. Reserve
+    outcome=NEEDS-VERIFICATION for when you could have verified something and
+    genuinely could not (a broken toolchain, a missing dependency) — never for a
+    change that is simply not locally runnable.
     Do not declare an issue already resolved unless the code at the exact place the
     issue names already does what the issue asks — open that file and confirm it. A
     change in a different file, or a commit that touched something related, is NOT the

--- a/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
@@ -84,6 +84,15 @@ spec:
     pytest, or the targets the repo defines) via the bash tool before finishing. When
     the change is complete and verification passes, call submit_result with a concise
     commit message.
+    Some changes cannot be verified locally at all — GitHub Actions workflows,
+    Dockerfiles, deploy manifests, anything whose only real test is the platform
+    running it. That is NOT a reason to withhold GO. Make the change, state in
+    your summary which part you could not verify locally and why, and return GO:
+    the pull request's own CI is the verification for that class of change, and a
+    NO-GO throws away work that was already correct. Reserve
+    outcome=NEEDS-VERIFICATION for when you could have verified something and
+    genuinely could not (a broken toolchain, a missing dependency) — never for a
+    change that is simply not locally runnable.
     Do not declare an issue already resolved unless the code at the exact place the
     issue names already does what the issue asks — open that file and confirm it. A
     change in a different file, or a commit that touched something related, is NOT the

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -73,3 +73,12 @@ spec:
     submit_result with a concise commit message describing what changed since the prior
     attempt. If a finding needs a human design decision or would touch many files, call
     submit_result with that verdict instead of guessing.
+    Some changes cannot be verified locally at all — GitHub Actions workflows,
+    Dockerfiles, deploy manifests, anything whose only real test is the platform
+    running it. That is NOT a reason to withhold GO. Make the change, state in
+    your summary which part you could not verify locally and why, and return GO:
+    the pull request's own CI is the verification for that class of change, and a
+    NO-GO throws away work that was already correct. Reserve
+    outcome=NEEDS-VERIFICATION for when you could have verified something and
+    genuinely could not (a broken toolchain, a missing dependency) — never for a
+    change that is simply not locally runnable.

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -82,6 +82,15 @@ spec:
     pip/npm-installing alternatives. Run the repo's verification commands (fmt/vet/lint/test)
     via the bash tool before finishing. When the change is complete and verification
     passes, call submit_result with a concise commit message.
+    Some changes cannot be verified locally at all — GitHub Actions workflows,
+    Dockerfiles, deploy manifests, anything whose only real test is the platform
+    running it. That is NOT a reason to withhold GO. Make the change, state in
+    your summary which part you could not verify locally and why, and return GO:
+    the pull request's own CI is the verification for that class of change, and a
+    NO-GO throws away work that was already correct. Reserve
+    outcome=NEEDS-VERIFICATION for when you could have verified something and
+    genuinely could not (a broken toolchain, a missing dependency) — never for a
+    change that is simply not locally runnable.
     Do not declare an issue already resolved unless the code at the exact place the
     issue names already does what the issue asks — open that file and confirm it. A
     change in a different file, or a commit that touched something related, is NOT the


### PR DESCRIPTION
## Summary
All six coder agents: when a change cannot be verified locally (workflows, Dockerfiles, deploy manifests), say so in the summary and **return GO** — the PR's own CI is the verification for that class. `NEEDS-VERIFICATION` is reserved for a verification that was *possible* and genuinely failed.

## Why — this is the queue bottleneck
The board showed **1 task running, 0 pending, 9 of 10 workloads Failed**. `MAX_IN_PROGRESS=3` was never binding: the GPU idles because work *fails*, not because it queues. Adding coder capacity would have multiplied failures, not throughput.

**5 of those 9 were coders discarding correct work.** Each did the job, pushed a real branch, then returned `NO-GO / NEEDS-VERIFICATION`:

| Workload | Summary | Branch actually contains |
|---|---|---|
| `llmkube-images#70` | "Pinned runs-on from ubuntu-latest to ubuntu-24.04" | +2 in `ai-pr-review.yaml`, `label-sync.yaml` |
| `llmkube-images#66` | "Fixed 'Retreive' typo, pinned all three jobs" | +4 in `vulnerability-scan.yaml` |
| `pr-reviewer-action#432` | "Replaced hardcoded python-version pin" | +12 in `ci.yaml` |

Every one touches `.github/workflows/*` — **you cannot run GitHub Actions locally.** Under the old gated model the gate Job settled it; gateless made "I can't verify this" fatal for an entire class of change. And since *pin ubuntu-latest / fix this workflow* is exactly what the weekly audit mass-produces for `llmkube-images` and `pr-reviewer-action` — the two largest backlogs — the audit was generating work the loop structurally could not complete.

## Deploy note
Needs `kubectl -n llm rollout restart deployment/foreman-agent deployment/foreman-llmkube-agent` after Flux reconciles (Agent CRs cache at pod startup).

## Follow-up
An upstream companion is coming: a coder `NO-GO` shouldn't cascade-kill reviewers when a branch with real changes exists — the reviewer can judge a diff the coder declined to certify.