### PR TITLE
fix(rook-ceph): raise operator memory limit

### DIFF
--- a/kubernetes/apps/base/rook-ceph/rook-ceph/app/helmrelease.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/app/helmrelease.yaml
@@ -22,7 +22,8 @@ spec:
       enabled: true
     resources:
       requests:
-        memory: 128Mi # unchangable
-        cpu: 100m # unchangable
-      limits: {}
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
   timeout: 15m


### PR DESCRIPTION
The `rook-ceph-operator` has been OOMKilled twice. The latest termination was confirmed at the live `512Mi` limit: exit 137 at `2026-08-11T02:47:31Z`, after roughly 3 days and 10 hours of runtime. Current post-restart usage is already about 208Mi.

The chart default is 512Mi even though the existing Helm values use `limits: {}`; Helm preserves the chart default when merging the empty map. This sets an explicit `256Mi` request and `1Gi` limit for the operator. The change affects only the stateless, leader-elected operator Deployment and will roll it normally; the Ceph data plane is unaffected.