### PR TITLE
Keep upstream quota alerts out of triage

### DIFF
--- a/kubernetes/apps/base/observability/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -27,6 +27,10 @@ spec:
         groupWait: 0s
         groupInterval: 1m
         repeatInterval: 12h
+        matchers:
+          - name: alertname
+            value: LiteLLMAuthOrQuotaFailures
+            matchType: "!~"
       - receiver: discord
     groupBy: ["alertname", "cluster", "job"]
     groupInterval: 10m


### PR DESCRIPTION
## Summary
- Exclude `LiteLLMAuthOrQuotaFailures` from the triage route. It still reaches Discord.

## Why not the label approach from misospace/alert-triage#15

#15 proposes `triage: "true"` on the PrometheusRule, and misospace/alert-triage#24 adds the matching `TRIAGE_LABEL` backstop in the service. Two problems with applying it here:

1. **The alerts worth triaging are not ours to label.** `KubeDeploymentReplicasMismatch` comes from `kube-prometheus-stack-kubernetes-apps` and `TargetDown` from `general.rules` — both upstream chart rules. Labelling them means `defaultRules.disabled` plus a re-added copy of each, the same vendoring we avoided for `KubeHpaMaxedOut`. Only `OomKilled` and the LiteLLM rules are ours.
2. **`additionalAlertRelabelConfigs` would sidestep that**, stamping the label from Prometheus without touching any rule — but `alert_relabel_configs` applies to every alert going to Alertmanager, and the Discord template prints `.Labels.SortedPairs`, so every message in the channel would grow a `triage: true` line.

A negative matcher on the triage route gets the same outcome in four lines with no new mechanism and no label noise. `TRIAGE_LABEL` stays unset, so the service-side filter remains available if per-rule opt-in is ever wanted.

## Note on scale

One exclusion, because the actual noise was fixed at source instead — the 19 permanent `KubeHpaMaxedOut` alerts and the duplicated `CephNodeDiskspaceWarning`. Over the last 26h of digests, 17 of 20 classified `fix_location=git` and read as genuinely actionable, so there is not much else worth excluding today. Extending is a one-word change to the regex.

## Verification
- `kubectl apply --dry-run=server` accepts the AlertmanagerConfig.