### PR TITLE
Expose WEBHOOK_TOKEN to alert-triage

### DIFF
--- a/kubernetes/apps/base/observability/alert-triage/externalsecret.yaml
+++ b/kubernetes/apps/base/observability/alert-triage/externalsecret.yaml
@@ -14,6 +14,7 @@ spec:
       data:
         DISCORD_WEBHOOK_URL: "{{ .DISCORD_TRIAGE_WEBHOOK_URL }}"
         LITELLM_API_KEY: "{{ .LITELLM_ALERT_TRIAGE_API_KEY }}"
+        WEBHOOK_TOKEN: "{{ .WEBHOOK_TOKEN }}"
   dataFrom:
     - extract:
         key: alert-triage


### PR DESCRIPTION
## Summary
- Map the `WEBHOOK_TOKEN` field (already in 1Password) into `alert-triage-secret`.

First of two steps. The Alertmanager receiver will reference this key via `httpConfig.authorization` in a follow-up PR — separated so there is no window where the Prometheus Operator references a key External Secrets has not synced yet, since a config it cannot generate affects all alerting, not just triage.

alert-triage 0.1.6 ignores `WEBHOOK_TOKEN`; enforcement ships in the next release (misospace/alert-triage#21), by which point the receiver will be sending it.

## Verification
- Not yet synced — refresh interval is 1h. After merge I'll force a sync and confirm the key is present before opening the receiver PR.