### PR TITLE
feat(llm): load the Qwen3.8-27B vision projector

### DIFF
--- a/kubernetes/apps/base/llm/litellm/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/configmap.yaml
@@ -66,7 +66,7 @@ data:
           max_input_tokens: 131072
           max_output_tokens: 16384
           supports_function_calling: true
-          supports_vision: false
+          supports_vision: true
         litellm_params:
           model: openai/llama-nvidia
           api_base: http://llama-nvidia.llm:8080/v1

--- a/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
@@ -7,6 +7,7 @@ spec:
   source: hf://unsloth/Qwen3.8-27B-GGUF
   files:
     - Qwen3.8-27B-UD-Q4_K_XL.gguf
+  mmproj: mmproj-F16.gguf
   format: gguf
   quantization: UD-Q4_K_XL
   hardware:
@@ -55,6 +56,8 @@ spec:
   extraArgs:
     - --alias
     - llama-nvidia
+    - --image-min-tokens
+    - "1024"
     - --cont-batching
     - --spec-type
     - draft-mtp

--- a/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
@@ -7,6 +7,7 @@ spec:
   source: hf://unsloth/Qwen3.8-27B-GGUF
   files:
     - Qwen3.8-27B-UD-Q4_K_XL.gguf
+    - mmproj-F16.gguf
   mmproj: mmproj-F16.gguf
   format: gguf
   quantization: UD-Q4_K_XL


### PR DESCRIPTION
Follow-up to #9074. Qwen3.8-27B is multimodal, but the main GGUF carries **zero** vision tensors — vision lives entirely in a separate mmproj, which #9074 deliberately left unloaded. Measured VRAM after that rollout came in lower than expected, so there is room to load it.

## Changes

- `mmproj: mmproj-F16.gguf` (~887 MiB)
- `--image-min-tokens 1024`, matching `llama-strix`
- `supports_vision: true` on the `nvidia` group

## Why this and not more context

The two do not both fit — `23392 + 462 + 887 > 24576 MiB`:

| option | cost | resulting VRAM |
|---|---|---|
| **mmproj (this PR)** | ~887 MiB | ~24279 MiB (98.8%) |
| contextSize → 145000 | ~462 MiB | ~23854 MiB (97.1%) |

Context was the weaker option. LiteLLM advertises `max_input_tokens: 131072` for this group — and did so under Qwen3.6 too, whose manifest ran `contextSize: 145000`. That extra 14k was never reachable by any client, and both dotfiles templates are pinned at 131072 as well, so the bump would have needed three more files changed before it did anything at all.

Vision, by contrast, fixes something **currently broken**: opencode routes image work to `fixer` (= the `nvidia` group) because Muse carried an mmproj, and since the Qwen3.8 swap that route has had no vision backend. The opencode and zed templates already advertise vision on this model, so they become correct again with no change.

## Measurements

Before, at 131072 / 1 slot / q8_0 KV / MTP on:

```
23392 MiB / 24576 idle,  23410 under a 10k prefill   (95.2%)
prefill 1090 tok/s @10.2k depth,  decode 62 tok/s
```

Expected after: ~24279 MiB static, leaving **~300 MiB** for image-encode transients. A 1024×1024 image is ~1024 vision tokens through a 27-layer ViT — roughly 100-200 MiB of peak activation. That margin is why the token floor is set explicitly rather than left to default.

Worth watching the first few image requests. If it proves too tight the mmproj is one line to drop again, and `--image-min-tokens` can be raised to trade image fidelity for headroom before giving up on vision entirely.

`kustomize build` renders cleanly. Not deployed.

https://claude.ai/code/session_0189WpTVXUhnduTupUM9M2oD