### PR TITLE
revert: fetch_pull_request Agent tooling until upstream fixes the webhook catalog

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -19,7 +19,6 @@ spec:
     - grep
     - bash
     - fetch_issue
-    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -69,10 +68,6 @@ spec:
     from the payload prompt alone: on a retry it carries only the previous attempt's
     feedback, and the original ask and acceptance criteria are NOT in it. If
     fetch_issue fails, say so in your summary rather than guessing at the requirement.
-    On a PR-fix task — your payload names a pull request instead of an issue — call
-    fetch_pull_request(repo, number) the same way: its review comments and check runs
-    are the scope anchor, and a verbatim reviewer sentence is the right citation for
-    what to change.
     Then read the relevant files and implement it fully — including
     anything the issue marks optional, nice-to-have, or "also consider." Optional
     means "the author would take it if you do it well," not "skip it." Decline an

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -19,7 +19,6 @@ spec:
     - grep
     - bash
     - fetch_issue
-    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -63,10 +62,7 @@ spec:
     checked out on its branch — do not start over; read the existing diff against the
     base branch first, then apply the reviewer's findings as targeted edits on top of it.
     Call fetch_issue(repo, issue) before you start: the reviewer feedback tells you what
-    to CHANGE, the issue tells you what DONE means, and the two are not the same. If a
-    pull request already exists for this branch, call fetch_pull_request(repo, number)
-    too: the live review thread and check runs are the authoritative version of that
-    feedback. A
+    to CHANGE, the issue tells you what DONE means, and the two are not the same. A
     finding is a derived artifact — satisfying every finding while drifting from the
     issue's actual ask still fails review. Read both, then address every finding, and
     where a finding cites a file or symbol as the source of truth, read that file and

--- a/kubernetes/apps/base/llm/foreman/agents/coder-strix.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-strix.yaml
@@ -19,7 +19,6 @@ spec:
     - grep
     - bash
     - fetch_issue
-    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -67,10 +66,6 @@ spec:
     from the payload prompt alone: on a retry it carries only the previous attempt's
     feedback, and the original ask and acceptance criteria are NOT in it. If
     fetch_issue fails, say so in your summary rather than guessing at the requirement.
-    On a PR-fix task — your payload names a pull request instead of an issue — call
-    fetch_pull_request(repo, number) the same way: its review comments and check runs
-    are the scope anchor, and a verbatim reviewer sentence is the right citation for
-    what to change.
     Then read the relevant files and implement it fully — including
     anything the issue marks optional, nice-to-have, or "also consider." Optional
     means "the author would take it if you do it well," not "skip it." Decline an

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -19,7 +19,6 @@ spec:
     - grep
     - bash
     - fetch_issue
-    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -67,10 +66,6 @@ spec:
     from the payload prompt alone: on a retry it carries only the previous attempt's
     feedback, and the original ask and acceptance criteria are NOT in it. If
     fetch_issue fails, say so in your summary rather than guessing at the requirement.
-    On a PR-fix task — your payload names a pull request instead of an issue — call
-    fetch_pull_request(repo, number) the same way: its review comments and check runs
-    are the scope anchor, and a verbatim reviewer sentence is the right citation for
-    what to change.
     Then read the relevant files and implement it fully — including
     anything the issue marks optional, nice-to-have, or "also consider." Optional
     means "the author would take it if you do it well," not "skip it." Decline an

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
@@ -21,7 +21,6 @@ spec:
     - grep
     - bash
     - fetch_issue
-    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -55,10 +54,7 @@ spec:
       1. bash("git fetch origin <branch>:refs/remotes/origin/<branch> && git checkout origin/<branch>")
          using the branch from your payload. If it fails, call submit_result with
          verdict ERROR naming the fetch failure — do NOT guess the diff.
-      2. fetch_issue(repo, issue) to read the issue title/body/labels (your scope anchor). If the
-         payload also names a pull request, fetch_pull_request(repo, number) for its
-         reviews, review_comments, and check_runs — prior feedback your verdict
-         should account for.
+      2. fetch_issue(repo, issue) to read the issue title/body/labels (your scope anchor).
       3. bash("git log -1 --pretty=full HEAD") for the commit message.
       4. bash("git diff --stat main...HEAD") then bash("git diff main...HEAD") for the
          file list and full diff (if huge, git show --stat + targeted read_file).

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -19,7 +19,6 @@ spec:
     - grep
     - bash
     - fetch_issue
-    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -53,10 +52,7 @@ spec:
       1. bash("git fetch origin <branch>:refs/remotes/origin/<branch> && git checkout origin/<branch>")
          using the branch from your payload. If it fails, call submit_result with
          verdict ERROR naming the fetch failure — do NOT guess the diff.
-      2. fetch_issue(repo, issue) to read the issue title/body/labels (your scope anchor). If the
-         payload also names a pull request, fetch_pull_request(repo, number) for its
-         reviews, review_comments, and check_runs — prior feedback your verdict
-         should account for.
+      2. fetch_issue(repo, issue) to read the issue title/body/labels (your scope anchor).
       3. bash("git log -1 --pretty=full HEAD") for the commit message.
       4. bash("git diff --stat main...HEAD") then bash("git diff main...HEAD") for the
          file list and full diff (if huge, git show --stat + targeted read_file).


### PR DESCRIPTION
## Summary
- Reverts #8949. Foreman 0.9.16 registers the new `fetch_pull_request` tool in the agent binary but forgot it in `catalog.CanonicalToolNames`, the allow-list the Agent admission webhook validates `spec.tools` against — so the KS dry-run fails and no Agent CR can enable the tool. Upstream issue incoming; re-apply once a fixed release ships.

## Verification
- `foreman` Kustomization error: `spec.tools[6]: Unsupported value: "fetch_pull_request"`