### PR TITLE
feat(llm): swap nvidia coder to Qwen3.8-27B

### DIFF
--- a/kubernetes/apps/base/llm/litellm/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/configmap.yaml
@@ -66,7 +66,7 @@ data:
           max_input_tokens: 131072
           max_output_tokens: 16384
           supports_function_calling: true
-          supports_vision: true
+          supports_vision: false
         litellm_params:
           model: openai/llama-nvidia
           api_base: http://llama-nvidia.llm:8080/v1

--- a/kubernetes/apps/base/llm/litellm/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
   - ./externalsecret.yaml
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
-  # - ./llama-nvidia.yaml
-  - ./llama-nvidia-muse.yaml
+  - ./llama-nvidia.yaml
+  # - ./llama-nvidia-muse.yaml
   - ./llama-strix.yaml
   - ./llama-strix-dsv4f.yaml
   - ./llama-reviewer.yaml

--- a/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
@@ -4,7 +4,9 @@ kind: Model
 metadata:
   name: llama-nvidia
 spec:
-  source: https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF/resolve/main/Qwen3.6-27B-UD-Q4_K_XL.gguf
+  source: hf://unsloth/Qwen3.8-27B-GGUF
+  files:
+    - Qwen3.8-27B-UD-Q4_K_XL.gguf
   format: gguf
   quantization: UD-Q4_K_XL
   hardware:
@@ -36,7 +38,7 @@ spec:
   env:
     - name: NVIDIA_DRIVER_CAPABILITIES
       value: compute,utility
-  contextSize: 145000
+  contextSize: 131072
   flashAttention: true
   jinja: true
   parallelSlots: 1


### PR DESCRIPTION
Qwen3.8-27B published today. This points `llama-nvidia` at unsloth's GGUF and re-activates `llama-nvidia.yaml`, commenting out `llama-nvidia-muse.yaml` the same way the Qwen3.6 config has been parked until now. Muse's manifest stays on disk, so reverting is flipping the same two lines back.

## What changed

| | before | after |
|---|---|---|
| source | `unsloth/Qwen3.6-27B-MTP-GGUF` (direct URL) | `hf://unsloth/Qwen3.8-27B-GGUF` + `files:` |
| contextSize | 145000 | 131072 |
| `supports_vision` (nvidia group) | true | false |
| kustomization | muse active | `llama-nvidia.yaml` active |

Unchanged: `parallelSlots: 1`, `cacheTypeK/V: q8_0`, the CUDA image digest, and the whole `--spec-type draft-mtp` block.

## MTP is embedded this time

No `-MTP-GGUF` repo exists for 3.8 — and it isn't needed. Parsing the GGUF header shows the MTP layer is in the plain unsloth build:

```
qwen35.nextn_predict_layers  1
qwen35.block_count           65      (64 + blk.64, the MTP layer)
blk.64.nextn.eh_proj.weight
blk.64.nextn.enorm.weight
blk.64.nextn.hnorm.weight
blk.64.nextn.shared_head_norm.weight
```

So the existing spec-decode args carry over untouched.

## Vision is deliberately off

The model is multimodal upstream (`Qwen3_5ForConditionalGeneration`, a 27-layer ViT, image *and* video tokens), but the main GGUF contains **zero** vision tensors — vision lives entirely in a separate `mmproj-F16.gguf` that this config does not load. `supports_vision: false` reflects that.

Consequence worth noting: opencode's image routing currently targets `fixer` (= `nvidia`) because Muse had an mmproj. With this merged that routing has no local vision backend. Adding `mmproj` later is a two-line change, at the cost of ~0.93 GB of VRAM.

## On the context number

The architecture is hybrid — `full_attention_interval: 4` across 64 layers, so only ~16 layers carry a KV cache and the remaining 48 are linear/Mamba with constant-size state. KV is therefore *cheaper* per token than a dense 27B, and `max_position_embeddings` is 262144.

The binding constraint is weights, not cache: UD-Q4_K_XL is 17.92 GB against a 24 GB card. **131072 is a conservative starting point, not a measured ceiling** — it should be walked up once real VRAM figures are in hand from the load log.

## Validation

`kustomize build` renders cleanly: exactly one `llama-nvidia` Model + InferenceService, no duplicate from the muse file, `contextSize: 131072`, source resolved to the Qwen3.8 GGUF. Not deployed — no cluster changes made.

https://claude.ai/code/session_0189WpTVXUhnduTupUM9M2oD