### PR TITLE
fix(foreman): disable CRS alerts until upstream fixes time_seconds()

### DIFF
--- a/kubernetes/apps/base/llm/foreman/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/foreman/helmrelease.yaml
@@ -24,8 +24,12 @@ spec:
       # mount a ConfigMap across namespaces).
       crs:
         enabled: true
+        # Chart 0.9.16's shipped rule uses time_seconds(), which is not a
+        # PromQL function; the prometheus-operator admission webhook rejects
+        # it and the whole Helm upgrade rolls back. Re-enable when the fix
+        # ships upstream.
         alerts:
-          enabled: true
+          enabled: false
     operator:
       # Audit-record ConfigMaps (foreman.llmkube.dev/audit) accumulate one per
       # task and are only GC'd by the operator's reaper. Default retention is 7d;


### PR DESCRIPTION
## Summary
- `foreman.crs.alerts.enabled: false`. The chart's `ForemanFleetNodeHeartbeatStale` expr calls `time_seconds()` — not a PromQL function — so the rule-validation webhook rejects it and the whole foreman Helm upgrade fails and rolls back (release stuck on v78, fleet unaffected). CRS ConfigMap + dashboard stay enabled.

## Verification
- Rendered the rule locally and validated each expr against the cluster's Prometheus: 2 of 3 OK, heartbeat expr rejected on `time_seconds()`
- Upstream bug + one-line fix being filed