### PR TITLE
feat(litellm): let llama-reviewer use its third slot

### DIFF
--- a/kubernetes/apps/base/llm/litellm/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/configmap.yaml
@@ -55,7 +55,7 @@ data:
           model: openai/llama-reviewer
           api_base: http://llama-reviewer.llm:8080/v1
           api_key: llama-reviewer
-          max_parallel_requests: 2
+          max_parallel_requests: 3
 
       - model_name: nvidia
         model_info:


### PR DESCRIPTION
## Summary
`llama-reviewer` has `parallelSlots: 3` in llmkube (live and in git) while litellm capped it at `max_parallel_requests: 2` — the third slot was already allocated in VRAM and simply never dispatched into. Raising the proxy cap to 3 needs no backend change and no inference-pod restart.

Takes the box from 4 to 5 concurrent streams (strix 2 + reviewer 3). It's memory-bandwidth bound, where aggregate tok/s improves with streams spread across several models rather than piled onto one, so this stays inside the useful range with comfyui also resident.

`llama-strix` stays at 2 deliberately — that one is a real backend limit, not a config artifact.