### PR TITLE
fix(comfyui): run on CPU; Iris Xe is not viable for diffusion

### DIFF
--- a/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
@@ -19,34 +19,27 @@ spec:
           app:
             image:
               repository: yanwk/comfyui-boot
-              tag: xpu@sha256:ab1ac553bfd6756fdf15f52f7da370cdef74a26cbca4e84177ac9720bc5d52f2
+              tag: cpu@sha256:28813f118b7ec92d7c58fa729d382364ceaf87f6ea43eda9a44a5d73009ab0dd
             env:
-              # Iris Xe (Gen12 Xe-LP) keeps rejecting mixed-dtype kernels with
-              # level_zero error 45 (UR_RESULT_ERROR_INVALID_ARGUMENT). Setting
-              # per-component dtypes fixed the VAE and then exposed the same failure
-              # in the CLIP embedding, which casts fp16 weights to fp32 output.
-              # --force-fp32 removes the whole class of cast rather than chasing it
-              # component by component. Slower, but fp32 is native on Xe-LP.
-              # If this still fails, Xe-LP is not viable for diffusion.
-              CLI_ARGS: "--listen 0.0.0.0 --port 8188 --use-pytorch-cross-attention --disable-mmap --force-fp32"
-            # It no longer shares a node with an LLM, so it no longer has to be the
-            # sacrificial pod. Real requests instead of BestEffort. No limits: the
-            # iGPU draws from system RAM and a hard cap would OOM mid-generation.
+              # --cpu is required; without it ComfyUI probes for an accelerator.
+              CLI_ARGS: "--listen 0.0.0.0 --port 8188 --use-pytorch-cross-attention --disable-mmap --cpu"
+              OMP_NUM_THREADS: "16"
+              MKL_NUM_THREADS: "16"
+            # It no longer shares a node with an LLM, so it no longer has to be
+            # the sacrificial BestEffort pod. CPU inference wants cores: request 4
+            # so it always schedules, cap at 16 of eula's 20 so a long generation
+            # cannot starve the control plane. No memory limit - a hard cap would
+            # OOM mid-generation, and the request is what protects it.
             resources:
-              claims:
-                - name: gpu
               requests:
-                cpu: 500m
-                memory: 8Gi
+                cpu: "4"
+                memory: 16Gi
+              limits:
+                cpu: "16"
     defaultPodOptions:
       hostIPC: true
-      resourceClaims:
-        - name: gpu
-          resourceClaimTemplateName: comfyui-gpu
-      # Steer AWAY from the labelled GPU node (skirk) rather than naming the Intel
-      # ones: DRA picks whichever of ayaka/eula/ganyu has a free i915 device. Same
-      # approach as tdarr-node. skirk also carries an llm-workload NoSchedule taint
-      # we no longer tolerate, so it is excluded twice over.
+      # No GPU at all now, so nothing pins this beyond keeping it off skirk —
+      # that node's RAM belongs to dsv4f and comfyui no longer needs its iGPU.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Closes out the iGPU experiment from #9046 / #9048 / `004e8b17a`.

## Three attempts, three failures, same error

Every one was `level_zero backend failed with error: 45 (UR_RESULT_ERROR_INVALID_ARGUMENT)`, and each fix simply exposed the next unsupported op:

| # | config | failed in | why |
|---|---|---|---|
| 1 | defaults | VAE, `dtype: torch.bfloat16` | Xe-LP has no bf16 — that's XMX, Arc and newer |
| 2 | `--fp16-unet --fp32-vae` | CLIP embedding | fp16 weight table cast to fp32 output |
| 3 | `--force-fp32` | `comfy/model_sampling.py:179` — `torch.clamp` | a clamp on a small **fp32** tensor |

**The third is decisive.** A `clamp` on a tiny fp32 tensor is about the simplest operation PyTorch can ask of a device, fp32 is native on Xe-LP, and it still failed. That's Level Zero failing at basic tensor ops — exactly what PyTorch's *"not officially supported ... please use Intel Arc (Alchemist) series or newer"* warning is for. No flag fixes that.

## CPU instead

| | |
|---|---|
| image | `yanwk/comfyui-boot:cpu`, pinned by digest |
| flag | `--cpu` — ComfyUI probes for an accelerator without it |
| threads | `OMP_NUM_THREADS` / `MKL_NUM_THREADS` = 16, matching the CPU limit |
| resources | requests 4 cores / 16 Gi; limit 16 of eula's 20 cores |
| GPU | DRA claim and container claim ref removed |
| placement | unchanged — affinity still steers off skirk |

No memory limit on purpose: a hard cap would OOM mid-generation, and the *request* is what stops it being evicted. The CPU limit exists so a long generation can't starve the control plane on a node that is also a k8s master.

## Honest tradeoff

Roughly **2-5 min/image** against the Strix's **~30 s uncontested** (70 s under llama.cpp contention, 100-120 s heavy). That's a real downgrade in speed.

What it buys: comfyui completes instead of dying. On skirk it was deliberately BestEffort — the removed comment said so — which made it the first pod the Talos OOM manager killed whenever dsv4f was resident. Slow and working beats fast and killed.

## If this is the wrong trade

The alternative is reverting to skirk on the ROCm image but with real `requests` instead of BestEffort. That keeps GPU speed and stops the auto-kill, at the cost of dsv4f losing guaranteed headroom. Worth revisiting if 2-5 min proves intolerable.