### PR TITLE
chore(llm): bump foreman-dispatch-bridge to 0.6.15

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           app:
             image:
               repository: ghcr.io/misospace/foreman-dispatch-bridge
-              tag: 0.6.14@sha256:68c81fd7a24f48f23b30f9e73ac30242c41bc35f666cc0cfd6dc2dda9a32d777
+              tag: 0.6.15@sha256:731137dd416bdbb6c46f7c07ccc484b974291640b7b4467e776a2521c11c9a8f
             env:
               DISPATCH_URL: http://dispatch.llm:3000
               # Dash, not slash (like saffron-normal): agents auto-register, but a "/"


### PR DESCRIPTION
## Summary
- Bump `foreman-dispatch-bridge` 0.6.14 → 0.6.15.

Ships the #101 fix (misospace/foreman-dispatch-bridge#106): `allowOverwrite` is now gated on evidence that the task branch was actually pushed — a `pullRequestURL`, a review task with a verdict, a coder GO, or a `PUSH-FAILED` outcome — instead of being set on every Workload. Without that, a re-dispatch producing an empty diff force-pushed base over a reviewed commit and GitHub autoclosed the PR.

Bumped by hand rather than waiting for Renovate: the running 0.6.14 still carries the bug, which cost ~2.2k lines across `alert-triage#13` and `foreman-dispatch-bridge#87` today (both recovered).

## Verification
- Digest resolved from the published multi-arch index: `sha256:731137dd…`
- Release build succeeded and `v0.6.15` is published.
- Swept for the failure fingerprint (closed foreman PR, 0 commits, 0 files) after release: no new victims.