### PR TITLE
feat(foreman): rebalance coder load toward self-hosted

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -45,16 +45,16 @@ spec:
               # there and builds the Workload with the coder-frontier Agent
               # (cloud-proxy -> litellm -> MiniMax-M3). Ignored by older bridges.
               ESCALATION_LANE: frontier
-              LANE_CODER_AGENTS: '{"*":["coder","coder-strix"],"frontier":"coder-frontier"}'
+              LANE_CODER_AGENTS: '{"*":["coder","coder-strix","coder-strix"],"frontier":"coder-frontier"}'
               FOREMAN_NAMESPACE: llm
-              MAX_IN_PROGRESS: "5"
+              MAX_IN_PROGRESS: "7"
               VERIFY_ENABLED: "false"
               VERDICT_SELF_GO: "code-fix,docs,packaging,config,ci-policy"
               GATEPROFILE_MAP: '{"misospace/KubeTix":{"language":"python","image":"python:3.11","commands":{"format":"pip install -q black && black --check .","lint":"pip install -q flake8 && flake8 .","build":"pip install -q -r requirements.txt && python -m compileall -q .","test":"pip install -q -r requirements.txt && TESTING=1 python -m pytest tests/unit/ tests/integration/ -q"}},"misospace/miso-gallery":{"language":"python","image":"python:3.14","commands":{"format":"true","lint":"pip install -q ruff && ruff check . --select=E,F,W,B,SIM,I --ignore=E501","build":"pip install -q -r requirements.txt && python -m compileall -q .","test":"pip install -q -r requirements.txt pytest requests && python -m pytest -q"}},"misospace/pr-reviewer-action":{"language":"python","image":"python:3.14","commands":{"format":"true","lint":"pip install -q yamllint && yamllint action.yml examples/","build":"python -m compileall -q .","test":"pip install -q pytest && python -m pytest tests/ -q"}},"misospace/dispatch":{"language":"node","image":"node:22","commands":{"format":"true","lint":"npm ci --include=dev && npx prisma generate && NODE_ENV=development npm run lint","build":"NODE_ENV=development npm run typecheck","test":"npm run test"}},"misospace/windowstead":{"language":"generic","sourceExtensions":[".gd"],"image":"ghcr.io/misospace/godot-gate:4.7.1@sha256:a560418dfeb7b8aba5cd1f6193410f95130cfb215ea0603b96040fb352f24ad4","commands":{"format":"true","lint":"true","build":"true","test":"export HOME=/tmp XDG_DATA_HOME=/tmp/.local/share && godot --headless --path . --script res://tests/test_runner.gd && godot --headless --path . --script res://tests/test_e2e.gd && godot --headless --path . --script res://tests/test_layout_math.gd && godot --headless --path . --script res://tests/test_reservations.gd && godot --headless --path . --fixed-fps 60 --quit-after 300 2>&1 | tee /tmp/smoke.log && ! grep -qE \"SCRIPT ERROR|ERROR:\" /tmp/smoke.log"}},"misospace/pinchflat":{"language":"generic","sourceExtensions":[".ex",".exs",".heex"],"image":"ghcr.io/misospace/elixir-gate:1.18.4@sha256:486ece7e2508f05ed4b0eb19bfaae544d8d9652c1549719b56215642891e78d5","commands":{"format":"mix deps.get && mix format --check-formatted","lint":"mix deps.get && mix credo && mix deps.audit","build":"mix deps.get && mix compile --warnings-as-errors","test":"mix deps.get && ./tooling/fetch-sqlean.sh && mix test"}},"*":{"language":"generic","image":"golang:1.26","commands":{"format":"true","lint":"true","build":"true","test":"true"}}}'
               REVISION_CODER_AGENTS: '{"*":"coder-revision"}'
               PR_FIX_ENABLED: "true"
               PR_FIX_MAX_ATTEMPTS: "3"
-              PR_FIX_LANE_AGENTS: '{"NORMAL":"coder","ESCALATED":"coder-frontier"}'
+              PR_FIX_LANE_AGENTS: '{"NORMAL":"coder-strix","ESCALATED":"coder-frontier"}'
             envFrom:
               - secretRef:
                   name: foreman-dispatch-bridge

--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
               REVISION_CODER_AGENTS: '{"*":"coder-revision"}'
               PR_FIX_ENABLED: "true"
               PR_FIX_MAX_ATTEMPTS: "3"
-              PR_FIX_LANE_AGENTS: '{"NORMAL":"coder-strix","ESCALATED":"coder-frontier"}'
+              PR_FIX_LANE_AGENTS: '{"NORMAL":"coder","ESCALATED":"coder-frontier"}'
             envFrom:
               - secretRef:
                   name: foreman-dispatch-bridge

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -8,7 +8,7 @@ spec:
   provider: cloud-proxy
   providerConfig:
     baseURL: http://litellm.llm:4000/v1
-    model: nvidia
+    model: self-hosted
     apiKeySecretRef:
       name: foreman-agent
       key: LITELLM_API_KEY


### PR DESCRIPTION
## Summary
- Queue is 58 deep and the loop merges ~3-6 PRs/day; the bottleneck is routing, not capacity. Since the single-slot change, nvidia logged 17.2 API-hours in an 8h window (deep queueing) while self-hosted ran at 12% of 4 slots.
- Local lane: `issue % 3`, strix takes 2 of 3 — the P3 mechanical bulk moves to the idle backend. `coder-revision` → `self-hosted` (revisions execute explicit reviewer findings). `MAX_IN_PROGRESS` 5 → 7 (in-progress counts review/merge-wait states that hold no backend slot).
- **pr-fix lanes unchanged**: NORMAL stays on the nvidia coder, escalation stays MiniMax. Fixes are the densest reasoning work in the loop and a failed round costs an escalation; their volume is too small to matter for queue relief, so difficulty wins over utilization there.
- Net: nvidia's single slot serves 1/3 of local issues + NORMAL pr-fixes, both uncontended by revisions.

## Verification
- LANE/PR_FIX maps parse as JSON, single occurrence each; kustomize builds clean
- 8h litellm measurements in commit message

## Notes
- Deterministic splits preserve per-issue cache affinity; retries land on the same backend as before