### PR TITLE
fix(pinchflat): move image to philmichel/pinchflat

### DIFF
--- a/kubernetes/apps/base/downloads/pinchflat/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/pinchflat/helmrelease.yaml
@@ -25,8 +25,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/communitymaintained/pinchflat
-              tag: 1.4.3@sha256:abc82f56d6d990997409d6de07d9f88779182dbd89e444f6ceea66dc25bfeb5a
+              repository: ghcr.io/philmichel/pinchflat
+              tag: 1.4.3@sha256:e0e0661e7b4248244e9b98d840ec5a0aa302d15636e28530feb2554322da47a3
             env:
               TZ: America/Edmonton
               TZ_DATA_DIR: /tmp/elixir_tz_data


### PR DESCRIPTION
The `ghcr.io/communitymaintained/pinchflat` GHCR package was deleted when the CommunityMaintained fork was abandoned on 2026-08-05. Renovate can no longer resolve it (`no-result`).

Switching to `ghcr.io/philmichel/pinchflat` — a snapshot rebuild of the exact same source (CommunityMaintained commit 2791d94, v1.4.3) published under a maintained namespace. Same version, same source, new digest. The release notes verify source authenticity against pre-wipe commit SHAs.

No DB migration needed — same v1.4.3 code, just re-hosted.