### PR TITLE
Triage: bearer token, and triage criticals too

### DIFF
--- a/kubernetes/apps/base/observability/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -50,6 +50,11 @@ spec:
       webhookConfigs:
         - url: http://alert-triage.observability.svc.cluster.local:8080/webhook
           sendResolved: false
+          httpConfig:
+            authorization:
+              credentials:
+                name: alert-triage-secret
+                key: WEBHOOK_TOKEN
     - name: blackhole
     - name: heartbeat
       webhookConfigs:

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -27,10 +27,6 @@ spec:
         groupWait: 0s
         groupInterval: 1m
         repeatInterval: 12h
-        matchers:
-          - name: severity
-            value: critical
-            matchType: "!="
       - receiver: discord
     groupBy: ["alertname", "cluster", "job"]
     groupInterval: 10m


### PR DESCRIPTION
Two Alertmanager changes, one commit each.

## Summary
- **`7e02c76`** — send `Authorization: Bearer` to the triage webhook from `alert-triage-secret`. **This must land before alert-triage v0.1.7 deploys**: #8832 already put `WEBHOOK_TOKEN` in the pod's env, and the next release starts enforcing it, so until the receiver sends the token every alert would 401.
- **`8f82d26`** — drop the `severity != critical` matcher so criticals get triaged too. `continue: true` still forwards them to Discord immediately; the digest arrives a flush window later.

## Verification
- `kubectl apply --dry-run=server` accepts the AlertmanagerConfig.
- Resulting route order: `blackhole` (InfoInhibitor) → `heartbeat` (Watchdog) → `triage` (everything remaining, continue) → `discord`.