### PR TITLE
docs(foreman): rewrite both foreman docs to the post-consolidation state

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/README.md
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/README.md
@@ -1,183 +1,122 @@
 # Foreman ⇄ Dispatch coding loop
 
-Self-hosted, GitOps-driven coding automation: GitHub issues go in, reviewed PRs
-come out. Dispatch is the assignment layer (system of record, pull-only),
-LLMKube Foreman is the execution layer, and this bridge is the only thing that
-connects them.
+Self-hosted, GitOps-driven coding automation: GitHub issues go in, reviewed PRs come out.
+Dispatch is the assignment layer (system of record, pull-only), LLMKube Foreman is the
+execution layer, and this bridge is the only thing that connects them. Agents and their
+runtimes are documented in [`../../foreman/README.md`](../../foreman/README.md).
 
 ```
 GitHub issue
-    │  (dispatch scheduled sync, 15m)
+    │  dispatch scheduled sync (15m)
     ▼
-Dispatch cache ──► Groomer (vision 4B) ──► lane: local (ready) / backlog
-    │  (bridge CronJob, hourly at :30)
+Dispatch cache ──► Groomer (self-hosted 35B, json_schema-constrained) ──► lane: local / backlog
+    │  bridge CronJob (*/15)
     ▼
 Workload (this bridge) ──► AgenticTasks (foreman-operator)
     │
-    ├─ code    coder Agent (llama-nvidia)  — clone, fix, test, push branch
-    ├─ verify  gate Job (generic no-op)    — would run fmt/lint/test per language
-    └─ review  reviewer Agent (Ornith/strix) — read-only diff review, verdict
+    ├─ code    coder Agent (Job, polyglot image) — clone, fix, SELF-GATE, push branch
+    └─ review  reviewer Agent (Mellum2, read-only) — diff review, verdict
     │
-    ▼
-reviewed branch pushed ──► PR (manual until LLMKube#937) ──► repo CI + MiniMax review ──► human merge
+    ▼ review GO
+foreman opens the PR (summary grounded against the diff)
+    ──► repo CI + AI PR-review action ──► human merge ──► dispatch sync marks done
     │
-    └─ 3 failed attempts? ──► bridge re-lanes issue to frontier
-                              ──► coder-frontier (cloud-proxy → litellm → MiniMax-M3)
+    ├─ 3 failed attempts in local ──► bridge re-lanes to frontier (MiniMax-M3-chat)
+    └─ PR gets red CI / CHANGES_REQUESTED ──► pr-fix loop (below)
 ```
 
 ## Stage by stage
 
-### 1. Issue created → Dispatch picks it up
+**1. Sync.** Dispatch's in-app scheduler syncs tracked repos every 15m. Closed issues are
+forced to `status/done` on GitHub itself; `renovate`-labeled issues are excluded.
 
-Dispatch's **in-app scheduler** (`DISPATCH_SCHEDULER_ENABLED`, dispatch 0.5.16+)
-runs a GitHub **sync every 15m** against tracked repos — no external cronjobs
-(the old `dispatch-heartbeat` app is retired). Sync also enforces the terminal
-state: any **closed** issue is forced to `status/done` (labels reconciled on
-GitHub itself), so closed issues can never linger claimable.
+**2. Groom.** The hosted groomer runs on `self-hosted` (the strix/mac litellm pool). It
+sends a `json_schema` response_format — grammar-constrained decoding, with
+`validateGroomerOutput` as the net. Grooming is binary: ready → `local`, not → `backlog`.
+It never routes to `frontier`; tiering is decided by *failure*, not prediction. Both pool
+members must honour `response_format` — a member that strips it returns prose and the
+groomer fails validation (that was `additional_drop_params` on the mac, removed in #8898).
 
-Issues labeled `renovate` are excluded (`DISPATCH_EXCLUDED_LABELS`).
+**3. Claim → Workload.** This CronJob (`*/15`) retries failed Workloads first, then claims
+one `status/ready` issue per lane. The Workload carries the coder Agent
+(lane → repo → language precedence), the repo's `gateProfile`, and `issues: [<n>]` — which
+survives retries (bridge 0.6.20; losing it once collided every third attempt onto a shared
+`wl-<repo>-0` branch that retries force-pushed over).
 
-### 2. Groomed
+**4. Execute.** The operator decomposes into `code → review` (verify Jobs are off:
+`VERIFY_ENABLED=false`, repo CI is the verifier). The coder runs as its own Job on the
+polyglot image, runs the `gateProfile` commands as a **self-gate** before submitting, and
+pushes `foreman/<workload>/issue-<n>`. The reviewer (Mellum2 via the `reviewer` alias)
+reads the diff and issues a verdict; deterministic rails ground its claims (filesTouched,
+issueAsk, findings, and — since 0.9.15 — the PR-body summary against the diff).
 
-The **hosted groomer** runs every 10m on **`vision`** (Qwen3.5-9B via litellm →
-llama.cpp). Small model, made reliable by grammar: dispatch sends a
-`json_schema` response_format and llama.cpp grammar-constrains decoding — lane
-ids, label allowlist, and title/body length bounds are enforced at the token
-level (dispatch 0.5.17+), with `validateGroomerOutput` as the safety net and a
-`json_object` fallback if a backend rejects the schema.
+**5. PR.** On review GO, foreman opens the PR itself (`Fixes #<n>`, idempotent). The repo's
+own CI and the AI PR-review action take over; a human merges; the next sync marks the
+issue done.
 
-Grooming is intentionally **binary**: an issue is either ready → **`local`**
-lane, or not → **`backlog`**. The groomer never routes to `frontier` — model
-tiering is decided by *failure*, not by upfront prediction (a 4B is not asked
-to guess difficulty). It may also rewrite the title / enrich the body.
+## The PR-fix loop
 
-Lanes (`DISPATCH_LANE_CONFIG_JSON` on the dispatch HelmRelease):
+Dispatch's pr-followup sync (15m) watches PRs authored by `PR_FOLLOWUP_BOT_IDENTITIES`
+and enqueues a `PrFixQueueItem` on real signals only:
 
-| Lane | Claimable | Fed by | Executor |
-|---|---|---|---|
-| `local` | yes (default) | groomer | `coder` Agent → llama-nvidia |
-| `frontier` | yes (escalation) | bridge give-up path | `coder-frontier` Agent → litellm → MiniMax-M3 |
-| `backlog` | no | groomer | — (needs grooming) |
+- a `CHANGES_REQUESTED` review (dispatch trusts the verdict, not keyword-matching prose)
+- failing check runs
+- comments that carry **actionable signal or @-mention the bot** — chatter, CI tables,
+  and status posts are ignored regardless of author (dispatch 0.5.38; an image-publish
+  comment used to re-queue an item every sweep)
 
-### 3. Bridge creates a Workload
+The bridge drains `QUEUED` items into `prfix-<repo>-<pr>` Workloads: the coder checks out
+the existing `foreman/*` branch and amends it. `NORMAL` lane → `coder`; after
+`PR_FIX_MAX_ATTEMPTS` (3) → `ESCALATED` → `coder-frontier`; exhausted there → `BLOCKED`
+(a human). Guard rails, each earned by an outage:
 
-This CronJob (hourly at :30) does one tick:
-
-1. **Retry pass** — for every `Failed` Workload it created:
-   - attempt < `RETRY_MAX_ATTEMPTS` (3): delete + recreate at attempt+1 with
-     the *current* config.
-   - attempts exhausted, lane ≠ `frontier`: **escalate** — re-classify the
-     issue's lane to `frontier` (`model: bridge-escalation`), release the
-     claim, delete the dead Workload. The next tick re-claims it from
-     `frontier`.
-   - attempts exhausted in `frontier`: leave a Failed tombstone for a human.
-2. **Claim pass** — for each lane in `DISPATCH_LANES` (`local,frontier`), claim
-   one `status/ready` issue from the dispatch queue and create a `Workload`:
-   - `spec.repo` = the issue's own repo (per-task clone, foreman ≥ 0.8.25)
-   - `spec.coderAgentRef` from `LANE_CODER_AGENTS` (lane → Agent map)
-   - `spec.gateProfile` from `GATEPROFILE_MAP` (currently `generic` no-op for
-     every repo — see the HelmRelease comment for why)
-
-### 4. AgenticTasks execute
-
-The foreman-operator decomposes each Workload into `code → verify → review`
-AgenticTasks; the single shared **foreman-agent** (roles: worker, coder,
-verifier) claims and executes them serially:
-
-- **code** — coder Agent (llama-nvidia) clones the repo, makes the smallest
-  correct change, runs verification, commits as **Saffron**
-  (`commitAuthorName/Email` on the foreman HelmRelease) and pushes
-  `foreman/<workload>/issue-<n>`.
-- **verify** — gate Job submitted into this namespace (`--foreman-namespace=llm`,
-  postRenderer-patched until LLMKube#933 exposes it in the chart). The generic
-  profile makes it a no-op; real per-language gates wait on the upstream
-  self-gate fix (LLMKube#929).
-- **review** — Ornith (llama-strix), read-only tool whitelist, approves or
-  requests changes against the issue.
-
-A failed upstream task cascade-fails its dependents; the Workload goes
-`Failed` and re-enters the bridge's retry pass.
-
-### 5. PR opened — currently the missing hop
-
-**Foreman does not open PRs** ([LLMKube#937](https://github.com/defilantech/LLMKube/issues/937)):
-a fully-green Workload (`code GO -> verify GATE-PASS -> review GO`) ends as a
-pushed `foreman/<workload>/issue-<n>` branch, reviewed and unopened. Until the
-upstream feature lands (agent/operator opens the PR with the same token it
-pushed with, `Fixes #<n>` body, skip-if-exists), a human opens the PR from the
-branch. Once open, the external controls take over: the repo's own CI and the
-MiniMax PR-review action; a human merges.
-
-## Revisiting blocked PRs (request-changes, failed CI)
-
-**What works today — detection.** Dispatch's scheduler runs **pr-followup
-every 15m** (`POST /api/pr-followup/sync`). It scans tracked repos for PRs
-authored by `PR_FOLLOWUP_BOT_IDENTITIES` (= `itsmiso-ai`, so all foreman PRs)
-and files a `PrFixQueueItem` (deduped per repo+PR, with feedback + history)
-whenever it sees:
-
-- a `CHANGES_REQUESTED` review
-- failing check runs (`failure`, `cancelled`, `timed_out`, `action_required`)
-- new non-self comments on the PR
-- problematic merge states (`behind`, `dirty`, `unstable`)
-
-**What's missing — the actuator.** Nothing currently turns a `PrFixQueueItem`
-into Foreman work; the fix queue predates the bridge and was consumed by the
-openclaw workers. The intended completion of the loop:
-
-> The bridge grows a third pass: poll dispatch's PR-fix queue, and for each
-> `QUEUED` item create a **fix Workload** — same repo, `spec.intent` carrying
-> the review feedback / CI failure text, and the coder instructed to check out
-> the *existing* `foreman/*` branch and amend it (push --force-with-lease,
-> pending LLMKube#934) rather than start fresh. `FIXED`/`BLOCKED` status flows
-> back to the queue item. Escalation applies the same way: a fix that
-> exhausts retries re-lanes to `frontier` so MiniMax-M3 gets the harder
-> review feedback.
-
-Until that lands, blocked PRs surface in the dispatch UI (`/pr-followup`) and
-in the fix queue API, but a human (or an openclaw worker) has to push the
-actual fix.
+| Guard | Since | What it stops |
+|---|---|---|
+| No check runs ≠ passing CI | bridge 0.6.19 | GHA outages marked unverified fixes FIXED → force-push loops |
+| merged/closed PR → resolve, never retry | bridge 0.6.21 | 3 attempts + frontier escalation burned on already-merged PRs |
+| duplicate evidence keeps item status | dispatch 0.5.38 | an undismissed review resurrected resolved items every sweep |
 
 ## Failure & escalation semantics
 
 | Failure | Handled by | Behavior |
 |---|---|---|
-| Task flake (model error, transient infra) | bridge retry pass | delete + recreate Workload, ≤ 3 attempts |
-| Persistently failing issue in `local` | bridge escalation | re-lane → `frontier` → MiniMax-M3 coder |
-| Persistently failing issue in `frontier` | tombstone | Failed Workload kept for human triage |
-| Closed issue still claimable | dispatch sync | forced to `status/done` on GitHub every sync |
-| PR gets CHANGES_REQUESTED / red CI | pr-followup ingestion | `PrFixQueueItem` filed (actuator TBD, see above) |
+| Task flake | bridge retry pass | delete + recreate, ≤ 3 attempts, issue number preserved |
+| Closed issue mid-retry | closed-issue guard | skip, no attempt burned |
+| Coder declares a dead end | `DESIGN-DECISION` / `NO-TECHNICAL-FIX` | parked for a human without burning attempts |
+| Persistent failure in `local` | escalation | re-lane → `frontier` → MiniMax-M3-chat |
+| Persistent failure in `frontier` | tombstone | Failed Workload kept for human triage |
+| Red CI / changes requested on a PR | pr-fix loop | see above |
+
+A `Failed` Workload is **not proof the model failed** — audit before assuming. One night's
+four Failed workloads were: two merged-PR retries (bug), one closed-issue tombstone, and
+one real. The real one turned out to be a reviewer false-NO-GO with 1,104 lines of good
+tests stranded on the branch (LLMKube#1447).
 
 ## Config quick reference
 
-Everything is env on this HelmRelease unless noted:
+Env on this HelmRelease unless noted:
 
-| Env | Value | Meaning |
-|---|---|---|
-| `DISPATCH_URL` | `http://dispatch.llm:3000` | assignment layer |
-| `DISPATCH_AGENT_NAME` | `foreman-coder` | queue identity (dash, not slash) |
-| `DISPATCH_LANES` | `local,frontier` | lanes polled per tick |
-| `ESCALATION_LANE` | `frontier` | give-up target (bridge ≥ 0.4.0) |
-| `LANE_CODER_AGENTS` | `{"*":"coder","frontier":"coder-frontier"}` | lane → coder Agent |
-| `GATEPROFILE_MAP` | `{"*":{"language":"generic"}}` | no-op gate everywhere (for now) |
-| `RETRY_MAX_ATTEMPTS` | 3 (default) | attempts before escalate/tombstone |
-
-Related manifests: dispatch app + lanes (`../helmrelease.yaml`), foreman agents
-(`../../foreman/agents/`: `coder`, `coder-frontier`, `gate`, `reviewer`),
-foreman chart values incl. the `--foreman-namespace=llm` postRenderer
-(`../../foreman/helmrelease.yaml`), MiniMax-M3 + the rest of the model catalog
-(`../../litellm/app/configmap.yaml`).
+| Env | Meaning |
+|---|---|
+| `DISPATCH_LANES` = `local,frontier` | lanes polled per tick |
+| `ESCALATION_LANE` = `frontier` | give-up target |
+| `LANE_CODER_AGENTS` | lane → Agent; frontier → `coder-frontier` |
+| `REPO_CODER_AGENTS` | exact repo → Agent (prompt specialization; e.g. windowstead → `coder-godot`) |
+| `BASE_CODER_AGENTS` | gate-profile language → Agent |
+| `GATEPROFILE_MAP` | per-repo self-gate commands + gate image + `sourceExtensions` (feeds the reviewer's scope vouch). Digest pins inside this JSON are Renovate-managed via a custom regex manager |
+| `VERIFY_ENABLED` = `false` | no clean-room verify Jobs; coder self-gate + repo CI verify |
+| `PR_FIX_ENABLED` / `PR_FIX_MAX_ATTEMPTS` / `PR_FIX_LANE_AGENTS` | the pr-fix loop above |
+| `MAX_IN_PROGRESS` | cap on concurrently-worked issues (0 = uncapped) |
 
 ## Known upstream issues
 
-- [LLMKube#933](https://github.com/defilantech/LLMKube/issues/933) — chart
-  doesn't expose the gate-Job namespace (postRenderer workaround here).
-- [LLMKube#934](https://github.com/defilantech/LLMKube/issues/934) — coder
-  push isn't idempotent across Workload re-runs (stale `foreman/*` branch ⇒
-  non-fast-forward NO-GO); also "push to fork" wording.
-- [LLMKube#935](https://github.com/defilantech/LLMKube/issues/935) — empty
-  assistant message poisons the loop history (`400: Assistant message must
-  contain either 'content' or 'tool_calls'`).
-- [LLMKube#929](https://github.com/defilantech/LLMKube/issues/929) — coder
-  self-gate should defer to a Job when the runtime is missing (blocks real
-  per-language gate profiles).
+- [LLMKube#1438](https://github.com/defilantech/LLMKube/issues/1438) — no drain-before-roll
+  for `foreman-agent`; restarts kill in-process (reviewer/gate) tasks. Coders are Job-based
+  and unaffected.
+- [LLMKube#1447](https://github.com/defilantech/LLMKube/issues/1447) — reviewer
+  scope-overlap can false-NO-GO test-coverage issues (diff touches `X.test.ts`, issue
+  names `X.ts`).
+- [LLMKube#1434](https://github.com/defilantech/LLMKube/issues/1434) — coders cannot read
+  the PR they are asked to fix (`fetch_pull_request` tool).
+- [LLMKube#1454](https://github.com/defilantech/LLMKube/issues/1454) — a reviewer that says
+  "cannot verify" can still return GO.

--- a/kubernetes/apps/base/llm/foreman/README.md
+++ b/kubernetes/apps/base/llm/foreman/README.md
@@ -1,91 +1,79 @@
 # Foreman
 
 Optional [LLMKube](https://llmkube.com/docs/foreman) add-on control plane that dispatches
-agentic coder/verifier/reviewer workloads across the fleet, running in the `llm` namespace.
+agentic coder/reviewer workloads across the fleet, running in the `llm` namespace.
 Depends on the `llmkube` core operator (its Flux Kustomization sets `dependsOn: llmkube`).
 
 This folder installs the operator (the `foreman` Helm chart, which ships the `Workload`,
 `AgenticTask`, `Agent`, and `FleetNode` CRDs) **and** the `Agent` CRs under `agents/`.
 `FleetNode`s register themselves at runtime, and per-issue `Workload`s are materialized by
 the [foreman-dispatch-bridge](https://github.com/misospace/foreman-dispatch-bridge) CronJob —
-both are ephemeral runtime state and are not committed.
+both are ephemeral runtime state and are not committed. The loop itself (dataflow, lanes,
+retry/escalation, PR fixes) is documented in
+[`../dispatch/foreman-dispatch-bridge/README.md`](../dispatch/foreman-dispatch-bridge/README.md);
+this file covers the agents and how they get their runtimes.
 
 Chart: `oci://ghcr.io/defilantech/charts/foreman`, pinned in `ocirepository.yaml`.
 
-## How an agent gets its runtime
+## One polyglot coder image
 
-This is the part that is easy to get wrong, because two different mechanisms decide it.
+Every coder agent runs the same image: `ghcr.io/misospace/llmkube-coder` — Python 3.14,
+Node, Go 1.26, Godot 4.7.1 (headless), and Elixir 1.18/OTP 27, plus each language's
+linters (~475 MB compressed, amd64 only; the fleet is amd64). Rootless coders cannot
+install anything at run time, so every runtime is baked in — the replacement for the old
+root-and-apt-get Saffron pods.
 
-**`spec.execution.image` decides where the agent runs.**
+This replaced four per-language images in 2026-08 (`llmkube-coder-{python,node,go,godot}`,
+retired in misospace/llmkube-images#165). The Python/Node/Go ones were strict subsets of
+the polyglot base, and `llmkube-coder-go` was *larger* than the base that already contained
+Go. The published packages still exist on ghcr for old digest pins; nothing builds them.
+
+**Rule of thumb:** stay on one image until a runtime is huge or conflicting (JVM, CUDA,
+Android SDK class), and split only that one out.
+
+## How an agent executes
+
+`spec.execution` decides where an agent runs:
 
 | `execution` | Runs | Consequence |
 |---|---|---|
-| empty | in-process inside the `foreman-agent` pods | uses the Deployment's image; **dies on any `foreman-agent` restart** |
-| `image: …` | its own Job, one per task | survives restarts; gets exactly that image |
+| `image: … / mode: Job` | one Job per task | survives `foreman-agent` restarts |
+| empty | in-process inside the `foreman-agent` pods | dies on any restart |
 
-Today `coder-go`, `coder-node`, `coder-python` (and `coder-godot`) run as Jobs. Everything
-else — `coder`, `coder-frontier`, `coder-revision`, `gate*`, `reviewer*` — runs in-process
-and therefore uses whatever image the `foreman-agent` Deployment runs, currently
-`ghcr.io/misospace/llmkube-coder` (Python 3.14 + Node 22 + Go 1.26, "the polyglot image").
+All seven coders (`coder`, `coder-frontier`, `coder-revision`, `coder-python`,
+`coder-node`, `coder-go`, `coder-godot`) are Job-based on the polyglot image. Only the
+gates and reviewers are in-process — they need no language runtime, and their tasks are
+short enough that a restart losing one is cheap.
 
-`coder-frontier` is a separate **agent**, not a separate image: it differs only by model
-(`MiniMax-M3-chat` vs `nvidia`). It inherits the polyglot image like every other in-process
-agent.
+The per-language agents survive as **prompt specializations of the same image**, not
+different runtimes: `coder-godot`'s prompt carries GDScript traps (`assert_eq` arity is a
+parse error that silently drops the whole test file), `coder-python`'s carries Python
+gate specifics, and so on. `coder-frontier` differs only by model (`MiniMax-M3-chat`).
 
-**The bridge decides which agent a repo gets**, in this precedence order:
+The bridge picks the agent per issue: `LANE_CODER_AGENTS` (escalation) →
+`REPO_CODER_AGENTS` (exact repo — exists because `gateProfile.language` is an enum, so
+GDScript/Elixir repos are both `generic` and indistinguishable by language) →
+`BASE_CODER_AGENTS` (language) → wildcards.
 
-1. `LANE_CODER_AGENTS` — lane, e.g. the frontier escalation tier
-2. `REPO_CODER_AGENTS` — exact repo full name
-3. `BASE_CODER_AGENTS` — the repo's gate-profile language
-4. wildcards, then the default `coder`
+## Why runtimes-in-the-coder matters
 
-The repo tier exists because `Workload.spec.gateProfile.language` is an **enum** —
-`go|python|rust|node|generic` — so every repo outside those presets is `generic` and cannot
-be told apart by language. windowstead (GDScript) and pinchflat (Elixir) are both `generic`
-and need different runtimes.
-
-## Why this matters
-
-A coder without its repo's runtime cannot run the tests it just wrote. On
-misospace/windowstead#321 foreman deferred its self-gate with `runtime missing in the coder
-image`, deferring to a clean-room verify Job that is **disabled fleet-wide**
-(`VERIFY_ENABLED=false`; repo CI is the verifier instead). The reviewer then returned GO
-while stating it could not verify, and the PR opened with a test file that did not parse —
-which drops the whole file, so the pre-existing tests in it silently stopped running too.
-CI caught it. Nothing before CI did.
-
-Escalation reintroduces the same gap: the lane tier outranks the repo tier, and
-`coder-frontier` is in-process, so an escalated GDScript or Elixir task is back on the
-polyglot image with no engine.
-
-## Per-language images vs one polyglot image
-
-Measured 2026-08-08, compressed, amd64:
-
-| Image | Size | Contents |
-|---|---|---|
-| `llmkube-coder` (polyglot) | 265 MB | python3, node, go, ruff, black, flake8, yamllint, eslint, gofmt |
-| `llmkube-coder-python` | 96 MB | python3 + the Python linters — a strict **subset** |
-| `llmkube-coder-node` | 180 MB | node + JS linters — a strict **subset** |
-| `llmkube-coder-go` | 388 MB | go only — **larger than the polyglot image that already contains Go** |
-| `llmkube-coder-godot` | 112 MB | Godot 4.2.2 headless — genuinely additive |
-
-The per-language images for Python/Node/Go add **no capability** the polyglot image lacks;
-they are smaller, and `coder-go` is not even that. The images that earn their existence are
-the ones carrying a runtime the polyglot image does not have.
-
-Consolidating the three onto the polyglot image, and adding Godot/Elixir to it, would put
-the base near ~377 MB — still smaller than `llmkube-coder-go` is today — and would fix the
-escalation gap for free, since every in-process agent would then have every runtime. The
-cost is that all three `foreman-agent` replicas pull it.
+The coder **self-gate runs the repo's `GATEPROFILE_MAP` commands** before submitting.
+With `VERIFY_ENABLED=false` (clean-room verify Jobs are off; repo CI is the verifier),
+the self-gate is the only pre-PR test execution — and it silently no-ops when the
+runtime is missing (`self-gate-deferred`, deferring to a backstop that is disabled).
+That is how misospace/windowstead#321 shipped a test file that did not parse: no Godot
+in the coder, no gate Job, reviewer GO'd anyway (LLMKube#1454). With the polyglot image
+the self-gate has every runtime, so the gate profiles do their job inside the coder.
 
 ## Gotchas
 
-- **Agent CRs are cached at startup.** Editing a `systemPrompt` or `maxOutputTokens` needs
-  `kubectl rollout restart deployment/foreman-agent`, which kills in-flight in-process work
-  (the Deployment is `Recreate`, with no drain — LLMKube#1438).
-- **Coder images are digest-pinned** because the CRD has no `imagePullPolicy` and the tag is
-  mutable. Renovate bumps the digests.
-- **`gateProfile` without a verifier is decorative.** With `VERIFY_ENABLED=false` no gate Job
-  is created, so the profile's commands never run; they exist for the coder's own self-gate
-  and for whenever verification is re-enabled.
+- **Agent CRs are cached at startup.** Editing a `systemPrompt` or `maxOutputTokens`
+  needs `kubectl rollout restart deployment/foreman-agent`. Since coders are Job-based,
+  a restart now only interrupts in-flight reviews/gates (LLMKube#1438 tracks a drain).
+- **Images are digest-pinned** (no `imagePullPolicy` in the CRD; tags are mutable).
+  Renovate bumps digests — including inside `GATEPROFILE_MAP`'s JSON, via a custom
+  regex manager in `.renovate/customManagers.json5` (the flux manager cannot see refs
+  embedded in a JSON string; the godot-gate pin sat stale at 4.2.2 because of this).
+- **Godot versions are pinned in three places** that must agree: the polyglot image, the
+  `godot-gate` pin in `GATEPROFILE_MAP`, and each Godot repo's own `godot-toolchain.json`
+  (which its CI reads). All three are 4.7.1 as of 2026-08.

--- a/kubernetes/apps/base/llm/foreman/README.md
+++ b/kubernetes/apps/base/llm/foreman/README.md
@@ -4,12 +4,88 @@ Optional [LLMKube](https://llmkube.com/docs/foreman) add-on control plane that d
 agentic coder/verifier/reviewer workloads across the fleet, running in the `llm` namespace.
 Depends on the `llmkube` core operator (its Flux Kustomization sets `dependsOn: llmkube`).
 
-This folder installs the **operator only** (the `foreman` Helm chart, which ships the
-`Workload`, `AgenticTask`, `Agent`, and `FleetNode` CRDs). The cluster-wide CRs that drive
-it — `FleetNode` (hardware registration) and `Agent` (role definitions), plus per-issue
-`Workload`s materialized at runtime by the
-[foreman-dispatch-bridge](https://github.com/joryirving/containers/tree/main/apps/foreman-dispatch-bridge)
-CronJob — are added separately and are **not** committed here (Workloads are ephemeral
-runtime state).
+This folder installs the operator (the `foreman` Helm chart, which ships the `Workload`,
+`AgenticTask`, `Agent`, and `FleetNode` CRDs) **and** the `Agent` CRs under `agents/`.
+`FleetNode`s register themselves at runtime, and per-issue `Workload`s are materialized by
+the [foreman-dispatch-bridge](https://github.com/misospace/foreman-dispatch-bridge) CronJob —
+both are ephemeral runtime state and are not committed.
 
 Chart: `oci://ghcr.io/defilantech/charts/foreman`, pinned in `ocirepository.yaml`.
+
+## How an agent gets its runtime
+
+This is the part that is easy to get wrong, because two different mechanisms decide it.
+
+**`spec.execution.image` decides where the agent runs.**
+
+| `execution` | Runs | Consequence |
+|---|---|---|
+| empty | in-process inside the `foreman-agent` pods | uses the Deployment's image; **dies on any `foreman-agent` restart** |
+| `image: …` | its own Job, one per task | survives restarts; gets exactly that image |
+
+Today `coder-go`, `coder-node`, `coder-python` (and `coder-godot`) run as Jobs. Everything
+else — `coder`, `coder-frontier`, `coder-revision`, `gate*`, `reviewer*` — runs in-process
+and therefore uses whatever image the `foreman-agent` Deployment runs, currently
+`ghcr.io/misospace/llmkube-coder` (Python 3.14 + Node 22 + Go 1.26, "the polyglot image").
+
+`coder-frontier` is a separate **agent**, not a separate image: it differs only by model
+(`MiniMax-M3-chat` vs `nvidia`). It inherits the polyglot image like every other in-process
+agent.
+
+**The bridge decides which agent a repo gets**, in this precedence order:
+
+1. `LANE_CODER_AGENTS` — lane, e.g. the frontier escalation tier
+2. `REPO_CODER_AGENTS` — exact repo full name
+3. `BASE_CODER_AGENTS` — the repo's gate-profile language
+4. wildcards, then the default `coder`
+
+The repo tier exists because `Workload.spec.gateProfile.language` is an **enum** —
+`go|python|rust|node|generic` — so every repo outside those presets is `generic` and cannot
+be told apart by language. windowstead (GDScript) and pinchflat (Elixir) are both `generic`
+and need different runtimes.
+
+## Why this matters
+
+A coder without its repo's runtime cannot run the tests it just wrote. On
+misospace/windowstead#321 foreman deferred its self-gate with `runtime missing in the coder
+image`, deferring to a clean-room verify Job that is **disabled fleet-wide**
+(`VERIFY_ENABLED=false`; repo CI is the verifier instead). The reviewer then returned GO
+while stating it could not verify, and the PR opened with a test file that did not parse —
+which drops the whole file, so the pre-existing tests in it silently stopped running too.
+CI caught it. Nothing before CI did.
+
+Escalation reintroduces the same gap: the lane tier outranks the repo tier, and
+`coder-frontier` is in-process, so an escalated GDScript or Elixir task is back on the
+polyglot image with no engine.
+
+## Per-language images vs one polyglot image
+
+Measured 2026-08-08, compressed, amd64:
+
+| Image | Size | Contents |
+|---|---|---|
+| `llmkube-coder` (polyglot) | 265 MB | python3, node, go, ruff, black, flake8, yamllint, eslint, gofmt |
+| `llmkube-coder-python` | 96 MB | python3 + the Python linters — a strict **subset** |
+| `llmkube-coder-node` | 180 MB | node + JS linters — a strict **subset** |
+| `llmkube-coder-go` | 388 MB | go only — **larger than the polyglot image that already contains Go** |
+| `llmkube-coder-godot` | 112 MB | Godot 4.2.2 headless — genuinely additive |
+
+The per-language images for Python/Node/Go add **no capability** the polyglot image lacks;
+they are smaller, and `coder-go` is not even that. The images that earn their existence are
+the ones carrying a runtime the polyglot image does not have.
+
+Consolidating the three onto the polyglot image, and adding Godot/Elixir to it, would put
+the base near ~377 MB — still smaller than `llmkube-coder-go` is today — and would fix the
+escalation gap for free, since every in-process agent would then have every runtime. The
+cost is that all three `foreman-agent` replicas pull it.
+
+## Gotchas
+
+- **Agent CRs are cached at startup.** Editing a `systemPrompt` or `maxOutputTokens` needs
+  `kubectl rollout restart deployment/foreman-agent`, which kills in-flight in-process work
+  (the Deployment is `Recreate`, with no drain — LLMKube#1438).
+- **Coder images are digest-pinned** because the CRD has no `imagePullPolicy` and the tag is
+  mutable. Renovate bumps the digests.
+- **`gateProfile` without a verifier is decorative.** With `VERIFY_ENABLED=false` no gate Job
+  is created, so the profile's commands never run; they exist for the coder's own self-gate
+  and for whenever verification is re-enabled.


### PR DESCRIPTION
Rewrites both foreman docs to the post-consolidation state, split by scope:

- **`foreman/README.md`** — the agents: the single polyglot coder image (what it replaced and why, with measured sizes), Job-based vs in-process execution, the lane→repo→language routing, why runtimes-in-the-coder re-arms the self-gates, and the gotchas (Agent CR caching, digest pins, the three places a Godot version lives).
- **`dispatch/foreman-dispatch-bridge/README.md`** — the loop: dataflow diagram, stage-by-stage, the pr-fix loop with its guard rails (each mapped to the release that earned it), failure/escalation semantics, config reference, and the four open upstream issues.

The old bridge README described ~early July: groomer on the retired `vision` alias, reviewer on Ornith, "Foreman does not open PRs", "the pr-fix actuator is missing", generic no-op gates everywhere, and five cited upstream issues that are all closed. Every claim in the rewrite was verified against the live cluster or the repo that ships it.