### PR TITLE
feat(foreman): let coders declare why a task needs a human

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -108,5 +108,13 @@ spec:
     Do NOT report it as GO. A GO that produces no diff is recorded as NO-CHANGES
     and reads as a plain failure, which then burns the remaining retry attempts
     re-discovering the same nothing.
-    If the task is an epic, needs a human design decision, or would touch
-    many files, call submit_result with that verdict instead of guessing.
+    If code cannot resolve this issue, say which kind of dead end it is instead of
+    attempting a guess: call submit_result with verdict NO-GO plus
+    extra.escalation = "DESIGN-DECISION" (a product or architecture call a human has
+    to make) or "NO-TECHNICAL-FIX" (nothing in this repo can fix it — wrong layer,
+    upstream bug, external service), and put the specific question or blocker in your
+    summary. The loop parks the issue for a human immediately on that signal, without
+    spending the remaining retry attempts re-deriving the same conclusion. Use these
+    only when you have read enough to be sure: a wrong escalation removes real work
+    from the queue. An epic that is merely large is not one of these — say so in your
+    summary and let a human split it.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
@@ -124,5 +124,13 @@ spec:
     Do NOT report it as GO. A GO that produces no diff is recorded as NO-CHANGES
     and reads as a plain failure, which then burns the remaining retry attempts
     re-discovering the same nothing.
-    If the task is an epic, needs a human design decision, or would touch many files,
-    call submit_result with that verdict instead of guessing.
+    If code cannot resolve this issue, say which kind of dead end it is instead of
+    attempting a guess: call submit_result with verdict NO-GO plus
+    extra.escalation = "DESIGN-DECISION" (a product or architecture call a human has
+    to make) or "NO-TECHNICAL-FIX" (nothing in this repo can fix it — wrong layer,
+    upstream bug, external service), and put the specific question or blocker in your
+    summary. The loop parks the issue for a human immediately on that signal, without
+    spending the remaining retry attempts re-deriving the same conclusion. Use these
+    only when you have read enough to be sure: a wrong escalation removes real work
+    from the queue. An epic that is merely large is not one of these — say so in your
+    summary and let a human split it.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
@@ -106,5 +106,13 @@ spec:
     Do NOT report it as GO. A GO that produces no diff is recorded as NO-CHANGES
     and reads as a plain failure, which then burns the remaining retry attempts
     re-discovering the same nothing.
-    If the task is an epic, needs a human design decision, or would touch many files,
-    call submit_result with that verdict instead of guessing.
+    If code cannot resolve this issue, say which kind of dead end it is instead of
+    attempting a guess: call submit_result with verdict NO-GO plus
+    extra.escalation = "DESIGN-DECISION" (a product or architecture call a human has
+    to make) or "NO-TECHNICAL-FIX" (nothing in this repo can fix it — wrong layer,
+    upstream bug, external service), and put the specific question or blocker in your
+    summary. The loop parks the issue for a human immediately on that signal, without
+    spending the remaining retry attempts re-deriving the same conclusion. Use these
+    only when you have read enough to be sure: a wrong escalation removes real work
+    from the queue. An epic that is merely large is not one of these — say so in your
+    summary and let a human split it.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
@@ -106,5 +106,13 @@ spec:
     Do NOT report it as GO. A GO that produces no diff is recorded as NO-CHANGES
     and reads as a plain failure, which then burns the remaining retry attempts
     re-discovering the same nothing.
-    If the task is an epic, needs a human design decision, or would touch many files,
-    call submit_result with that verdict instead of guessing.
+    If code cannot resolve this issue, say which kind of dead end it is instead of
+    attempting a guess: call submit_result with verdict NO-GO plus
+    extra.escalation = "DESIGN-DECISION" (a product or architecture call a human has
+    to make) or "NO-TECHNICAL-FIX" (nothing in this repo can fix it — wrong layer,
+    upstream bug, external service), and put the specific question or blocker in your
+    summary. The loop parks the issue for a human immediately on that signal, without
+    spending the remaining retry attempts re-deriving the same conclusion. Use these
+    only when you have read enough to be sure: a wrong escalation removes real work
+    from the queue. An epic that is merely large is not one of these — say so in your
+    summary and let a human split it.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -75,8 +75,14 @@ spec:
     alternatives. Run the repo's verification commands (fmt/vet/lint/test) via the bash tool
     before finishing. When the revision is complete and verification passes, call
     submit_result with a concise commit message describing what changed since the prior
-    attempt. If a finding needs a human design decision or would touch many files, call
-    submit_result with that verdict instead of guessing.
+    attempt. If a finding cannot be resolved in code, say which kind of dead end it is
+    instead of guessing: call submit_result with verdict NO-GO plus
+    extra.escalation = "DESIGN-DECISION" (a product or architecture call a human has to
+    make — including a finding that contradicts the issue's ask) or "NO-TECHNICAL-FIX"
+    (nothing in this repo can fix it — wrong layer, upstream bug, external service), and
+    put the specific question or blocker in your summary. The loop parks the issue for a
+    human on that signal instead of spending the remaining attempts re-deriving it. Use
+    these only when you are sure: a wrong escalation removes real work from the queue.
     If the reviewer's findings are ALREADY satisfied on this branch — you read the diff
     and the code at each cited location and it already does what the finding asks — do
     not re-commit or invent a change to look busy. Call submit_result with verdict NO-GO

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -104,5 +104,13 @@ spec:
     Do NOT report it as GO. A GO that produces no diff is recorded as NO-CHANGES
     and reads as a plain failure, which then burns the remaining retry attempts
     re-discovering the same nothing.
-    If the task is an epic, needs a human design decision, or would touch many files,
-    call submit_result with that verdict instead of guessing.
+    If code cannot resolve this issue, say which kind of dead end it is instead of
+    attempting a guess: call submit_result with verdict NO-GO plus
+    extra.escalation = "DESIGN-DECISION" (a product or architecture call a human has
+    to make) or "NO-TECHNICAL-FIX" (nothing in this repo can fix it — wrong layer,
+    upstream bug, external service), and put the specific question or blocker in your
+    summary. The loop parks the issue for a human immediately on that signal, without
+    spending the remaining retry attempts re-deriving the same conclusion. Use these
+    only when you have read enough to be sure: a wrong escalation removes real work
+    from the queue. An epic that is merely large is not one of these — say so in your
+    summary and let a human split it.


### PR DESCRIPTION
## Summary
- All six coder prompts now declare **why** a task needs a human: `extra.escalation = "DESIGN-DECISION" | "NO-TECHNICAL-FIX"`.

## Why

The prompts said *"call submit_result with that verdict"* for an epic or a human design decision — without naming a field. So the only signal reaching the loop was a generic `NO-GO`, indistinguishable from "I tried and failed". The route to a human was then attempt-exhaustion, which spends every attempt to reach a conclusion the coder already had on the first read.

Now the coder names the dead end:

- **`DESIGN-DECISION`** — a product or architecture call a human has to make
- **`NO-TECHNICAL-FIX`** — nothing in this repo can fix it (wrong layer, upstream bug, external service)

with the specific question or blocker in the summary. The bridge parks the issue for a human on that signal, consuming no attempt and not escalating to a stronger coder (foreman-dispatch-bridge#113).

## Two guards stated in the prompt itself

The failure mode is asymmetric — a wrong escalation removes **real work** from the queue — so the prompt says to use these only when the coder has read enough to be sure.

And **"merely large" is explicitly not one of these.** An epic is work a human splits, not a dead end; the prompt tells the coder to say so in its summary rather than reach for an escalation. Without that carve-out, "would touch many files" is the obvious wrong trigger, since the old sentence bundled it with design decisions.

`coder-revision` gets the same contract, with *a finding that contradicts the issue's ask* called out as the design-decision case — it's the shape that actually occurs there.

## Deploy
Needs `kubectl rollout restart deployment/foreman-agent -n llm`.

Order doesn't matter: without bridge#113 the field is simply ignored, and without these prompts nothing emits it.

## Verification
- All six files parse; each carries `extra.escalation`, both reason strings, and the `verdict NO-GO` requirement alongside the `ALREADY-RESOLVED` contract from #8858.
- Verify after rollout: a coder facing a genuine design question produces `extra.modelExtra.escalation`, the issue lands in `status/backlog`, and no retry attempt is consumed.
