### PR TITLE
feat(open-webui): sync OpenClaw pipes

### DIFF
--- a/kubernetes/apps/base/llm/open-webui/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/open-webui/externalsecret.yaml
@@ -22,6 +22,29 @@ spec:
         OPENID_REDIRECT_URI: https://chat.jory.dev/oauth/oidc/callback
         OAUTH_CLIENT_ID: "{{ .OPEN_WEBUI_CLIENT_ID }}"
         OAUTH_CLIENT_SECRET: "{{ .OPEN_WEBUI_CLIENT_SECRET }}"
+        WEBUI_SECRET_KEY: "{{ .WEBUI_SECRET_KEY }}"
+  data:
+    - secretKey: WEBUI_SECRET_KEY
+      remoteRef:
+        key: open-webui-runtime
+        property: WEBUI_SECRET_KEY
   dataFrom:
     - extract:
         key: open-webui
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name open-webui-openclaw
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+  data:
+    - secretKey: OPENCLAW_GATEWAY_TOKEN
+      remoteRef:
+        key: openclaw
+        property: OPENCLAW_GATEWAY_TOKEN

--- a/kubernetes/apps/base/llm/open-webui/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/open-webui/externalsecret.yaml
@@ -23,28 +23,11 @@ spec:
         OAUTH_CLIENT_ID: "{{ .OPEN_WEBUI_CLIENT_ID }}"
         OAUTH_CLIENT_SECRET: "{{ .OPEN_WEBUI_CLIENT_SECRET }}"
         WEBUI_SECRET_KEY: "{{ .WEBUI_SECRET_KEY }}"
-  data:
-    - secretKey: WEBUI_SECRET_KEY
-      remoteRef:
-        key: open-webui-runtime
-        property: WEBUI_SECRET_KEY
+        OPENCLAW_GATEWAY_TOKEN: "{{ .OPENCLAW_GATEWAY_TOKEN }}"
   dataFrom:
     - extract:
         key: open-webui
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: &name open-webui-openclaw
-spec:
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: onepassword
-  target:
-    name: *name
-  data:
-    - secretKey: OPENCLAW_GATEWAY_TOKEN
-      remoteRef:
+    - extract:
+        key: open-webui-runtime
+    - extract:
         key: openclaw
-        property: OPENCLAW_GATEWAY_TOKEN

--- a/kubernetes/apps/base/llm/open-webui/function-sync.yaml
+++ b/kubernetes/apps/base/llm/open-webui/function-sync.yaml
@@ -1,0 +1,150 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/core/v1/configmap.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: open-webui-function-sync
+data:
+  sync.py: |
+    """Reconcile the OpenClaw Gateway pipes before Open WebUI starts."""
+
+    from __future__ import annotations
+
+    import hashlib
+    import urllib.request
+
+    from open_webui.models.config import Config
+    from open_webui.models.functions import FunctionForm, Functions
+
+
+    PIPE_REF = "50d30bb37e25e9e37bbe167a38b74c2ef5baffbc"
+    PIPE_URL = (
+        "https://raw.githubusercontent.com/Eliav2/"
+        f"openclaw-openwebui-integration/{PIPE_REF}/openclaw_pipe.py"
+    )
+    PIPE_SHA256 = "ae9d2c52a732d2ebce5b1e6ad9a80c5d8c542822891568fabb833ea346590f40"
+    TOKEN_LINE = "token = valves.GATEWAY_TOKEN"
+    TOKEN_FALLBACK = (
+        'token = valves.GATEWAY_TOKEN or '
+        'os.environ.get("OPENCLAW_GATEWAY_TOKEN", "")'
+    )
+    NAME_MARKER = "\n\nimport asyncio\n"
+    FUNCTION_DESCRIPTION = (
+        "Run an OpenClaw agent over its native Gateway WebSocket with "
+        "streaming tool cards and persistent sessions."
+    )
+    FUNCTIONS = (
+        ("openclaw_gateway", "OpenClaw / Miso", "main", "openclaw-bridge"),
+        ("openclaw_matcha", "OpenClaw / Matcha", "matcha", "openclaw-bridge-matcha"),
+        ("openclaw_saffron", "OpenClaw / Saffron", "saffron", "openclaw-bridge-saffron"),
+    )
+
+
+    def fetch_pipe() -> str:
+        request = urllib.request.Request(
+            PIPE_URL,
+            headers={"User-Agent": "home-ops/open-webui-function-sync"},
+        )
+        with urllib.request.urlopen(request, timeout=30) as response:
+            content = response.read()
+
+        digest = hashlib.sha256(content).hexdigest()
+        if digest != PIPE_SHA256:
+            raise RuntimeError(
+                f"OpenClaw pipe checksum mismatch: expected {PIPE_SHA256}, got {digest}"
+            )
+
+        source = content.decode("utf-8")
+        if source.count(TOKEN_LINE) != 1:
+            raise RuntimeError("OpenClaw pipe token lookup changed upstream")
+        source = source.replace(TOKEN_LINE, TOKEN_FALLBACK, 1)
+        if source.count(NAME_MARKER) != 1:
+            raise RuntimeError("OpenClaw pipe import layout changed upstream")
+        return source
+
+
+    def manifest(source: str) -> dict[str, str]:
+        frontmatter = source.split('"""', 2)[1]
+        values: dict[str, str] = {}
+        for line in frontmatter.splitlines():
+            if ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            values[key.strip()] = value.strip()
+        return values
+
+
+    def named_source(source: str, display_name: str) -> str:
+        return source.replace(
+            NAME_MARKER,
+            f"\n\nname = {display_name!r}\n" + NAME_MARKER,
+            1,
+        )
+
+
+    async def sync() -> None:
+        # Open WebUI persists these settings in PostgreSQL, so the
+        # ENABLE_OPENAI_API=false environment variable alone does not remove
+        # old admin-configured OpenAI endpoints. Keep the database aligned with
+        # the deployment intent and stop refreshes against stale LAN hosts.
+        await Config.upsert(
+            {
+                "openai.enable": False,
+                "openai.api_base_urls": [],
+                "ollama.enable": True,
+            }
+        )
+
+        source = fetch_pipe()
+        source_manifest = manifest(source)
+
+        for function_id, function_name, agent_id, state_suffix in FUNCTIONS:
+            content = named_source(source, f"{function_name} / ")
+            form = FunctionForm(
+                id=function_id,
+                name=function_name,
+                content=content,
+                meta={
+                    "description": FUNCTION_DESCRIPTION,
+                    "manifest": source_manifest,
+                },
+            )
+            existing = await Functions.get_function_by_id(function_id)
+            if existing:
+                result = await Functions.update_function_by_id(
+                    function_id,
+                    {
+                        "name": function_name,
+                        "type": "pipe",
+                        "content": content,
+                        "meta": form.meta.model_dump(mode="json"),
+                        "is_active": True,
+                        "is_global": True,
+                    },
+                )
+            else:
+                result = await Functions.insert_new_function("gitops", "pipe", form)
+
+            if not result:
+                raise RuntimeError(f"failed to reconcile function {function_id}")
+
+            valves = {
+                "GATEWAY_URL": "openclaw.llm.svc.cluster.local:18789",
+                "GATEWAY_TOKEN": "",
+                "STATE_DIR": f"/app/backend/data/{state_suffix}",
+                "AGENT_ID": agent_id,
+                "ENABLE_FILE_SERVER": False,
+                "USE_OWUI_FILES": True,
+                "SEND_STOP_ON_CANCEL": True,
+                "AUTO_TITLE": False,
+            }
+            if not await Functions.update_function_valves_by_id(function_id, valves):
+                raise RuntimeError(f"failed to reconcile valves for {function_id}")
+
+            print(f"reconciled {function_id} ({agent_id})")
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(sync())

--- a/kubernetes/apps/base/llm/open-webui/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/open-webui/helmrelease.yaml
@@ -64,8 +64,6 @@ spec:
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}"
-              - secretRef:
-                  name: "{{ .Release.Name }}-openclaw"
             resources:
               requests:
                 cpu: 500m

--- a/kubernetes/apps/base/llm/open-webui/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/open-webui/helmrelease.yaml
@@ -15,6 +15,21 @@ spec:
       open-webui:
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          function-sync:
+            image:
+              repository: ghcr.io/open-webui/open-webui
+              tag: v0.11.0@sha256:72c0ba641ba75e7aa52655cb242570906ececd09b1140fb736483038a22b3228
+            command: [python, /opt/openclaw-function-sync.py]
+            env:
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: "{{ .Release.Name }}-app"
+                    key: uri
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}"
         containers:
           app:
             image:
@@ -31,6 +46,8 @@ spec:
               IMAGE_STEPS: 8
               COMFYUI_BASE_URL: http://smurf-pc:8188
               # Open-webui settings
+              ENABLE_PIP_INSTALL_FRONTMATTER_REQUIREMENTS: true
+              ENABLE_PLUGINS: true
               OLLAMA_BASE_URL: http://llama-swap.llm:8080/v1
               ENABLE_RAG_WEB_SEARCH: true
               ENABLE_SEARCH_QUERY: true
@@ -47,6 +64,8 @@ spec:
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}"
+              - secretRef:
+                  name: "{{ .Release.Name }}-openclaw"
             resources:
               requests:
                 cpu: 500m
@@ -58,6 +77,13 @@ spec:
         existingClaim: "{{ .Release.Name }}"
         globalMounts:
           - path: /app/backend/data
+      function-sync:
+        type: configMap
+        name: open-webui-function-sync
+        globalMounts:
+          - path: /opt/openclaw-function-sync.py
+            subPath: sync.py
+            readOnly: true
     route:
       app:
         hostnames: ["chat.jory.dev"]

--- a/kubernetes/apps/base/llm/open-webui/kustomization.yaml
+++ b/kubernetes/apps/base/llm/open-webui/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./function-sync.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml


### PR DESCRIPTION
This replaces the hand-installed Open WebUI OpenClaw pipe with a GitOps-managed reconciliation step and exposes Miso, Matcha, and Saffron as separate agent-scoped pipes.

The init container pins and verifies the upstream integration source, applies the gateway-token environment fallback, reconciles Open WebUI's database-backed provider settings, and writes encrypted function valves. It also makes the Open WebUI signing key stable across restarts. Miso-chat remains unchanged for rollback.

Validation:
- Native Open WebUI -> OpenClaw request succeeded with: `OpenClaw bridge test passed.`
- `kubectl kustomize kubernetes/apps/base/llm/open-webui`
- Embedded sync script syntax check
- Targeted `flate test hr open-webui` rendered successfully (`1 passed`; the command returned nonzero despite the pass)
- Full `flate test all` remains blocked by unrelated missing `ocharted.jory.dev` registry credentials