### PR TITLE
fix(comfyui): force fp16 unet + fp32 vae on the Intel iGPU

### DIFF
--- a/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
@@ -21,7 +21,12 @@ spec:
               repository: yanwk/comfyui-boot
               tag: xpu@sha256:ab1ac553bfd6756fdf15f52f7da370cdef74a26cbca4e84177ac9720bc5d52f2
             env:
-              CLI_ARGS: "--listen 0.0.0.0 --port 8188 --use-pytorch-cross-attention --disable-mmap"
+              # Iris Xe is Gen12 Xe-LP: fp16 is native, bf16 is NOT (that is an XMX
+              # feature on Arc and newer). ComfyUI defaulted the VAE to bf16 and
+              # Level Zero rejected the kernel with UR_RESULT_ERROR_INVALID_ARGUMENT.
+              # fp32 for the VAE rather than fp16, which upstream warns can produce
+              # black images.
+              CLI_ARGS: "--listen 0.0.0.0 --port 8188 --use-pytorch-cross-attention --disable-mmap --fp16-unet --fp32-vae"
             # It no longer shares a node with an LLM, so it no longer has to be the
             # sacrificial pod. Real requests instead of BestEffort. No limits: the
             # iGPU draws from system RAM and a hard cap would OOM mid-generation.


### PR DESCRIPTION
Follow-up to #9046. comfyui now runs on the Intel iGPU, but the first generation failed.

## The error

```
VAE load device: xpu:0, offload device: cpu, dtype: torch.bfloat16
CLIP/text encoder model load device: xpu:0, dtype: torch.float16
!!! Exception during processing !!!
RuntimeError: level_zero backend failed with error: 45 (UR_RESULT_ERROR_INVALID_ARGUMENT)
```

Models loaded onto the GPU fine — it died at execution.

## Why

Iris Xe is **Gen12 Xe-LP**. fp16 is native there; **bf16 is not** — that's an XMX feature introduced on Arc (Xe-HPG). It's the same reason PyTorch prints *"The detected GPU (Intel Iris Xe Graphics) is not officially supported ... please use Intel Arc (Alchemist) or newer."*

ComfyUI defaulted the VAE to bf16, and Level Zero rejected the kernel with `INVALID_ARGUMENT`.

## The change

`CLI_ARGS` gains `--fp16-unet --fp32-vae`. Both flags verified present in this image's `main.py --help`.

`--fp32-vae` rather than `--fp16-vae` because upstream warns fp16 VAE *"might cause black images"*, and the VAE isn't the expensive part.

## Expectations

This is the cheap hypothesis test, not a guarantee. If it still fails on Level Zero, Iris Xe is not viable for diffusion and the choice is CPU (`yanwk/comfyui-boot:cpu`, reliable but ~2-5 min/image on SDXL) or reverting to skirk.

For reference, the Strix baseline was **~30 s uncontested**, 70 s under llama.cpp contention, 100-120 s under heavy contention. Anything on Iris Xe or CPU is a step down; the tradeoff is that comfyui stops being the sacrificial pod that dies whenever dsv4f is loaded.

## Rollback

`git revert`. One line of `CLI_ARGS`.