### PR TITLE
fix(alerts): drop spent rollout trigger, unlatch LiteLLM outage

### DIFF
--- a/kubernetes/apps/base/llm/litellm/prometheusrule.yaml
+++ b/kubernetes/apps/base/llm/litellm/prometheusrule.yaml
@@ -32,12 +32,18 @@ spec:
           labels:
             severity: warning
         - alert: LiteLLMDeploymentOutage
+          # deployment_state latches at 2 via the cooldown callback's pool label and
+          # never resets (success callbacks label by requested model). Require
+          # ongoing failures so a recovered deployment doesn't alert forever.
           expr: |-
             max by (litellm_model_name) (litellm_deployment_state) >= 2
+            and on (litellm_model_name)
+            sum by (litellm_model_name) (rate(litellm_deployment_failure_responses_total[15m])) > 0
           for: 10m
           annotations:
             summary: >-
-              LiteLLM {{ $labels.litellm_model_name }} out of rotation (deployment_state >= 2)
+              LiteLLM {{ $labels.litellm_model_name }} out of rotation and still failing
+              (deployment_state >= 2)
           labels:
             severity: warning
         - alert: LiteLLMAuthOrQuotaFailures

--- a/kubernetes/apps/base/observability/exporters/drm-exporter-amd/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/drm-exporter-amd/helmrelease.yaml
@@ -51,20 +51,3 @@ spec:
       - key: llm-workload
         operator: Exists
         effect: NoSchedule
-  # Force one rollout to clear stale DRA/CDI allocation on existing pods.
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: DaemonSet
-              name: drm-exporter-amd
-            patch: |
-              apiVersion: apps/v1
-              kind: DaemonSet
-              metadata:
-                name: drm-exporter-amd
-              spec:
-                template:
-                  metadata:
-                    annotations:
-                      drm-exporter.home-operations.com/restartedAt: "2026-08-04"


### PR DESCRIPTION
Removes the one-shot postRenderer added in #8788 to force a drm-exporter-amd rollout. The rollout did its job — the stale DRA/CDI allocation is cleared and the pod has been Ready for 20h+ — so the trigger is spent.

Also fixes `LiteLLMDeploymentOutage` false positives: the `deployment_state` gauge latches at 2 under the pool label (cooldown callback labels by pool name; success callbacks label by requested model), so pools like `frontier-pool` alert forever even while real traffic succeeds. The expr now additionally requires ongoing failure responses, verified live against Prometheus — returns nothing for the currently-firing pools, still fires for a genuinely-down deployment serving traffic.

Also verified while here: the blackbox DNS probes from #8715 are now live on both clusters (2d23h) and all probe_success targets are green, so nothing further is needed on that front.