### PR TITLE
feat(foreman): bridge 0.6.14 + allow ci-policy to self-certify

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           app:
             image:
               repository: ghcr.io/misospace/foreman-dispatch-bridge
-              tag: 0.6.13@sha256:7cfec7fc82a3fe2f2e62c59bd3a787ee70f1b979020c6917f8a7d1b2b241d788
+              tag: 0.6.14@sha256:68c81fd7a24f48f23b30f9e73ac30242c41bc35f666cc0cfd6dc2dda9a32d777
             env:
               DISPATCH_URL: http://dispatch.llm:3000
               # Dash, not slash (like saffron-normal): agents auto-register, but a "/"
@@ -50,6 +50,7 @@ spec:
               FOREMAN_NAMESPACE: llm
               MAX_IN_PROGRESS: "3"
               VERIFY_ENABLED: "false"
+              VERDICT_SELF_GO: "code-fix,docs,packaging,config,ci-policy"
               GATEPROFILE_MAP: '{"misospace/KubeTix":{"language":"python","image":"python:3.11","commands":{"format":"pip install -q black && black --check .","lint":"pip install -q flake8 && flake8 .","build":"pip install -q -r requirements.txt && python -m compileall -q .","test":"pip install -q -r requirements.txt && TESTING=1 python -m pytest tests/unit/ tests/integration/ -q"}},"misospace/miso-gallery":{"language":"python","image":"python:3.14","commands":{"format":"true","lint":"pip install -q ruff && ruff check . --select=E,F,W,B,SIM,I --ignore=E501","build":"pip install -q -r requirements.txt && python -m compileall -q .","test":"pip install -q -r requirements.txt pytest requests && python -m pytest -q"}},"misospace/pr-reviewer-action":{"language":"python","image":"python:3.14","commands":{"format":"true","lint":"pip install -q yamllint && yamllint action.yml examples/","build":"python -m compileall -q .","test":"pip install -q pytest && python -m pytest tests/ -q"}},"misospace/dispatch":{"language":"node","image":"node:22","commands":{"format":"true","lint":"npm ci --include=dev && npx prisma generate && NODE_ENV=development npm run lint","build":"NODE_ENV=development npm run typecheck","test":"npm run test"}},"misospace/windowstead":{"language":"generic","sourceExtensions":[".gd"],"image":"ghcr.io/misospace/godot-gate:4.2.2@sha256:59929aac43e76a01090fab71bd4d1bfb0747bea720cb3c9fbd42986763d31245","commands":{"format":"true","lint":"true","build":"true","test":"export HOME=/tmp XDG_DATA_HOME=/tmp/.local/share && godot --headless --path . --script res://tests/test_runner.gd && godot --headless --path . --script res://tests/test_e2e.gd && godot --headless --path . --script res://tests/test_layout_math.gd && godot --headless --path . --script res://tests/test_reservations.gd && godot --headless --path . --fixed-fps 60 --quit-after 300 2>&1 | tee /tmp/smoke.log && ! grep -qE \"SCRIPT ERROR|ERROR:\" /tmp/smoke.log"}},"*":{"language":"generic","image":"golang:1.26","commands":{"format":"true","lint":"true","build":"true","test":"true"}}}'
               REVISION_CODER_AGENTS: '{"*":"coder-revision"}'
               PR_FIX_ENABLED: "true"


### PR DESCRIPTION
## Summary
- Bridge `0.6.13` → `0.6.14` (digest-pinned) — brings misospace/foreman-dispatch-bridge#92.
- `VERDICT_SELF_GO: "code-fix,docs,packaging,config,ci-policy"` — Foreman's four defaults **plus** `ci-policy`.

## Why
Foreman's default self-GO policy (LLMKube #1075) excludes `ci-policy` because the in-workspace gate can prove a workflow *parses* but not that its *logic* is correct. In this fleet that made every CI/workflow chore terminal: coder does the work → pushes a correct branch → `applyVerdictPolicy` demotes the GO to `NO-GO/NEEDS-VERIFICATION` → reviewers cascade `INCOMPLETE` → workload fails → **diff discarded**.

That was **5 of the 9 failed workloads** on today's board (llmkube-images#66/#70, pr-reviewer-action#432 — each with a real pushed branch), against precisely the repos whose weekly audit mass-produces "pin ubuntu-latest" / "fix this workflow" issues.

## Why ci-policy is safe here
It's verified downstream by three gates: the PR **runs the changed workflow**, saffron reviews it, and nothing auto-merges. `release-policy` stays human-gated — release behaviour is higher-stakes and not observable from a PR.

## Rollback
Drop the `VERDICT_SELF_GO` line to restore Foreman's default policy; no bridge downgrade needed (unset omits the field entirely).

## Note
No fleet restart required — this is bridge env, not an Agent CR.