### PR TITLE
chore(llm): bump dispatch to 0.5.35

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/dispatch/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.5.33
+    tag: 0.5.35
   url: oci://ghcr.io/misospace/charts/dispatch


### PR DESCRIPTION
## Summary
- dispatch 0.5.33 → **0.5.35** (picks up both 0.5.34 and 0.5.35).

Both releases are on the review-feedback path, and neither is deployed yet — which is why requesting changes on a foreman PR currently goes nowhere.

**0.5.34** — `CHANGES_REQUESTED` routes to the fix lane instead of being keyword-classified. Measured on this deployment before the fix: of three human reviews, **two were stranded** in `NEEDS_HUMAN` (#467, alert-triage#24) and the third reached the fix lane only because its wording happened to match a pattern.

**0.5.35** — a reviewer's inline findings become work regardless of verdict. An approve-with-nits review produced nothing: `APPROVED` was skipped on state, and the findings live on `pulls/N/comments`, an endpoint the sync never fetched. Observed on foreman-dispatch-bridge#111 — four findings discarded, two of them about silently swallowed errors.

## Expect on first sync
A one-time burst: every inline review comment on a currently-open bot PR is unseen, so each becomes a fix item. Settles after the first pass (the evidence key dedupes thereafter).

## Follow-up
Items already parked in `NEEDS_HUMAN` do not re-route themselves — #467 and alert-triage#24 need re-laning to `NORMAL` after this deploys.