### PR TITLE
perf(comfyui): bind CPU inference to P-cores only

### DIFF
--- a/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
@@ -23,8 +23,16 @@ spec:
             env:
               # --cpu is required; without it ComfyUI probes for an accelerator.
               CLI_ARGS: "--listen 0.0.0.0 --port 8188 --use-pytorch-cross-attention --disable-mmap --cpu"
-              OMP_NUM_THREADS: "16"
-              MKL_NUM_THREADS: "16"
+              # eula is an i9-13900H: P-cores are CPUs 0-11, E-cores 12-19. An
+              # OpenMP parallel region finishes when its SLOWEST thread does, so
+              # spreading 16 threads over both core types made every iteration wait
+              # on Gracemont. Bind to P-cores only. GOMP_ for libgomp, KMP_ for the
+              # Intel OpenMP runtime MKL may load instead.
+              OMP_NUM_THREADS: "12"
+              MKL_NUM_THREADS: "12"
+              GOMP_CPU_AFFINITY: "0-11"
+              KMP_AFFINITY: "granularity=fine,proc_list=[0-11],explicit"
+              OMP_PROC_BIND: "close"
             # It no longer shares a node with an LLM, so it no longer has to be
             # the sacrificial BestEffort pod. CPU inference wants cores: request 4
             # so it always schedules, cap at 16 of eula's 20 so a long generation


### PR DESCRIPTION
Follow-up to #9049. CPU works, but the first generation ran at **48.55 s/it × 25 steps ≈ 20 min/image** — roughly 4× worse than the 2-5 min I estimated, and 40× the Strix's ~30 s.

## Cause

eula is an **i9-13900H**, a hybrid part:

```
P-cores  0-11   (6 physical, hyperthreaded)
E-cores  12-19  (8 Gracemont)
```

`OMP_NUM_THREADS=16` spread work over both. An OpenMP parallel region only completes when its **slowest** thread does, so four threads on Gracemont cores gated every iteration.

## Change

Bind OpenMP to P-cores only:

| var | value |
|---|---|
| `OMP_NUM_THREADS` / `MKL_NUM_THREADS` | `12` |
| `GOMP_CPU_AFFINITY` | `0-11` (libgomp) |
| `KMP_AFFINITY` | `granularity=fine,proc_list=[0-11],explicit` (Intel OpenMP runtime) |
| `OMP_PROC_BIND` | `close` |

Both affinity variables are set because it depends which OpenMP runtime PyTorch/MKL loads. CPU limit stays at 16 so quota never throttles 12 threads.

## Expectations

If E-cores were the gate this should help materially. It will **not** close the gap to GPU — even a 2-3× win lands around 7-10 min/image against ~30 s on the Strix.

Worth measuring before deciding whether CPU is viable at all. The standing alternative remains reverting to skirk on ROCm with real `requests` instead of BestEffort: 30 s uncontested, 100-120 s under heavy llama.cpp contention, at the cost of dsv4f losing guaranteed headroom.