### PR TITLE
fix(openclaw): add comfy and memory-wiki to plugins allowlist

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -253,7 +253,7 @@ data:
         },
       },
       plugins: {
-        allow: ["discord", "lossless-claw", "memini", "searxng", "openclaw-better-gateway"],
+        allow: ["discord", "lossless-claw", "memini", "searxng", "openclaw-better-gateway", "comfy", "memory-wiki"],
         entries: {
           discord: { enabled: true },
           comfy: {


### PR DESCRIPTION
Both plugins have `enabled: true` config blocks but were missing from the `plugins.allow` array, causing them to be silently skipped and producing config warnings on startup.

- **comfy**: actively used for image generation (`imageGenerationModel: comfy/workflow`)
- **memory-wiki**: knowledge base for Miso and Saffron (bridge indexing, dashboards, backlinks)