### PR TITLE
feat(foreman): route windowstead to a Godot-capable coder

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -47,6 +47,7 @@ spec:
               ESCALATION_LANE: frontier
               LANE_CODER_AGENTS: '{"*":"coder","frontier":"coder-frontier"}'
               BASE_CODER_AGENTS: '{"python":"coder-python","node":"coder-node","go":"coder-go","*":"coder"}'
+              REPO_CODER_AGENTS: '{"misospace/windowstead":"coder-godot"}'
               FOREMAN_NAMESPACE: llm
               MAX_IN_PROGRESS: "3"
               VERIFY_ENABLED: "false"

--- a/kubernetes/apps/base/llm/foreman/agents/coder-godot.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-godot.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Agent
+metadata:
+  name: coder-godot
+spec:
+  role: coder
+  provider: cloud-proxy
+  providerConfig:
+    baseURL: http://litellm.llm:4000/v1
+    model: nvidia
+    apiKeySecretRef:
+      name: foreman-agent
+      key: LITELLM_API_KEY
+  tools:
+    - read_file
+    - write_file
+    - str_replace
+    - grep
+    - bash
+    - fetch_issue
+    - submit_result
+  mcp:
+    enabled: true
+    servers:
+      - name: context7
+        transport: http
+        url: https://mcp.context7.com/mcp
+        headers:
+          - name: CONTEXT7_API_KEY
+            valueFrom:
+              name: foreman-agent
+              key: CONTEXT7_API_KEY
+  temperature: "0.2"
+  maxTurns: 160
+  maxRetries: 3
+  maxOutputTokens: 20480
+  stuckLoopDetection:
+    # nvidia local model has a 131k context window; give more exploration room
+    # before the edit-free abort, and cap context just under the window (the
+    # default hard cap of 140k sat above it).
+    editFreeTurnsLimit: 100
+    contextSoftCap: 100000
+    contextHardCap: 120000
+  requestTurnTimeoutSeconds: 1800
+  requestTimeoutSeconds: 7200
+  bashTimeoutSeconds: 60
+  execution:
+    activeDeadlineSeconds: 7200
+    image: ghcr.io/misospace/llmkube-coder-godot:0.9.14@sha256:a9d16e8988bf631aa823f6ec331cae137c54c06afc1090ffaa4159d6e85eb849
+    mode: Job
+    serviceAccountName: foreman-coder
+  requiredCapability:
+    roles:
+      - coder
+    accelerator: any
+  systemPrompt: |
+    You are a coding agent resolving a single GitHub issue in a Godot/GDScript project.
+    STEP 1 — read the issue yourself. Call fetch_issue(repo, issue) using the repo and
+    issue number in your payload, before reading code or editing anything. Do not work
+    from the payload prompt alone: on a retry it carries only the previous attempt's
+    feedback, and the original ask and acceptance criteria are NOT in it. If
+    fetch_issue fails, say so in your summary rather than guessing at the requirement.
+    Then read the relevant files and implement it fully — including
+    anything the issue marks optional, nice-to-have, or "also consider." Optional
+    means "the author would take it if you do it well," not "skip it." Decline an
+    optional item only when it is genuinely wrong (wrong layer, needs a human design
+    decision, or would balloon the diff past reviewable) and say so in your summary.
+    You are the primary coder on this repo, so a long run of minimal patches is how
+    tech debt accumulates: leave the code you touch better than you found it. While
+    you are already reading a file, fix the adjacent dead code, missing test, stale
+    comment, or duplicated block — and prefer the change that makes the next change
+    easier over the one that merely closes this issue.
+    Stay in the neighbourhood: improve what the issue names and what you had to touch
+    to fix it. Do not wander into unrelated subsystems or bundle a drive-by refactor
+    of files this issue has nothing to do with — that is scope creep, not stewardship.
+    Every behavior change needs a test (add a regression test for a bug). Match the
+    surrounding code style.
+    Make every file change with the write_file and str_replace tools only — never
+    edit files through the bash tool (no sed/echo/tee/heredocs/git apply). Edits
+    made via bash are invisible to the harness, count as no progress, and will trip
+    the stuck-loop detector. Do NOT run git add, git commit, or git push: leave your
+    changes uncommitted in the working tree — the harness stages, commits, DCO-signs,
+    and pushes them for you using the message you pass to submit_result. If you
+    commit the work yourself the harness sees a clean tree and records it as "no
+    changes."
+    Ground every external fact in something you can read: reference GitHub Actions
+    by version tag (uses: azure/setup-helm@v5) and NEVER write commit SHAs, URLs, or
+    version numbers from memory — if you cannot verify a value from the repo, leave a
+    TODO comment instead. This image ships Godot headless, so run the repo's own test
+    scripts via the bash tool before finishing — typically
+    `godot --headless --path . --script res://tests/<suite>.gd`, using the suites the
+    repo actually defines. Read a test helper before calling it: assert_eq takes
+    (actual, expected, name) and omitting the name is a parse error, which drops the
+    WHOLE file and silently stops every other test in it from running. A GDScript
+    parse error is not reported as a failing assertion, so check the output for
+    "Parse Error" as well as the summary line. When the change is complete and
+    verification passes, call submit_result with a concise commit message.
+    Do not declare an issue already resolved unless the code at the exact place the
+    issue names already does what the issue asks — open that file and confirm it. A
+    change in a different file, or a commit that touched something related, is NOT the
+    same fix. If you cannot show the issue's specific concern is already handled where
+    it lives, implement the fix: a false "already resolved" verdict leaves a real bug
+    unfixed, so when in doubt, do the work.
+    When the issue IS already handled where it lives, report it as a machine
+    outcome, not as a success: call submit_result with verdict NO-GO plus
+    extra.outcome = "ALREADY-RESOLVED" and extra.resolvedBy = a one-line evidence
+    string naming what resolved it (the file and what it already does, or the PR
+    or commit that did it). Foreman treats that pair specially — it skips
+    escalation, keeps the task out of the incomplete bucket, and marks dependent
+    steps Skipped.
+    Do NOT report it as GO. A GO that produces no diff is recorded as NO-CHANGES
+    and reads as a plain failure, which then burns the remaining retry attempts
+    re-discovering the same nothing.
+    If code cannot resolve this issue, say which kind of dead end it is instead of
+    attempting a guess: call submit_result with verdict NO-GO plus
+    extra.escalation = "DESIGN-DECISION" (a product or architecture call a human has
+    to make) or "NO-TECHNICAL-FIX" (nothing in this repo can fix it — wrong layer,
+    upstream bug, external service), and put the specific question or blocker in your
+    summary. The loop parks the issue for a human immediately on that signal, without
+    spending the remaining retry attempts re-deriving the same conclusion. Use these
+    only when you have read enough to be sure: a wrong escalation removes real work
+    from the queue. An epic that is merely large is not one of these — say so in your
+    summary and let a human split it.

--- a/kubernetes/apps/base/llm/foreman/kustomization.yaml
+++ b/kubernetes/apps/base/llm/foreman/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./agents/coder-frontier.yaml
   - ./agents/coder-revision.yaml
   - ./agents/coder-go.yaml
+  - ./agents/coder-godot.yaml
   - ./agents/gate-fork.yaml
   - ./agents/reviewer-fork.yaml
   - ./agents/gate.yaml


### PR DESCRIPTION
## Summary
- Adds a `coder-godot` Agent and routes `misospace/windowstead` to it via `REPO_CODER_AGENTS`.

## Why

The generic `coder` runs in-process in `foreman-agent` with no language runtime, so a coder on a GDScript repo cannot run the tests it writes. On windowstead#321 foreman deferred its self-gate (`"runtime missing in the coder image"`), the verify Job that deferral names is disabled fleet-wide, the reviewer said it "cannot verify" and returned GO, and the PR opened with a test file that **did not parse** — which drops the whole file, so the pre-existing `test_goal_reward` tests silently stopped running too. CI caught it; nothing before CI did.

`gateProfile.language` is an enum, so GDScript repos are `generic` and cannot be addressed by language — hence the per-repo map (misospace/foreman-dispatch-bridge#124).

## Verification

The published image was pulled and checked before pinning:

```
godot: 4.2.2.stable.official   agent: foreman-agent v0.9.14   uid: 65534:65534
```

and run against windowstead's real suite inside it, as the non-root uid:

```
=== test_runner summary: 97 passed, 0 failed ===
=== test_goal_reward summary: 187 passed, 0 failed ===
```

`kustomize` builds with the new Agent; `REPO_CODER_AGENTS` parses. Verified from `git archive HEAD`, not the working tree.

## Notes

- **Godot 4.2.2**, matching `godot-toolchain.json` in windowstead — the version its CI and gate both run. A coder on a different engine would report results CI cannot reproduce.
- **Pinned to LLMKube 0.9.14** to match the other three coders. 0.9.15 is out; Renovate should move them together rather than this one leading.
- The system prompt is adapted from `coder-node`: Godot test invocation instead of npm scripts, plus the specific trap from #321 — `assert_eq` takes `(actual, expected, name)`, and omitting the name is a parse error that fails the whole file without reporting a failing assertion.
- Escalation still loses the runtime: `coder-frontier` is cloud-proxy with no image, and the lane tier outranks the repo tier by design.