### PR TITLE
Keep AutobrrNetworkUnmonitored out of triage

### DIFF
--- a/kubernetes/apps/base/observability/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -29,7 +29,7 @@ spec:
         repeatInterval: 12h
         matchers:
           - name: alertname
-            value: LiteLLMAuthOrQuotaFailures
+            value: LiteLLMAuthOrQuotaFailures|AutobrrNetworkUnmonitored
             matchType: "!~"
       - receiver: discord
     groupBy: ["alertname", "cluster", "job"]


### PR DESCRIPTION
## Summary
- Add `AutobrrNetworkUnmonitored` to the triage route's exclusion regex. It still reaches Discord unchanged.

## Why

The alert describes an application's own IRC connection state. The evidence available to triage never distinguishes a dropped connection from rejected credentials, so the narrative can only restate the alert and suggest reading autobrr's logs.

Both real firings classified `fix_location=unknown` with low confidence — the model correctly declined to claim a repository fix existed. That is the right answer, and it costs a model call and a channel message to reach it.

Worth noting the smaller self-hosted model classified this same alert `git` with **high** confidence and pointed at repository config it had not seen, which is one of the reasons that model comparison landed where it did.

## Verification
- `kubectl apply --dry-run=server` accepts the AlertmanagerConfig.
- Regex now `LiteLLMAuthOrQuotaFailures|AutobrrNetworkUnmonitored`; Alertmanager anchors matchers fully, so neither name matches anything broader.