### PR TITLE
feat(foreman): move both reviewers off self-hosted to dsv4f

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
@@ -10,11 +10,9 @@ spec:
   # (fork -> upstream). Reads LITELLM_API_KEY from the shared foreman-agent
   # Secret via the agent SA (which has secrets:get).
   provider: cloud-proxy
-  # MiniMax (stronger than dsv4f) — dsv4f mis-read the diff (flagged already-merged
-  # ancestor commits as branch additions) even after the prompt trim.
   providerConfig:
     baseURL: http://litellm.llm:4000/v1
-    model: self-hosted
+    model: dsv4f
     apiKeySecretRef:
       name: foreman-agent
       key: LITELLM_API_KEY

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -5,12 +5,10 @@ metadata:
   name: reviewer
 spec:
   role: reviewer
-  # Ornith-1.0-35B on the Strix Halo — the big/slow model, used to review rather
-  # than code.
   provider: cloud-proxy
   providerConfig:
     baseURL: http://litellm.llm:4000/v1
-    model: self-hosted
+    model: dsv4f
     apiKeySecretRef:
       name: foreman-agent
       key: LITELLM_API_KEY


### PR DESCRIPTION
## Summary
- Point `reviewer` and `reviewer-fork` at `dsv4f` instead of `self-hosted`.

self-hosted is the slowest model in the fleet and every foreman review ran through it, gating the code → review pipeline while a 70-issue backlog waited. dsv4f is already OpenAI-compatible via litellm (`mode: chat`, 1M input), so no new alias is required — unlike MiniMax-M2.7, which only exposes an Anthropic `/messages` endpoint and would need a `-chat` entry, and which already serves as the standalone PR reviewer.

Dropped two comments that the new value contradicts (the Ornith/Strix-Halo description, and a note asserting MiniMax over dsv4f).

## Risk
dsv4f previously mis-read diffs in this role — flagging already-merged ancestor commits as branch additions, i.e. false NO-GO. Retried on the strength of its logic upgrade. If reviews start citing changes the coder did not make, that regression is back.

## Verification
- `dsv4f` confirmed present in the litellm configmap as `mode: chat`, OpenAI-compatible, function calling, 1M input.
- Needs `kubectl rollout restart deployment/foreman-agent -n llm` after apply — InProcess agents read provider config at startup.
