### PR TITLE
fix(litellm): point the self-hosted Mac fallback at a model it serves

### DIFF
--- a/kubernetes/apps/base/llm/litellm/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/configmap.yaml
@@ -42,7 +42,9 @@ data:
           # than filtering it out and leaving images with no fallback at all.
           supports_vision: true
         litellm_params:
-          model: openai/ornith-1.0-35b
+          # Must match an id LM Studio actually serves — it 400s on an unknown
+          # model rather than falling back to whatever is loaded.
+          model: openai/qwen3.6-35b-a3b
           api_base: http://mac.internal:1234/v1
           api_key: lm-studio
           max_parallel_requests: 1


### PR DESCRIPTION
## Summary
- `self-hosted` Mac upstream: `openai/ornith-1.0-35b` → `openai/qwen3.6-35b-a3b`.

## Why

The Mac fallback has been dead. LM Studio serves `qwen3.6-35b-a3b`; there is no `ornith-1.0-35b` in its model list, and it returns **400 Bad Request** for an unknown id rather than substituting whatever is loaded.

That never surfaced while the Strix upstream was healthy — the pool always resolved on `order: 1`. It surfaced the moment it was actually needed: the Strix is down pulling its new Q5_K_P weights, and `self-hosted` requests now **time out** instead of failing over. That alias backs openclaw's image and text paths, hermes' four auxiliary roles, and repo-wiki's `WIKI_MODEL`.

## Verification

Directly against `mac.internal:1234` from a litellm pod:

```
ornith-1.0-35b   -> FAILED HTTP Error 400: Bad Request
qwen3.6-35b-a3b  -> OK -> qwen3.6-35b-a3b
```

## Note

Worth merging ahead of the Strix finishing its download — that is the window where the fallback is load-bearing.