### PR TITLE
feat(foreman): raise coder maxOutputTokens to 20480

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-go.yaml
@@ -40,6 +40,7 @@ spec:
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3
+  maxOutputTokens: 20480
   stuckLoopDetection:
     # nvidia local model has a 131k context window; give more exploration room
     # before the edit-free abort, and cap context just under the window (the

--- a/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-node.yaml
@@ -34,6 +34,7 @@ spec:
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3
+  maxOutputTokens: 20480
   stuckLoopDetection:
     # nvidia local model has a 131k context window; give more exploration room
     # before the edit-free abort, and cap context just under the window (the

--- a/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-python.yaml
@@ -34,6 +34,7 @@ spec:
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3
+  maxOutputTokens: 20480
   stuckLoopDetection:
     # nvidia local model has a 131k context window; give more exploration room
     # before the edit-free abort, and cap context just under the window (the

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -34,6 +34,7 @@ spec:
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3
+  maxOutputTokens: 20480
   stuckLoopDetection:
     # nvidia local model has a 131k context window; give more exploration room
     # before the edit-free abort, and cap context just under the window (the

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -34,6 +34,7 @@ spec:
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3
+  maxOutputTokens: 20480
   stuckLoopDetection:
     # nvidia local model has a 131k context window; give more exploration room
     # before the edit-free abort, and cap context just under the window (the


### PR DESCRIPTION
## Summary
- Sets `maxOutputTokens: 20480` on the five coder agents that run against `llama-nvidia`.

## Why

`maxOutputTokens` was unset on every agent, so all of them ran the executor default of **8192** (`llmkube api/foreman/v1alpha1/agent_types.go:256`). Coder tasks fail roughly once a day or two with:

```
FOREMAN ERROR: turn 13: chat: after 3 retries:
oai: truncated tool_call.arguments JSON — unexpected end of JSON input
```

The generation ceiling is visible in the server's own history — 3162 generations, **none above 8192**:

```
7000-8000    70
8000-8100     9
8100-8192     3
8192+         0
```

A decision turn has to fit reasoning *and* the tool call inside one budget, and `llama-nvidia` sets `reasoningBudget: 16384` — twice the output cap. So a turn that reasons heavily and then emits a large `write_file` gets cut mid-JSON. `maxRetries: 3` cannot help, because a budget ceiling is deterministic and all three retries hit the identical wall; the CRD documents that retry as mitigation for llama.cpp #22072, where truncation is nondeterministic.

20480 clears the 16384 reasoning budget with ~4k left for the call.

## Sizing

Measured, not estimated. With `n_ctx_slot = 145152` after the 145k/512-ubatch roll:

```
145152 − 120000 (contextHardCap) = 25152 headroom  →  20480 fits with ~4.6k spare
```

`contextHardCap` is deliberately unchanged. litellm metrics over 7 days (27,967 requests through `llama-nvidia`) show typical context sits far below it — hourly average input tokens: p50 9,553, p90 16,438, p99 25,255, max 27,559. Even the heaviest hour averaged ~19% of the window, so there is no need to trade context away to buy output room.

## Scope

Only the agents that reach `llama-nvidia`: `coder`, `coder-node`, `coder-python`, `coder-revision` (cloud-proxy → `nvidia`) and `coder-go` (`inferenceServiceRef: llama-nvidia`).

Excluded: `coder-frontier` (MiniMax-M3-chat, different limits) and `reviewer`/`reviewer-fork` (different server, and verdicts are small).

## Rollout

Agent CRs are cached at startup, so this needs `kubectl rollout restart deployment/foreman-agent`. That kills in-process tasks — the agents with empty `execution` run in-process and the Deployment is `strategy: Recreate` with no drain (LLMKube#1438) — so it wants a quiet window.