### PR TITLE
fix(litellm): stop dropping response_format on the mac self-hosted member

### DIFF
--- a/kubernetes/apps/base/llm/litellm/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/configmap.yaml
@@ -16,6 +16,7 @@ data:
           max_input_tokens: 262144
           max_output_tokens: 16384
           supports_function_calling: true
+          supports_response_schema: true
           # Qwen3.6-35B-A3B is natively multimodal and the service loads its
           # mmproj, so this box serves images as well as text.
           supports_vision: true
@@ -36,6 +37,11 @@ data:
           max_input_tokens: 262144
           max_output_tokens: 16384
           supports_function_calling: true
+          # Paired with additional_drop_params below: this member silently strips
+          # response_format, so a json_schema request answered here returns prose.
+          # enable_pre_call_checks filters this deployment out for schema-bearing
+          # requests instead, leaving it in the pool for ordinary chat.
+          supports_response_schema: false
           supports_vision: true
         litellm_params:
           # Must match an id LM Studio actually serves — it 400s on an unknown

--- a/kubernetes/apps/base/llm/litellm/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/configmap.yaml
@@ -37,10 +37,6 @@ data:
           max_input_tokens: 262144
           max_output_tokens: 16384
           supports_function_calling: true
-          # Paired with additional_drop_params below: this member silently strips
-          # response_format, so a json_schema request answered here returns prose.
-          # enable_pre_call_checks filters this deployment out for schema-bearing
-          # requests instead, leaving it in the pool for ordinary chat.
           supports_response_schema: false
           supports_vision: true
         litellm_params:

--- a/kubernetes/apps/base/llm/litellm/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/configmap.yaml
@@ -16,7 +16,6 @@ data:
           max_input_tokens: 262144
           max_output_tokens: 16384
           supports_function_calling: true
-          supports_response_schema: true
           # Qwen3.6-35B-A3B is natively multimodal and the service loads its
           # mmproj, so this box serves images as well as text.
           supports_vision: true
@@ -37,7 +36,6 @@ data:
           max_input_tokens: 262144
           max_output_tokens: 16384
           supports_function_calling: true
-          supports_response_schema: false
           supports_vision: true
         litellm_params:
           # Must match an id LM Studio actually serves — it 400s on an unknown
@@ -49,7 +47,6 @@ data:
           max_parallel_requests: 1
           # Same order as the strix: simple-shuffle load-splits across both.
           order: 1
-          additional_drop_params: ["response_format"]
 
       # Mellum2-12B-A2.5B-Instruct on the strix: JetBrains' software-engineering
       # MoE (2.5B active), used as foreman's reviewer. Deliberately a different


### PR DESCRIPTION
Drops a stale arg. The mac member stripped `response_format`, so groomer requests routed there came back as prose instead of JSON. Both members serve the same build now and it honours json_schema fine — verified directly.