### PR TITLE
Tell alert-triage which cluster it serves

### DIFF
--- a/kubernetes/apps/base/observability/alert-triage/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/alert-triage/helmrelease.yaml
@@ -33,6 +33,7 @@ spec:
               repository: ghcr.io/misospace/alert-triage
               tag: 0.1.9@sha256:89e3420169a7d62cc409df4b546aa6bf134fa850a276b2430fa82492f3d6e90c
             env:
+              CLUSTER: ${CLUSTER}
               LITELLM_URL: ${LITELLM_URL:=http://litellm.llm:4000/v1}
               MODEL: dsv4f
               HISTORY_PATH: /data/history.jsonl


### PR DESCRIPTION
## Summary
- Set `CLUSTER` on the alert-triage container. `${CLUSTER}` is already substituted per cluster and propagated to every child Kustomization, so one line in the shared base resolves to `main` and `utility` respectively.

## Why

Both instances currently log this at startup:

```
CLUSTER is unset: every group is enriched against this API server.
Set it if this instance receives alerts from more than one cluster.
```

Unset is harmless today — each instance only receives its own cluster's alerts, and the guard from misospace/alert-triage#33 fails open — but:

- Alerts carrying no `cluster` label (Flux's kustomize-controller ones, for example) are attributed to `default` in the digest header and title.
- That same `default` lands in `Group.Signature()`, so unlabelled alerts from different clusters would share a history key if state were ever shared.

Setting it makes the guard correct rather than merely harmless, and is a prerequisite for misospace/alert-triage#39.

## Verification
- Values parse; `CLUSTER: ${CLUSTER}` sits alongside the existing `LITELLM_URL` substitution, which already resolves per cluster on both instances today.
- Expect the startup warning to disappear on both after rollout.