### PR TITLE
feat(llm): adopt foreman 0.9.17 — CRS metrics via cluster KSM + fetch_pull_request

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -19,6 +19,7 @@ spec:
     - grep
     - bash
     - fetch_issue
+    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -87,6 +88,10 @@ spec:
     When the issue names files, those paths are where the work goes — start from them
     rather than searching for the behaviour by name. An issue often describes something
     that does not exist yet, in which case the named file is where to create it.
+
+    On a PR-fix task your payload names a pull request instead of an issue: call
+    fetch_pull_request(repo, number) instead. Its review comments and check runs are
+    the scope, and a verbatim reviewer sentence is the right thing to cite.
 
     Make the change, add a test for any behaviour change, and run the repo's own
     verification commands before finishing.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -19,6 +19,7 @@ spec:
     - grep
     - bash
     - fetch_issue
+    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -85,6 +86,10 @@ spec:
     a finding cites a file or symbol as the source of truth, read that file. Preserve the
     parts of the prior attempt the reviewer did not object to. If the repo has an
     AGENTS.md, read it.
+
+    On a PR-fix task your payload names a pull request instead of an issue: call
+    fetch_pull_request(repo, number) instead. Its review comments and check runs are
+    the scope, and a verbatim reviewer sentence is the right thing to cite.
 
     Every behaviour change still needs a test. Run the repo's verification commands
     before finishing.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-strix.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-strix.yaml
@@ -19,6 +19,7 @@ spec:
     - grep
     - bash
     - fetch_issue
+    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -89,6 +90,10 @@ spec:
     When the issue names files, those paths are where the work goes — start from them
     rather than searching for the behaviour by name. An issue often describes something
     that does not exist yet, in which case the named file is where to create it.
+
+    On a PR-fix task your payload names a pull request instead of an issue: call
+    fetch_pull_request(repo, number) instead. Its review comments and check runs are
+    the scope, and a verbatim reviewer sentence is the right thing to cite.
 
     Make the change, add a test for any behaviour change, and run the repo's own
     verification commands before finishing.

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -19,6 +19,7 @@ spec:
     - grep
     - bash
     - fetch_issue
+    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -89,6 +90,10 @@ spec:
     When the issue names files, those paths are where the work goes — start from them
     rather than searching for the behaviour by name. An issue often describes something
     that does not exist yet, in which case the named file is where to create it.
+
+    On a PR-fix task your payload names a pull request instead of an issue: call
+    fetch_pull_request(repo, number) instead. Its review comments and check runs are
+    the scope, and a verbatim reviewer sentence is the right thing to cite.
 
     Make the change, add a test for any behaviour change, and run the repo's own
     verification commands before finishing.

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
@@ -21,6 +21,7 @@ spec:
     - grep
     - bash
     - fetch_issue
+    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -55,7 +56,10 @@ spec:
       1. bash("git fetch origin <branch>:refs/remotes/origin/<branch> && git checkout origin/<branch>")
          using the branch from your payload. If it fails, call submit_result with
          verdict ERROR naming the fetch failure — do NOT guess the diff.
-      2. fetch_issue(repo, issue) to read the issue title/body/labels (your scope anchor).
+      2. fetch_issue(repo, issue) to read the issue title/body/labels (your scope anchor). If the
+         payload also names a pull request, fetch_pull_request(repo, number) for its
+         reviews, review_comments, and check_runs — prior feedback your verdict
+         should account for.
       3. bash("git log -1 --pretty=full HEAD") for the commit message.
       4. bash("git diff --stat main...HEAD") then bash("git diff main...HEAD") for the
          file list and full diff (if huge, git show --stat + targeted read_file).

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -19,6 +19,7 @@ spec:
     - grep
     - bash
     - fetch_issue
+    - fetch_pull_request
     - submit_result
   mcp:
     enabled: true
@@ -53,7 +54,10 @@ spec:
       1. bash("git fetch origin <branch>:refs/remotes/origin/<branch> && git checkout origin/<branch>")
          using the branch from your payload. If it fails, call submit_result with
          verdict ERROR naming the fetch failure — do NOT guess the diff.
-      2. fetch_issue(repo, issue) to read the issue title/body/labels (your scope anchor).
+      2. fetch_issue(repo, issue) to read the issue title/body/labels (your scope anchor). If the
+         payload also names a pull request, fetch_pull_request(repo, number) for its
+         reviews, review_comments, and check_runs — prior feedback your verdict
+         should account for.
       3. bash("git log -1 --pretty=full HEAD") for the commit message.
       4. bash("git diff --stat main...HEAD") then bash("git diff main...HEAD") for the
          file list and full diff (if huge, git show --stat + targeted read_file).

--- a/kubernetes/apps/base/llm/foreman/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/foreman/helmrelease.yaml
@@ -24,12 +24,11 @@ spec:
       # mount a ConfigMap across namespaces).
       crs:
         enabled: true
-        # Chart 0.9.16's shipped rule uses time_seconds(), which is not a
-        # PromQL function; the prometheus-operator admission webhook rejects
-        # it and the whole Helm upgrade rolls back. Re-enable when the fix
-        # ships upstream.
+        # Render the CRS ConfigMap where the cluster kube-state-metrics can
+        # mount it (0.9.17, LLMKube#1492).
+        namespace: observability
         alerts:
-          enabled: false
+          enabled: true
     operator:
       # Audit-record ConfigMaps (foreman.llmkube.dev/audit) accumulate one per
       # task and are only GC'd by the operator's reaper. Default retention is 7d;

--- a/kubernetes/apps/base/llm/foreman/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/foreman/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.9.16
+    tag: 0.9.17
   url: oci://ghcr.io/defilantech/charts/foreman

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
@@ -138,6 +138,18 @@ spec:
         - pods=[*]
         - deployments=[*]
         - persistentvolumeclaims=[*]
+      rbac:
+        extraRules:
+          - apiGroups: ["foreman.llmkube.dev"]
+            resources: ["agentictasks", "workloads", "fleetnodes"]
+            verbs: ["list", "watch"]
+      customResourceState:
+        enabled: true
+        # The foreman chart renders this ConfigMap into observability
+        # (foreman.crs.namespace); definitions update on foreman chart bumps.
+        create: false
+        name: foreman-crs
+        key: foreman-crs.yaml
     kubeEtcd:
       service:
         selector:


### PR DESCRIPTION
## Summary
Atomic adoption of foreman chart **0.9.17**, which carries all three of this week's upstream fixes:

- `foreman.crs.namespace: observability` (LLMKube#1492) — the CRS ConfigMap renders where the existing kube-state-metrics can mount it; cluster KSM consumes it by name (`create: false`). No copied definitions, no extra exporter.
- CRS alerts re-enabled — the `time()` fix (LLMKube#1494) makes the shipped PrometheusRule pass rule validation, reverting #8970's workaround.
- Reverts #8950, restoring #8949: `fetch_pull_request` on the six model-facing Agent CRs plus prompt hints.

## Merge gate — now satisfied
`oci://ghcr.io/defilantech/charts/foreman:0.9.17` is published (upstream release PR #1484 merged 2026-08-13T16:54Z). Verified against the registry: tags now run `0.9.12 … 0.9.17`.

## Why the Agent CRs won't dry-run against the live cluster
`kubectl apply --dry-run=server` currently rejects them:

```
spec.tools[6]: Unsupported value: "fetch_pull_request": supported values:
"bash","fetch_issue","grep","read_file","run_gate_job","str_replace","submit_result","write_file"
```

That's the **0.9.16** CRD talking. 0.9.17 drops the `tools` enum entirely — it is now free-form `items: {type: string}`, with validation moved to agent startup ("Unknown names are rejected at agent startup so a typo in an Agent CR fails loud rather than silently disabling a tool"). Validation therefore moves from the CRD to the runtime catalog, and `fetch_pull_request` is present there at the release tag:

```
pkg/foreman/agent/tools/catalog/catalog.go@v0.9.17
  45:  "fetch_issue",
  46:  "fetch_pull_request",
```

This is why the chart bump and the Agent CRs must land in the same commit.

## Rebase note
The branch was 146 commits behind and conflicted on all four coder prompts, because today's work rewrote them (#9038 find-path guidance and base-branch grounding for `ALREADY-RESOLVED`, #9036 timeouts, #9039 resources). The conflicting side was the **pre-lean** prompt, so resolving naively would have reverted that.

Resolved by keeping `main`'s prompts and re-adding only this branch's actual contribution — `fetch_pull_request` in the tools list plus a sentence about it, rewritten to match the current lean style. The agent diff is now purely additive; verified each prompt still carries today's changes.

## Post-merge
- `kubectl rollout restart deployment/foreman-agent` — Agent CRs are cached at pod start.
- Expect a transient window where the Agent CRs fail validation until the HelmRelease finishes upgrading the CRD. Flux retries, so it self-heals; worth watching rather than acting on.
