### PR TITLE
fix(llm): encode images on CPU so vision stops OOMing the 3090

### DIFF
--- a/kubernetes/apps/base/llm/litellm/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/configmap.yaml
@@ -32,7 +32,7 @@ data:
           cache_read_input_token_cost: 0.0000000216
           output_cost_per_token: 0.0000008649
           max_input_tokens: 125000
-          max_output_tokens: 16384
+          max_output_tokens: 40960
           supports_function_calling: true
           supports_vision: true
         litellm_params:

--- a/kubernetes/apps/base/llm/litellm/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/configmap.yaml
@@ -31,7 +31,7 @@ data:
           cache_creation_input_token_cost: 0.0000002162
           cache_read_input_token_cost: 0.0000000216
           output_cost_per_token: 0.0000008649
-          max_input_tokens: 120000
+          max_input_tokens: 125000
           max_output_tokens: 16384
           supports_function_calling: true
           supports_vision: true

--- a/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
@@ -40,7 +40,7 @@ spec:
   env:
     - name: NVIDIA_DRIVER_CAPABILITIES
       value: compute,utility
-  contextSize: 120000
+  contextSize: 125000
   flashAttention: true
   jinja: true
   parallelSlots: 1
@@ -57,8 +57,7 @@ spec:
   extraArgs:
     - --alias
     - llama-nvidia
-    - --image-min-tokens
-    - "1024"
+    - --no-mmproj-offload
     - --cont-batching
     - --spec-type
     - draft-mtp


### PR DESCRIPTION
Shipping an image to `nvidia` kills llama-server **mid-prefill** — around 6k of ~7.6k prompt tokens, no error, just EOF — then it crashloops as the restart races the dying process for VRAM. This fixes that, and squares three numbers that had drifted apart.

## 1. Vision encode moves to CPU

Nothing bounded the vision encode. Qwen3.8 is a dynamic-resolution vision model, so a full-size image expands to thousands of image tokens and the ViT forward pass allocates on the order of **gigabytes** of transient activation. The card sits at ~97.8% with the projector resident, leaving ~550 MiB — orders of magnitude short.

`--no-mmproj-offload` runs the vision tower on **CPU**, in system RAM, so the encode spike never competes with the GPU. Context, MTP and full image resolution are preserved; the cost is encode latency on a path used occasionally rather than per-token.

Also drops `--image-min-tokens 1024`. That flag was a mistake — it is a **floor**, not a cap:

```
--image-min-tokens N   minimum number of tokens each image can take
--image-max-tokens N   maximum number of tokens each image can take
```

It never bounded anything and only forced small images to consume more than they needed. `--image-max-tokens` is the real cap, but it works by downscaling images, so it stays unset unless CPU encode proves too slow.

## 2. Context back to 125000

120000 was tried first and bought nothing measurable:

| context | VRAM used | free |
|---|---|---|
| 125000 | 24020 MiB | 556 MiB |
| 120000 | 24034 MiB | 542 MiB |

~170 MiB of freed KV was absorbed by other buffers. Freeing enough for a GPU-side encode would mean roughly **75000** context — surrendering 40% of the window permanently so occasional images work.

## 3. LiteLLM now matches the server

Both values on the `nvidia` group had drifted from what the server actually does:

| | was | now | matches |
|---|---|---|---|
| `max_input_tokens` | 120000 | **125000** | `contextSize` |
| `max_output_tokens` | 16384 | **40960** | `--n-predict` and Foreman's `maxOutputTokens` |

The output ceiling was the worse of the two: it advertised **less than the `reasoningBudget: 32768`** sitting beneath it, so a client honouring the advertised value would cap itself below what a long review needs.

## Verification

`kustomize build` renders cleanly. Not deployed.

The open question is CPU encode latency — measuring it is the point of this change. If it is unacceptable, `--image-max-tokens` is the fallback, trading image resolution for GPU-speed encoding. VRAM at idle should be essentially unchanged, since the projector still loads to GPU and only the *encode* moves; if it still OOMs after this, the resident projector rather than the transient activation is the problem, and the answer is dropping vision at this context size.

Worth flagging to the Foreman session once merged: their reviewer agent has a `vision` field and would hit the identical crash the moment it sends an image.

https://claude.ai/code/session_0189WpTVXUhnduTupUM9M2oD