### PR TITLE
fix(rook-ceph): bump mgr memory limit to 2Gi

### DIFF
--- a/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -75,6 +75,13 @@ spec:
             enabled: true
           - name: rook
             enabled: true
+      resources:
+        mgr:
+          limits:
+            memory: 2Gi
+          requests:
+            cpu: 500m
+            memory: 1Gi
       network:
         provider: host
         addressRanges:


### PR DESCRIPTION
mgr-b (the active manager) has been OOMKilled 15 times in 3 days. The `diskprediction_local` module loads ML models in-process and `insights` adds telemetry overhead — together they spike the active mgr past the Rook chart default 1Gi limit. mgr-a (standby) sits at 157Mi and never spikes.

Sets `cephClusterSpec.resources.mgr` (the CephCluster CRD top-level resources map keyed by daemon type — NOT `mgr.resources`, which the CRD schema does not expose under `spec.mgr`).

Validated: no immutable fields on the CephCluster CRD; `spec.resources` has `x-kubernetes-preserve-unknown-fields: true` and is fully mutable. Rook operator will reconcile and recreate the mgr Deployment pods with the new limit.