### PR TITLE
Stop two permanent sources of alert noise

### DIFF
--- a/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
@@ -49,6 +49,29 @@ spec:
                   100
                 labels:
                   severity: critical
+      hpa-rules:
+        groups:
+          - name: hpa
+            rules:
+              - alert: KubeHpaMaxedOut
+                annotations:
+                  description: HPA {{ $labels.namespace }}/{{
+                    $labels.horizontalpodautoscaler }} has been running at max
+                    replicas for longer than 15 minutes on cluster {{
+                    $labels.cluster }}.
+                  runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpamaxedout
+                  summary: HPA is running at max replicas
+                expr: (kube_horizontalpodautoscaler_status_current_replicas{job="kube-state-metrics"}
+                  == kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics"})
+                  and on (namespace, horizontalpodautoscaler, cluster)
+                  (kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics"}
+                  != kube_horizontalpodautoscaler_spec_min_replicas{job="kube-state-metrics"})
+                  and on (namespace, horizontalpodautoscaler, cluster)
+                  (kube_horizontalpodautoscaler_spec_max_replicas{job="kube-state-metrics"}
+                  > 1)
+                for: 15m
+                labels:
+                  severity: warning
       oom-rules:
         groups:
           - name: oom
@@ -98,6 +121,9 @@ spec:
                 requests:
                   storage: 1Gi
     cleanPrometheusOperatorObjectNames: true
+    defaultRules:
+      disabled:
+        KubeHpaMaxedOut: true
     grafana:
       enabled: false
       forceDeployDashboards: true
@@ -161,6 +187,12 @@ spec:
                   storage: ${PVC_CAPACITY}Gi
     prometheus-node-exporter:
       fullnameOverride: node-exporter
+      prometheus:
+        monitor:
+          metricRelabelings:
+            - action: drop
+              sourceLabels: ["mountpoint"]
+              regex: /etc/.*
   valuesFrom:
     - kind: ConfigMap
       name: flux-metrics-configmap


### PR DESCRIPTION
## Summary
- `KubeHpaMaxedOut`: disable the upstream rule, re-add it with a `maxReplicas > 1` guard. Nineteen HPAs run `min=0/max=1` as an availability switch, not for capacity, so `current == max` is permanently true whenever the app is up.
- Drop `node_filesystem_*` series whose `mountpoint` is under `/etc` at scrape time.

## Why the /etc prefix, not one path

Talos bind-mounts config files into `/etc` and node-exporter reports each as a filesystem carrying its parent's capacity. Every node shows ~13 of them:

```
/etc/cri/conf.d/cri.toml        device=none
/etc/hosts                      device=none
/etc/machine-id                 device=none
/etc/nfsmount.conf              device=/dev/nvme2n1p4   <-- real partition
/etc/resolv.conf                device=none
...
```

Most have `device=none`, so `CephNodeDiskspaceWarning`'s `device=~"/.*"` filter already skips them. `/etc/nfsmount.conf` is the one that slips through, which is why `/var` on skirk gets alerted on twice. Excluding the prefix covers the ones that arrive with future Talos config changes too, and nothing under `/etc` is a filesystem worth capacity-planning.

The Ceph rule itself is unchanged and still fires — the point is that it stops firing twice for one disk.

## Verification
Corrected HPA expression run against live Prometheus:

| | result |
| --- | --- |
| upstream expression | 19 series firing |
| corrected expression | 0 series |
| HPAs still in scope (`max > 1`) | `security/authentik-server`, `security/authentik-worker` (max=5) |

## Notes
- Uses `prometheus.monitor.metricRelabelings`, which is `[]` by default, so this is purely additive. The earlier revision set `extraArgs` instead, which replaces the chart's default list and would have frozen two regexes Renovate could not keep current.
- One side effect: voyager's `/etc/libvirt` (a real mount on `/dev/loop3`) is dropped too. Say so if you want it kept and I'll anchor the regex to exclude it.