### PR TITLE
feat(llm): swap strix to the MTP-preserved 35B and re-enable spec decoding

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-strix.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-strix.yaml
@@ -4,12 +4,12 @@ kind: Model
 metadata:
   name: llama-strix
 spec:
-  source: hf://HauhauCS/Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive
+  source: hf://SC117/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-APEX-GGUF
   files:
-    - Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive-Q5_K_P.gguf
-  mmproj: mmproj-Qwen3.6-35B-A3B-Uncensored-HauhauCS-Aggressive-f16.gguf
+    - Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-APEX-I-Balanced.gguf
+  mmproj: mmproj-Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-APEX-F16.gguf
   format: gguf
-  quantization: Q5_K_P
+  quantization: I-Balanced
   hardware:
     accelerator: rocm
     gpu:
@@ -67,6 +67,16 @@ spec:
     - --image-min-tokens
     - "1024"
     - --cont-batching
+    - --spec-type
+    - draft-mtp
+    - --spec-draft-p-min
+    - "0.75"
+    - --spec-draft-n-max
+    - "3"
+    - --spec-draft-type-k
+    - q8_0
+    - --spec-draft-type-v
+    - q8_0
     - --cache-prompt
     - --kv-unified
     - --checkpoint-min-step


### PR DESCRIPTION
## Summary
- Swaps `llama-strix` to `SC117/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-APEX-GGUF` (I-Balanced).
- Re-enables MTP self-speculative decoding, using the same arg set `llama-nvidia` runs today.

## Why

The current HauhauCS build has no MTP tensors, so speculative decoding has been off on the strix since `9feda965` ("cleanup mtp") stripped the args. This build preserves them natively, which is the whole point of the swap — the args are dead weight without a model that carries the MTP head.

The restored block is byte-identical to the one removed in `9feda965`, and to what `llama-nvidia` runs in production:

```
--spec-type draft-mtp --spec-draft-p-min 0.75 --spec-draft-n-max 3
--spec-draft-type-k q8_0 --spec-draft-type-v q8_0
```

## Sizing

I-Balanced is **25.96 GB** against the current Q5_K_P's **28.03 GB**, so this is a ~2 GB reduction and `memory: 28Gi` is unchanged. Multimodal is preserved — the repo ships an mmproj, so the operator keeps injecting it and no hand-written `--mmproj` arg is needed (the same mistake as `e652efbd4`).

## Verification
- Both referenced filenames checked against the live HF API, byte-for-byte including case: `…APEX-I-Balanced.gguf` and `mmproj-…APEX-F16.gguf` both resolve.
- `kubectl kustomize` builds; `--spec-type` appears exactly once in `llama-strix` and once in `llama-nvidia`, none in `llama-reviewer`.
- Verified from `git archive HEAD`, not the working tree.

## Rollout note

This is a ~27 GB pull. `rolloutPolicy.waitForIdle: true` with a 24h idle timeout means it will not interrupt in-flight work, but the model cache has previously trusted a partially downloaded file forever under `IfNotPresent` — if the pull is interrupted mid-flight again (as in #8859), delete the partial before retrying rather than letting it start dirty.