### PR TITLE
chore(llm): bump dispatch to 0.5.36 and bridge to 0.6.17

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           app:
             image:
               repository: ghcr.io/misospace/foreman-dispatch-bridge
-              tag: 0.6.16@sha256:95736fce50ff0fffee94d17445012ac1c614bc1fa460a90a311285722a3a389e
+              tag: 0.6.17@sha256:5f8493930efea6aa39c451eb617c1317dead06ed73835ce21b4796889081c611
             env:
               DISPATCH_URL: http://dispatch.llm:3000
               # Dash, not slash (like saffron-normal): agents auto-register, but a "/"

--- a/kubernetes/apps/base/llm/dispatch/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/dispatch/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.5.35
+    tag: 0.5.36
   url: oci://ghcr.io/misospace/charts/dispatch


### PR DESCRIPTION
## Summary
- dispatch 0.5.35 → **0.5.36**
- foreman-dispatch-bridge 0.6.16 → **0.6.17**

Two halves of one change: stop retrying a `Failed` workload whose issue is closed.

**dispatch 0.5.36** adds `/api/issues/state`, an unfiltered single-issue lookup. The general `/api/issues` endpoint couldn't answer "is this still open?" — Renovate exclusion, excluded-label filters, and its open-only default make absence ambiguous between *closed*, *excluded*, and *filtered out*.

**bridge 0.6.17** uses it as a retry precondition, placed **before** the `max_attempts` branch so a closed issue isn't escalated to a stronger coder either. `wl-misospace-llmkube-images-38` was the case: `Failed` at attempt 1 for an issue closed as already-resolved, with two more attempts pending that could only return `NO-CHANGES`.

## Fails open
Only an explicit `closed` skips. A 404, transport failure, malformed response, unrecognised state, raising hook, or unwired hook all retry exactly as 0.6.16 did. Reading ambiguity as "closed" would cancel legitimate retries whenever dispatch blipped — worse than the waste avoided.

## Ordering
Doesn't matter. Against an older dispatch the lookup 404s, which is the fail-open path.

## Verification
- dispatch: 2179 tests, lint, typecheck clean. bridge: 292 tests, ruff, mypy clean.
- Bridge digest resolved from the published multi-arch index: `sha256:5f849393…`