### PR TITLE
Run alert-triage on utility too

### DIFF
--- a/kubernetes/apps/base/observability/alert-triage/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/alert-triage/helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
               repository: ghcr.io/misospace/alert-triage
               tag: 0.1.7@sha256:c3f72978ae97d399afe6d55aadef0a142804528bfebebf66ca07b65a38dab696
             env:
-              LITELLM_URL: http://litellm.llm:4000/v1
+              LITELLM_URL: ${LITELLM_URL:=http://litellm.llm:4000/v1}
               MODEL: dsv4f
               HISTORY_PATH: /data/history.jsonl
             envFrom:

--- a/kubernetes/apps/base/observability/alert-triage/pvc.yaml
+++ b/kubernetes/apps/base/observability/alert-triage/pvc.yaml
@@ -8,4 +8,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: ceph-block

--- a/kubernetes/apps/utility/observability/alert-triage.yaml
+++ b/kubernetes/apps/utility/observability/alert-triage.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: alert-triage
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/observability/alert-triage
+  postBuild:
+    substitute:
+      LITELLM_URL: https://litellm.jory.dev/v1
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/kubernetes/apps/utility/observability/kustomization.yaml
+++ b/kubernetes/apps/utility/observability/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 replacements:
   - path: ../../../components/replacements/ks.yaml
 resources:
+  - ./alert-triage.yaml
   - ./gatus.yaml
   # - ./grafana.yaml
   - ./kube-prometheus-stack.yaml


### PR DESCRIPTION
## Summary
- Deploy alert-triage to utility via the existing base, with `LITELLM_URL` pointed at the external hostname (split DNS resolves it internally).
- Drop `storageClassName` from the base PVC so each cluster uses its own default — `ceph-block` on main, `local-hostpath` on utility.

## Why now

The shared kube-prometheus-stack base wires the `triage` receiver and route into every cluster, so utility has been posting alerts at a service that does not exist there. Since #8836 the receiver also references `alert-triage-secret`, which utility lacks, so its Prometheus Operator has been unable to regenerate the Alertmanager config since 2026-08-06 00:32 — alerting there is running on the last good config. Deploying the service creates that secret and gives the receiver a real target.

An instance per cluster keeps enrichment correct without cross-cluster credentials: each reads the API server it runs in. The cost is that a fault in shared infrastructure (NFS, DNS, VLANs) yields one digest per cluster rather than one story — tracked as misospace/alert-triage#25, worth revisiting if that duplication turns out to be confusing rather than merely redundant.

## Needs a manual step after merge

`storageClassName` is immutable, so main's existing PVC cannot be updated in place. It has to be deleted and recreated, which **loses `/data/history.jsonl`** — "seen N times" resets and every incident reads as novel until the 7-day retention window refills. The reclaim policy is `Delete`, so the data goes with it.

```sh
kubectl scale -n observability deploy/alert-triage --replicas=0
kubectl delete pvc -n observability alert-triage
flux reconcile ks alert-triage -n flux-system --with-source
kubectl scale -n observability deploy/alert-triage --replicas=1
```

I can run that once this merges, or preserve the history file first if the counts are worth keeping.

## Verification
- `kubectl kustomize` builds the base cleanly with the field removed.
- `ceph-block` confirmed default on main, `local-hostpath` on utility.
- `onepassword` ClusterSecretStore is present and Valid on utility, so the ExternalSecret will resolve there.