### PR TITLE
feat(foreman): teach coders to declare ALREADY-RESOLVED

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -98,5 +98,15 @@ spec:
     same fix. If you cannot show the issue's specific concern is already handled where
     it lives, implement the fix: a false "already resolved" verdict leaves a real bug
     unfixed, so when in doubt, do the work.
+    When the issue IS already handled where it lives, report it as a machine
+    outcome, not as a success: call submit_result with verdict NO-GO plus
+    extra.outcome = "ALREADY-RESOLVED" and extra.resolvedBy = a one-line evidence
+    string naming what resolved it (the file and what it already does, or the PR
+    or commit that did it). Foreman treats that pair specially — it skips
+    escalation, keeps the task out of the incomplete bucket, and marks dependent
+    steps Skipped.
+    Do NOT report it as GO. A GO that produces no diff is recorded as NO-CHANGES
+    and reads as a plain failure, which then burns the remaining retry attempts
+    re-discovering the same nothing.
     If the task is an epic, needs a human design decision, or would touch
     many files, call submit_result with that verdict instead of guessing.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
@@ -114,5 +114,15 @@ spec:
     same fix. If you cannot show the issue's specific concern is already handled where
     it lives, implement the fix: a false "already resolved" verdict leaves a real bug
     unfixed, so when in doubt, do the work.
+    When the issue IS already handled where it lives, report it as a machine
+    outcome, not as a success: call submit_result with verdict NO-GO plus
+    extra.outcome = "ALREADY-RESOLVED" and extra.resolvedBy = a one-line evidence
+    string naming what resolved it (the file and what it already does, or the PR
+    or commit that did it). Foreman treats that pair specially — it skips
+    escalation, keeps the task out of the incomplete bucket, and marks dependent
+    steps Skipped.
+    Do NOT report it as GO. A GO that produces no diff is recorded as NO-CHANGES
+    and reads as a plain failure, which then burns the remaining retry attempts
+    re-discovering the same nothing.
     If the task is an epic, needs a human design decision, or would touch many files,
     call submit_result with that verdict instead of guessing.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
@@ -96,5 +96,15 @@ spec:
     same fix. If you cannot show the issue's specific concern is already handled where
     it lives, implement the fix: a false "already resolved" verdict leaves a real bug
     unfixed, so when in doubt, do the work.
+    When the issue IS already handled where it lives, report it as a machine
+    outcome, not as a success: call submit_result with verdict NO-GO plus
+    extra.outcome = "ALREADY-RESOLVED" and extra.resolvedBy = a one-line evidence
+    string naming what resolved it (the file and what it already does, or the PR
+    or commit that did it). Foreman treats that pair specially — it skips
+    escalation, keeps the task out of the incomplete bucket, and marks dependent
+    steps Skipped.
+    Do NOT report it as GO. A GO that produces no diff is recorded as NO-CHANGES
+    and reads as a plain failure, which then burns the remaining retry attempts
+    re-discovering the same nothing.
     If the task is an epic, needs a human design decision, or would touch many files,
     call submit_result with that verdict instead of guessing.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
@@ -96,5 +96,15 @@ spec:
     same fix. If you cannot show the issue's specific concern is already handled where
     it lives, implement the fix: a false "already resolved" verdict leaves a real bug
     unfixed, so when in doubt, do the work.
+    When the issue IS already handled where it lives, report it as a machine
+    outcome, not as a success: call submit_result with verdict NO-GO plus
+    extra.outcome = "ALREADY-RESOLVED" and extra.resolvedBy = a one-line evidence
+    string naming what resolved it (the file and what it already does, or the PR
+    or commit that did it). Foreman treats that pair specially — it skips
+    escalation, keeps the task out of the incomplete bucket, and marks dependent
+    steps Skipped.
+    Do NOT report it as GO. A GO that produces no diff is recorded as NO-CHANGES
+    and reads as a plain failure, which then burns the remaining retry attempts
+    re-discovering the same nothing.
     If the task is an epic, needs a human design decision, or would touch many files,
     call submit_result with that verdict instead of guessing.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -77,3 +77,11 @@ spec:
     submit_result with a concise commit message describing what changed since the prior
     attempt. If a finding needs a human design decision or would touch many files, call
     submit_result with that verdict instead of guessing.
+    If the reviewer's findings are ALREADY satisfied on this branch — you read the diff
+    and the code at each cited location and it already does what the finding asks — do
+    not re-commit or invent a change to look busy. Call submit_result with verdict NO-GO
+    plus extra.outcome = "ALREADY-RESOLVED" and extra.resolvedBy = a one-line evidence
+    string naming where each finding is already handled. Foreman treats that pair
+    specially: it skips escalation and keeps the task out of the incomplete bucket.
+    Do NOT report GO with no diff — that records as NO-CHANGES, reads as a plain
+    failure, and burns the remaining attempts re-discovering the same nothing.

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -94,5 +94,15 @@ spec:
     same fix. If you cannot show the issue's specific concern is already handled where
     it lives, implement the fix: a false "already resolved" verdict leaves a real bug
     unfixed, so when in doubt, do the work.
+    When the issue IS already handled where it lives, report it as a machine
+    outcome, not as a success: call submit_result with verdict NO-GO plus
+    extra.outcome = "ALREADY-RESOLVED" and extra.resolvedBy = a one-line evidence
+    string naming what resolved it (the file and what it already does, or the PR
+    or commit that did it). Foreman treats that pair specially — it skips
+    escalation, keeps the task out of the incomplete bucket, and marks dependent
+    steps Skipped.
+    Do NOT report it as GO. A GO that produces no diff is recorded as NO-CHANGES
+    and reads as a plain failure, which then burns the remaining retry attempts
+    re-discovering the same nothing.
     If the task is an epic, needs a human design decision, or would touch many files,
     call submit_result with that verdict instead of guessing.


### PR DESCRIPTION
## Summary
- Teach all six coder agents to declare `ALREADY-RESOLVED` when an issue is already handled, instead of reporting GO with no diff.

## Why

Foreman has had a machine outcome for "the work is already done" since LLMKube#970. **Our coder prompts never mentioned it.** So a coder that correctly found nothing to do reported GO, produced no diff, and the harness recorded `NO-CHANGES` — indistinguishable from a failure.

We watched it happen: `wl-misospace-llmkube-images-38` coded an issue whose target file a sibling issue had already deleted. It emitted GO with no diff, landed as `NO-GO`/`NO-CHANGES`, and left **two retry attempts queued** that could only rediscover the same nothing.

## What the declared outcome buys

All already implemented in `internal/foreman/controller/workload_coder_escalation.go`:

| behaviour | effect |
| --- | --- |
| `shouldEscalateCoder` returns false | *"already-resolved is not a capability failure"* — does not burn a stronger frontier coder |
| rollup excludes it from the incomplete bucket | does not pin the Workload to `Failed` |
| dependents marked `Skipped` | review/verify steps don't run against nothing |

So this is a prompt-only change that unlocks controller logic already shipped upstream.

## The contract, and why it's stated so explicitly

`verdict: NO-GO` + `extra.outcome = "ALREADY-RESOLVED"` + `extra.resolvedBy = <evidence>`.

**NO-GO, not GO** — which is counterintuitive enough that the prompt says it twice. The GO path commits, and a GO with nothing to commit is converted to `NO-CHANGES` before `extra` is ever consulted (`executor_native.go:1023`: *"Model said GO but never edited anything"*). A coder that declares already-resolved on the GO path gets its declaration discarded.

`resolvedBy` is an evidence string; the Workload controller aggregates it into a resolved-issues list, so "the file already does X" or "resolved by PR #146" both work.

`coder-revision` gets the same contract shaped for its case — the reviewer's findings already satisfied on the branch — with an explicit "do not re-commit or invent a change to look busy".

## Deploy
Needs `kubectl rollout restart deployment/foreman-agent -n llm` — InProcess agents read Agent specs at startup.

## Verification
- All six files parse; each carries the outcome name, the NO-GO requirement, `resolvedBy`, and the NO-CHANGES warning.
- Verify after rollout: a coder facing an already-fixed issue produces `extra.outcome=ALREADY-RESOLVED` with no retry attempts queued, instead of `NO-CHANGES`.
