### PR TITLE
chore(llm): bump dispatch to 0.5.33 and bridge to 0.6.16

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           app:
             image:
               repository: ghcr.io/misospace/foreman-dispatch-bridge
-              tag: 0.6.15@sha256:731137dd416bdbb6c46f7c07ccc484b974291640b7b4467e776a2521c11c9a8f
+              tag: 0.6.16@sha256:95736fce50ff0fffee94d17445012ac1c614bc1fa460a90a311285722a3a389e
             env:
               DISPATCH_URL: http://dispatch.llm:3000
               # Dash, not slash (like saffron-normal): agents auto-register, but a "/"

--- a/kubernetes/apps/base/llm/dispatch/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/dispatch/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.5.32
+    tag: 0.5.33
   url: oci://ghcr.io/misospace/charts/dispatch


### PR DESCRIPTION
## Summary
- dispatch 0.5.32 → **0.5.33**
- foreman-dispatch-bridge 0.6.15 → **0.6.16**

Both halves of the stuck-claim fix.

An issue at `status/ready` still carrying its own `agent/foreman-coder` label was served at the **head** of the queue, refused on every claim (a conflict with itself), and skipped so the lane would not starve. Served, refused, skipped — every tick. `pr-reviewer-action#419` and `llmkube-images#34` sat that way for 20 days while throughput looked healthy.

- **dispatch 0.5.33** — root cause: a re-claim by the same agent is idempotent instead of 409, and `/api/issues/claimed` takes a `status` parameter so the state is listable at all.
- **bridge 0.6.16** — second layer: releases stuck claims with no Workload and no open PR.

## Notes
Deploy order does not matter. The reaper verifies `status/ready` from the item's own labels rather than trusting the server-side filter, so it is correct against either dispatch version.

The two p0s were unstuck by hand already (stale label removed), so this is about preventing recurrence rather than clearing the current backlog.

## Verification
- dispatch: 2158 tests, lint, typecheck clean. bridge: 277 tests, ruff, mypy clean.
- Bridge digest resolved from the published multi-arch index: `sha256:95736fce…`