### PR TITLE
feat(foreman): let coders read the issue themselves via fetch_issue

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -18,6 +18,7 @@ spec:
     - str_replace
     - grep
     - bash
+    - fetch_issue
     - submit_result
   mcp:
     enabled: true
@@ -55,7 +56,12 @@ spec:
     model — read any existing foreman branches/comments for prior context, expect
     the problem to be subtler than it looks, and prefer root-cause fixes over
     surface patches.
-    Read the issue and the relevant files, then implement it fully — including
+    STEP 1 — read the issue yourself. Call fetch_issue(repo, issue) using the repo and
+    issue number in your payload, before reading code or editing anything. Do not work
+    from the payload prompt alone: on a retry it carries only the previous attempt's
+    feedback, and the original ask and acceptance criteria are NOT in it. If
+    fetch_issue fails, say so in your summary rather than guessing at the requirement.
+    Then read the relevant files and implement it fully — including
     anything the issue marks optional, nice-to-have, or "also consider." Optional
     means "the author would take it if you do it well," not "skip it." Decline an
     optional item only when it is genuinely wrong (wrong layer, needs a human design

--- a/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
@@ -24,6 +24,7 @@ spec:
     - str_replace
     - grep
     - bash
+    - fetch_issue
     - submit_result
   mcp:
     enabled: true
@@ -72,7 +73,12 @@ spec:
     accelerator: any
   systemPrompt: |
     You are a coding agent resolving a single GitHub issue in a Go project.
-    Read the issue and the relevant files, then implement it fully — including
+    STEP 1 — read the issue yourself. Call fetch_issue(repo, issue) using the repo and
+    issue number in your payload, before reading code or editing anything. Do not work
+    from the payload prompt alone: on a retry it carries only the previous attempt's
+    feedback, and the original ask and acceptance criteria are NOT in it. If
+    fetch_issue fails, say so in your summary rather than guessing at the requirement.
+    Then read the relevant files and implement it fully — including
     anything the issue marks optional, nice-to-have, or "also consider." Optional
     means "the author would take it if you do it well," not "skip it." Decline an
     optional item only when it is genuinely wrong (wrong layer, needs a human design

--- a/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
@@ -18,6 +18,7 @@ spec:
     - str_replace
     - grep
     - bash
+    - fetch_issue
     - submit_result
   mcp:
     enabled: true
@@ -54,7 +55,12 @@ spec:
     accelerator: any
   systemPrompt: |
     You are a coding agent resolving a single GitHub issue in a Node/TypeScript project.
-    Read the issue and the relevant files, then implement it fully — including
+    STEP 1 — read the issue yourself. Call fetch_issue(repo, issue) using the repo and
+    issue number in your payload, before reading code or editing anything. Do not work
+    from the payload prompt alone: on a retry it carries only the previous attempt's
+    feedback, and the original ask and acceptance criteria are NOT in it. If
+    fetch_issue fails, say so in your summary rather than guessing at the requirement.
+    Then read the relevant files and implement it fully — including
     anything the issue marks optional, nice-to-have, or "also consider." Optional
     means "the author would take it if you do it well," not "skip it." Decline an
     optional item only when it is genuinely wrong (wrong layer, needs a human design

--- a/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
@@ -18,6 +18,7 @@ spec:
     - str_replace
     - grep
     - bash
+    - fetch_issue
     - submit_result
   mcp:
     enabled: true
@@ -54,7 +55,12 @@ spec:
     accelerator: any
   systemPrompt: |
     You are a coding agent resolving a single GitHub issue in a Python project.
-    Read the issue and the relevant files, then implement it fully — including
+    STEP 1 — read the issue yourself. Call fetch_issue(repo, issue) using the repo and
+    issue number in your payload, before reading code or editing anything. Do not work
+    from the payload prompt alone: on a retry it carries only the previous attempt's
+    feedback, and the original ask and acceptance criteria are NOT in it. If
+    fetch_issue fails, say so in your summary rather than guessing at the requirement.
+    Then read the relevant files and implement it fully — including
     anything the issue marks optional, nice-to-have, or "also consider." Optional
     means "the author would take it if you do it well," not "skip it." Decline an
     optional item only when it is genuinely wrong (wrong layer, needs a human design

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -18,6 +18,7 @@ spec:
     - str_replace
     - grep
     - bash
+    - fetch_issue
     - submit_result
   mcp:
     enabled: true
@@ -52,9 +53,12 @@ spec:
     a reviewer returned changes. The workspace already contains that prior attempt,
     checked out on its branch — do not start over; read the existing diff against the
     base branch first, then apply the reviewer's findings as targeted edits on top of it.
-    Treat the reviewer feedback as the spec: address every finding, and where a finding
-    cites a file or symbol as the source of truth, read that file and verify your change
-    against it rather than guessing. Preserve the parts of the prior attempt the reviewer
+    Call fetch_issue(repo, issue) before you start: the reviewer feedback tells you what
+    to CHANGE, the issue tells you what DONE means, and the two are not the same. A
+    finding is a derived artifact — satisfying every finding while drifting from the
+    issue's actual ask still fails review. Read both, then address every finding, and
+    where a finding cites a file or symbol as the source of truth, read that file and
+    verify your change against it rather than guessing. Preserve the parts of the prior attempt the reviewer
     did not object to. Every behaviour change still needs a test. Match the surrounding
     code style.
     Make every file change with the write_file and str_replace tools only — never edit

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -18,6 +18,7 @@ spec:
     - str_replace
     - grep
     - bash
+    - fetch_issue
     - submit_result
   mcp:
     enabled: true
@@ -52,7 +53,12 @@ spec:
     accelerator: any
   systemPrompt: |
     You are a coding agent resolving a single GitHub issue in the referenced repo.
-    Read the issue and the relevant files, then implement it fully — including
+    STEP 1 — read the issue yourself. Call fetch_issue(repo, issue) using the repo and
+    issue number in your payload, before reading code or editing anything. Do not work
+    from the payload prompt alone: on a retry it carries only the previous attempt's
+    feedback, and the original ask and acceptance criteria are NOT in it. If
+    fetch_issue fails, say so in your summary rather than guessing at the requirement.
+    Then read the relevant files and implement it fully — including
     anything the issue marks optional, nice-to-have, or "also consider." Optional
     means "the author would take it if you do it well," not "skip it." Decline an
     optional item only when it is genuinely wrong (wrong layer, needs a human design


### PR DESCRIPTION
## Summary
- Add `fetch_issue` to all six coder agents' `tools`.
- Instruct the call explicitly as step 1 in each coder prompt.
- `coder-revision`: stop calling reviewer feedback "the spec".

## Why

The coder prompt already said *"Read the issue and the relevant files"* — but the coders had no tool to read an issue. Their tools were `read_file, write_file, str_replace, grep, bash, submit_result`. Only the reviewer had `fetch_issue`, which is part of why reviews are grounded in the issue text and fixes sometimes aren't.

The payload carries the issue **number**, not its body. Foreman lazily injects the body via `fetchIssueBodyIfNeeded`, but bails when a composed prompt is present and `reviseFromBranch` is not:

```go
if task.Spec.Payload.Prompt != "" && task.Spec.Payload.ReviseFromBranch == "" {
    // Pre-#951 contract: a composed prompt owns the task context.
    return
}
```

Bridge retries hit exactly that shape — `payload.prompt` is the feedback digest — so those coders received the digest and **no issue body**. Upstream's own comment names the hazard: *"a retry handed only the feedback loses the original ask and acceptance criteria."* Confirmed on live tasks: `wl-…-bridge-36-code-36` and `-35-code-35` both carry a feedback prompt and nothing else.

Granting the tool makes that guard irrelevant — the coder pulls the issue itself rather than depending on whether something upstream happened to inject it.

## Risk

Low. No new capability: `FetchIssueTool` is registered unconditionally in the agent binary (`cmd/foreman-agent/main.go`), and `spec.tools` is a whitelist over that set (`assembleAgentRegistry(native, ag.Spec.Tools, mcpTools)`). It uses the token the agent already loads at startup — no extra secret, and one bounded Go-side call rather than `$GH_TOKEN` in every bash subprocess.

Worst case the model ignores the tool and behaves exactly as today.

## Notes

`coder-revision` previously said "Treat the reviewer feedback as the spec." Feedback says what to **change**; the issue says what **done** means. Satisfying every finding while drifting from the issue's ask still fails review, so it now reads both.

## Deploy
Needs `kubectl rollout restart deployment/foreman-agent -n llm` — InProcess agents read Agent specs at startup.

## Verification
- All six files parse; each has both the tool and the instruction.
- Verify after rollout: a coder task transcript shows a `fetch_issue` call before its first edit.
