### PR TITLE
fix(foreman): stop coder Jobs reserving 2 CPU each while idle

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-dsv4f.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-dsv4f.yaml
@@ -59,6 +59,19 @@ spec:
   requestTimeoutSeconds: 39600
   bashTimeoutSeconds: 60
   execution:
+    # The Job default mirrors the gate (2 CPU / 4Gi requested), but a coder is
+    # I/O-bound on model calls and only bursts during the repo's test command.
+    # At MAX_IN_PROGRESS 14 the default reserved 28 CPU against ~57 schedulable
+    # (skirk's 32 carries the llm-workload taint), so Jobs sat Pending on
+    # "Insufficient cpu" while node utilisation was 27%. Limits stay high so a
+    # test run can still burst.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2Gi
+      limits:
+        cpu: 4
+        memory: 8Gi
     activeDeadlineSeconds: 43200
     image: ghcr.io/misospace/llmkube-coder:0.9.16@sha256:c99120f992ae588fdaa5000377da4da1d4e04f349ba681e27083f5a4008cc97f
     mode: Job

--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -53,6 +53,19 @@ spec:
   requestTimeoutSeconds: 39600
   bashTimeoutSeconds: 60
   execution:
+    # The Job default mirrors the gate (2 CPU / 4Gi requested), but a coder is
+    # I/O-bound on model calls and only bursts during the repo's test command.
+    # At MAX_IN_PROGRESS 14 the default reserved 28 CPU against ~57 schedulable
+    # (skirk's 32 carries the llm-workload taint), so Jobs sat Pending on
+    # "Insufficient cpu" while node utilisation was 27%. Limits stay high so a
+    # test run can still burst.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2Gi
+      limits:
+        cpu: 4
+        memory: 8Gi
     activeDeadlineSeconds: 43200
     image: ghcr.io/misospace/llmkube-coder:0.9.16@sha256:c99120f992ae588fdaa5000377da4da1d4e04f349ba681e27083f5a4008cc97f
     mode: Job

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -54,6 +54,19 @@ spec:
   requestTimeoutSeconds: 39600
   bashTimeoutSeconds: 60
   execution:
+    # The Job default mirrors the gate (2 CPU / 4Gi requested), but a coder is
+    # I/O-bound on model calls and only bursts during the repo's test command.
+    # At MAX_IN_PROGRESS 14 the default reserved 28 CPU against ~57 schedulable
+    # (skirk's 32 carries the llm-workload taint), so Jobs sat Pending on
+    # "Insufficient cpu" while node utilisation was 27%. Limits stay high so a
+    # test run can still burst.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2Gi
+      limits:
+        cpu: 4
+        memory: 8Gi
     activeDeadlineSeconds: 43200
     image: ghcr.io/misospace/llmkube-coder:0.9.16@sha256:c99120f992ae588fdaa5000377da4da1d4e04f349ba681e27083f5a4008cc97f
     mode: Job

--- a/kubernetes/apps/base/llm/foreman/agents/coder-strix.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-strix.yaml
@@ -54,6 +54,19 @@ spec:
   requestTimeoutSeconds: 39600
   bashTimeoutSeconds: 60
   execution:
+    # The Job default mirrors the gate (2 CPU / 4Gi requested), but a coder is
+    # I/O-bound on model calls and only bursts during the repo's test command.
+    # At MAX_IN_PROGRESS 14 the default reserved 28 CPU against ~57 schedulable
+    # (skirk's 32 carries the llm-workload taint), so Jobs sat Pending on
+    # "Insufficient cpu" while node utilisation was 27%. Limits stay high so a
+    # test run can still burst.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2Gi
+      limits:
+        cpu: 4
+        memory: 8Gi
     activeDeadlineSeconds: 43200
     image: ghcr.io/misospace/llmkube-coder:0.9.16@sha256:c99120f992ae588fdaa5000377da4da1d4e04f349ba681e27083f5a4008cc97f
     mode: Job

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -54,6 +54,19 @@ spec:
   requestTimeoutSeconds: 39600
   bashTimeoutSeconds: 60
   execution:
+    # The Job default mirrors the gate (2 CPU / 4Gi requested), but a coder is
+    # I/O-bound on model calls and only bursts during the repo's test command.
+    # At MAX_IN_PROGRESS 14 the default reserved 28 CPU against ~57 schedulable
+    # (skirk's 32 carries the llm-workload taint), so Jobs sat Pending on
+    # "Insufficient cpu" while node utilisation was 27%. Limits stay high so a
+    # test run can still burst.
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2Gi
+      limits:
+        cpu: 4
+        memory: 8Gi
     activeDeadlineSeconds: 43200
     image: ghcr.io/misospace/llmkube-coder:0.9.16@sha256:c99120f992ae588fdaa5000377da4da1d4e04f349ba681e27083f5a4008cc97f
     mode: Job


### PR DESCRIPTION
## Summary
Set `execution.resources` on all five coder agents: requests **500m CPU / 2Gi**, limits unchanged at **4 CPU / 8Gi**.

## Why
Four coder Jobs sat `Pending` for 38 minutes:

```
FailedScheduling: 0/4 nodes are available:
  1 node(s) had untolerated taint(s), 3 Insufficient cpu
```

The Job resource default mirrors the gate Job — **2 CPU / 4Gi requested** — so at `MAX_IN_PROGRESS: 14` the coders reserved **28 CPU**.

```
schedulable for coders   ayaka+eula+ganyu = 57 CPU
                         (skirk's 32 carries the llm-workload taint)
llm namespace requests   43.4 CPU        <- mostly coder Jobs
everything else         ~16.6 CPU
```

A coder is I/O-bound on model calls and only bursts CPU during the repo's test command, which is why node *utilisation* sat at 27% while nothing could schedule. Requests are the scheduling gate, not usage.

**14 concurrent coders now reserve 7 CPU instead of 28**, freeing 21.

## Notes
- Limits stay at 4 CPU / 8Gi so `go test -race`, `npm ci` etc. can still burst.
- This was the missing half of raising `MAX_IN_PROGRESS` to 14 — the cap was raised without the capacity to schedule it, so the extra concurrency partly went to Pending pods instead of work.
- Applies to `coder-revision` too, which shares the same default.
- Validated with `--dry-run=server` on all five.