### PR TITLE
feat(foreman): give coders and reviewers the fetch_pull_request tool

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -19,6 +19,7 @@ spec:
     - grep
     - bash
     - fetch_issue
+    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -68,6 +69,10 @@ spec:
     from the payload prompt alone: on a retry it carries only the previous attempt's
     feedback, and the original ask and acceptance criteria are NOT in it. If
     fetch_issue fails, say so in your summary rather than guessing at the requirement.
+    On a PR-fix task — your payload names a pull request instead of an issue — call
+    fetch_pull_request(repo, number) the same way: its review comments and check runs
+    are the scope anchor, and a verbatim reviewer sentence is the right citation for
+    what to change.
     Then read the relevant files and implement it fully — including
     anything the issue marks optional, nice-to-have, or "also consider." Optional
     means "the author would take it if you do it well," not "skip it." Decline an

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -19,6 +19,7 @@ spec:
     - grep
     - bash
     - fetch_issue
+    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -62,7 +63,10 @@ spec:
     checked out on its branch — do not start over; read the existing diff against the
     base branch first, then apply the reviewer's findings as targeted edits on top of it.
     Call fetch_issue(repo, issue) before you start: the reviewer feedback tells you what
-    to CHANGE, the issue tells you what DONE means, and the two are not the same. A
+    to CHANGE, the issue tells you what DONE means, and the two are not the same. If a
+    pull request already exists for this branch, call fetch_pull_request(repo, number)
+    too: the live review thread and check runs are the authoritative version of that
+    feedback. A
     finding is a derived artifact — satisfying every finding while drifting from the
     issue's actual ask still fails review. Read both, then address every finding, and
     where a finding cites a file or symbol as the source of truth, read that file and

--- a/kubernetes/apps/base/llm/foreman/agents/coder-strix.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-strix.yaml
@@ -19,6 +19,7 @@ spec:
     - grep
     - bash
     - fetch_issue
+    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -66,6 +67,10 @@ spec:
     from the payload prompt alone: on a retry it carries only the previous attempt's
     feedback, and the original ask and acceptance criteria are NOT in it. If
     fetch_issue fails, say so in your summary rather than guessing at the requirement.
+    On a PR-fix task — your payload names a pull request instead of an issue — call
+    fetch_pull_request(repo, number) the same way: its review comments and check runs
+    are the scope anchor, and a verbatim reviewer sentence is the right citation for
+    what to change.
     Then read the relevant files and implement it fully — including
     anything the issue marks optional, nice-to-have, or "also consider." Optional
     means "the author would take it if you do it well," not "skip it." Decline an

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -19,6 +19,7 @@ spec:
     - grep
     - bash
     - fetch_issue
+    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -66,6 +67,10 @@ spec:
     from the payload prompt alone: on a retry it carries only the previous attempt's
     feedback, and the original ask and acceptance criteria are NOT in it. If
     fetch_issue fails, say so in your summary rather than guessing at the requirement.
+    On a PR-fix task — your payload names a pull request instead of an issue — call
+    fetch_pull_request(repo, number) the same way: its review comments and check runs
+    are the scope anchor, and a verbatim reviewer sentence is the right citation for
+    what to change.
     Then read the relevant files and implement it fully — including
     anything the issue marks optional, nice-to-have, or "also consider." Optional
     means "the author would take it if you do it well," not "skip it." Decline an

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
@@ -21,6 +21,7 @@ spec:
     - grep
     - bash
     - fetch_issue
+    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -54,7 +55,10 @@ spec:
       1. bash("git fetch origin <branch>:refs/remotes/origin/<branch> && git checkout origin/<branch>")
          using the branch from your payload. If it fails, call submit_result with
          verdict ERROR naming the fetch failure — do NOT guess the diff.
-      2. fetch_issue(repo, issue) to read the issue title/body/labels (your scope anchor).
+      2. fetch_issue(repo, issue) to read the issue title/body/labels (your scope anchor). If the
+         payload also names a pull request, fetch_pull_request(repo, number) for its
+         reviews, review_comments, and check_runs — prior feedback your verdict
+         should account for.
       3. bash("git log -1 --pretty=full HEAD") for the commit message.
       4. bash("git diff --stat main...HEAD") then bash("git diff main...HEAD") for the
          file list and full diff (if huge, git show --stat + targeted read_file).

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -19,6 +19,7 @@ spec:
     - grep
     - bash
     - fetch_issue
+    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -52,7 +53,10 @@ spec:
       1. bash("git fetch origin <branch>:refs/remotes/origin/<branch> && git checkout origin/<branch>")
          using the branch from your payload. If it fails, call submit_result with
          verdict ERROR naming the fetch failure — do NOT guess the diff.
-      2. fetch_issue(repo, issue) to read the issue title/body/labels (your scope anchor).
+      2. fetch_issue(repo, issue) to read the issue title/body/labels (your scope anchor). If the
+         payload also names a pull request, fetch_pull_request(repo, number) for its
+         reviews, review_comments, and check_runs — prior feedback your verdict
+         should account for.
       3. bash("git log -1 --pretty=full HEAD") for the commit message.
       4. bash("git diff --stat main...HEAD") then bash("git diff main...HEAD") for the
          file list and full diff (if huge, git show --stat + targeted read_file).


### PR DESCRIPTION
## Summary
- Adds `fetch_pull_request` (new in foreman 0.9.16 — the LLMKube#1434 ask) to the tools list of all four coders and both reviewers, with a one-line prompt hint each: coders treat the PR review thread as the scope anchor on PR-fix tasks, reviewers fold prior PR feedback into their verdict.

## Notes
- Coders are Job-based and read Agent CRs fresh per task; reviewers are in-process, so this needs the usual `kubectl rollout restart deployment/foreman-agent` after merge. No reviews/gates in flight matters less now — I'll pick a quiet window.