### PR TITLE
fix(foreman): 12 agent replicas — Job-based coders were starving reviewers of FleetNodes

### DIFF
--- a/kubernetes/apps/base/llm/foreman/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/foreman/helmrelease.yaml
@@ -38,7 +38,9 @@ spec:
       audit:
         retention: 48h
     agent:
-      replicaCount: 3
+      # One task per FleetNode, and Job-based coders hold theirs for the
+      # whole Job — so replicas cap concurrent coders + reviews (#1496).
+      replicaCount: 12
       mode: native
       taskNamespace: llm
       roles:


### PR DESCRIPTION
## Summary
Reviews have been unschedulable for hours. The operator loops `no free FleetNode matches; will retry` because **all three FleetNodes are reserved by coder tasks**:

```
foreman-agent-...-4l2lj  current=llm/wl-...-pr-reviewer-action-438-code-438
foreman-agent-...-f4qd9  current=llm/wl-...-pr-reviewer-action-420-code-420
foreman-agent-...-t8459  current=llm/wl-...-bridge-35-code-35
```

Coders are Job-based (since the polyglot consolidation) — the work runs in separate Job pods — but the claiming agent still reserves its FleetNode for the Job's whole multi-hour lifetime. Foreman enforces one task per node with no concurrency knob, so `replicaCount: 3` capped the fleet at 3 concurrent coders and **zero** in-process reviewers.

This is the real throughput ceiling, upstream of any model-routing tuning: five workloads were holding claim slots while their reviews sat `Pending` for up to two hours.

## Why 12
7 issue coders (MAX_IN_PROGRESS after #8973) + ~3 pr-fix coders + headroom for in-process reviews and gates. Agent pods are coordinators: measured 1–2m CPU and ~17–20Mi each, on a cluster at 6–25% CPU.

## Follow-up
Upstream fix is that a Job-mode task shouldn't reserve a FleetNode at all (or should use a separate pool) — filing on LLMKube. This PR is the interim unblock.