### PR TITLE
fix(foreman): give coders a path when they cannot find the code

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-dsv4f.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-dsv4f.yaml
@@ -90,6 +90,9 @@ spec:
       GO — the change is complete and verification passes.
       NO-GO + extra.outcome="ALREADY-RESOLVED" + extra.resolvedBy=<file and what it
         already does> — the code where the issue points already does what it asks.
+        Check this against the base branch, not your workspace: a retry starts on the
+        previous attempt's branch, so work you find there has not shipped and the issue
+        is still open. Quote the base-branch content you are relying on.
       NO-GO + extra.escalation="DESIGN-DECISION" — a product or architecture call a
         human has to make.
       NO-GO + extra.escalation="NO-TECHNICAL-FIX" — nothing in this repo can fix it

--- a/kubernetes/apps/base/llm/foreman/agents/coder-dsv4f.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-dsv4f.yaml
@@ -75,7 +75,11 @@ spec:
     If the repo has an AGENTS.md, read it: it carries conventions and the testing traps
     earlier attempts learned the hard way.
 
-    Implement the fix, add a test for any behaviour change, and run the repo's own
+    When the issue names files, those paths are where the work goes — start from them
+    rather than searching for the behaviour by name. An issue often describes something
+    that does not exist yet, in which case the named file is where to create it.
+
+    Make the change, add a test for any behaviour change, and run the repo's own
     verification commands before finishing.
 
     How the harness works around you: it stages, commits, DCO-signs and pushes whatever
@@ -91,4 +95,6 @@ spec:
       NO-GO + extra.escalation="NO-TECHNICAL-FIX" — nothing in this repo can fix it
         (wrong layer, upstream bug, external service).
     Put the specific blocker in your summary. These route the issue, so a wrong one
-    removes real work from the queue. Being unable to find something is not one of them.
+    removes real work from the queue. If you cannot find what the issue points at, read
+    the files it names and work from what is there — not having found it yet is not a
+    blocker.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -86,6 +86,9 @@ spec:
       GO — the change is complete and verification passes.
       NO-GO + extra.outcome="ALREADY-RESOLVED" + extra.resolvedBy=<file and what it
         already does> — the code where the issue points already does what it asks.
+        Check this against the base branch, not your workspace: a retry starts on the
+        previous attempt's branch, so work you find there has not shipped and the issue
+        is still open. Quote the base-branch content you are relying on.
       NO-GO + extra.escalation="DESIGN-DECISION" — a product or architecture call a
         human has to make.
       NO-GO + extra.escalation="NO-TECHNICAL-FIX" — nothing in this repo can fix it

--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -71,7 +71,11 @@ spec:
     If the repo has an AGENTS.md, read it: it carries conventions and the testing traps
     earlier attempts learned the hard way.
 
-    Implement the fix, add a test for any behaviour change, and run the repo's own
+    When the issue names files, those paths are where the work goes — start from them
+    rather than searching for the behaviour by name. An issue often describes something
+    that does not exist yet, in which case the named file is where to create it.
+
+    Make the change, add a test for any behaviour change, and run the repo's own
     verification commands before finishing.
 
     How the harness works around you: it stages, commits, DCO-signs and pushes whatever
@@ -87,4 +91,6 @@ spec:
       NO-GO + extra.escalation="NO-TECHNICAL-FIX" — nothing in this repo can fix it
         (wrong layer, upstream bug, external service).
     Put the specific blocker in your summary. These route the issue, so a wrong one
-    removes real work from the queue. Being unable to find something is not one of them.
+    removes real work from the queue. If you cannot find what the issue points at, read
+    the files it names and work from what is there — not having found it yet is not a
+    blocker.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-strix.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-strix.yaml
@@ -73,7 +73,11 @@ spec:
     If the repo has an AGENTS.md, read it: it carries conventions and the testing traps
     earlier attempts learned the hard way.
 
-    Implement the fix, add a test for any behaviour change, and run the repo's own
+    When the issue names files, those paths are where the work goes — start from them
+    rather than searching for the behaviour by name. An issue often describes something
+    that does not exist yet, in which case the named file is where to create it.
+
+    Make the change, add a test for any behaviour change, and run the repo's own
     verification commands before finishing.
 
     How the harness works around you: it stages, commits, DCO-signs and pushes whatever
@@ -89,4 +93,6 @@ spec:
       NO-GO + extra.escalation="NO-TECHNICAL-FIX" — nothing in this repo can fix it
         (wrong layer, upstream bug, external service).
     Put the specific blocker in your summary. These route the issue, so a wrong one
-    removes real work from the queue. Being unable to find something is not one of them.
+    removes real work from the queue. If you cannot find what the issue points at, read
+    the files it names and work from what is there — not having found it yet is not a
+    blocker.

--- a/kubernetes/apps/base/llm/foreman/agents/coder-strix.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-strix.yaml
@@ -88,6 +88,9 @@ spec:
       GO — the change is complete and verification passes.
       NO-GO + extra.outcome="ALREADY-RESOLVED" + extra.resolvedBy=<file and what it
         already does> — the code where the issue points already does what it asks.
+        Check this against the base branch, not your workspace: a retry starts on the
+        previous attempt's branch, so work you find there has not shipped and the issue
+        is still open. Quote the base-branch content you are relying on.
       NO-GO + extra.escalation="DESIGN-DECISION" — a product or architecture call a
         human has to make.
       NO-GO + extra.escalation="NO-TECHNICAL-FIX" — nothing in this repo can fix it

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -73,7 +73,11 @@ spec:
     If the repo has an AGENTS.md, read it: it carries conventions and the testing traps
     earlier attempts learned the hard way.
 
-    Implement the fix, add a test for any behaviour change, and run the repo's own
+    When the issue names files, those paths are where the work goes — start from them
+    rather than searching for the behaviour by name. An issue often describes something
+    that does not exist yet, in which case the named file is where to create it.
+
+    Make the change, add a test for any behaviour change, and run the repo's own
     verification commands before finishing.
 
     How the harness works around you: it stages, commits, DCO-signs and pushes whatever
@@ -89,4 +93,6 @@ spec:
       NO-GO + extra.escalation="NO-TECHNICAL-FIX" — nothing in this repo can fix it
         (wrong layer, upstream bug, external service).
     Put the specific blocker in your summary. These route the issue, so a wrong one
-    removes real work from the queue. Being unable to find something is not one of them.
+    removes real work from the queue. If you cannot find what the issue points at, read
+    the files it names and work from what is there — not having found it yet is not a
+    blocker.

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -88,6 +88,9 @@ spec:
       GO — the change is complete and verification passes.
       NO-GO + extra.outcome="ALREADY-RESOLVED" + extra.resolvedBy=<file and what it
         already does> — the code where the issue points already does what it asks.
+        Check this against the base branch, not your workspace: a retry starts on the
+        previous attempt's branch, so work you find there has not shipped and the issue
+        is still open. Quote the base-branch content you are relying on.
       NO-GO + extra.escalation="DESIGN-DECISION" — a product or architecture call a
         human has to make.
       NO-GO + extra.escalation="NO-TECHNICAL-FIX" — nothing in this repo can fix it


### PR DESCRIPTION
## Summary
Two prompt changes on the four issue coders (`coder`, `coder-strix`, `coder-dsv4f`, `coder-frontier`).

## Why
**It forbade a reason without offering an alternative.** The prompt ended with *"Being unable to find something is not one of them."* — so a coder that couldn't locate the code had nowhere to go and emitted the bare NO-GO anyway. Five NO-GOs in the last window read like this:

> `Unable to locate metrics endpoint implementation; no edit made.`
> `Unable to locate exact file content for safe edit within remaining turns; no changes made.`

Replaced with a path: read the files the issue names and work from what's there.

**It assumed every issue modifies existing code.** *"Implement the fix"* framed the task as find-then-change, so an issue describing behaviour that doesn't exist yet got searched for instead of created. alert-triage#17 asks for a `/metrics` endpoint; the coder went looking for the endpoint implementation, didn't find one, and declined — the issue names `main.go` as where the handler wires in.

Added: when the issue names files, those paths are where the work goes, and the named file may be where to *create* something rather than find it.

## Notes
- The file references are now dependable: 20 issue bodies were edited yesterday so every queue-visible issue names paths its diff would touch, and LLMKube#1516 fixes the extractor that was silently discarding `path:line` citations.
- `coder-revision` deliberately untouched — different role, and it already says *"Where a finding cites a file or symbol as the source of truth, read that file."*
- Accounts for ~5 of the recent NO-GOs. The larger category is 19 "already resolved" verdicts, which I'm investigating separately — those come from first attempts, not retries, so they aren't coders seeing their own prior work.
- Validated with `--dry-run=server` on all five agents.
- Needs `kubectl rollout restart deployment/foreman-agent` after merge — prompts are cached at pod start.