### PR TITLE
feat(llm): Qwen3.8 codes, Nemotron reviews, dsv4f retired

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -8,7 +8,7 @@ spec:
   provider: cloud-proxy
   providerConfig:
     baseURL: http://litellm.llm:4000/v1
-    model: dsv4f-local
+    model: nvidia
     apiKeySecretRef:
       name: foreman-agent
       key: LITELLM_API_KEY
@@ -41,8 +41,8 @@ spec:
     # before the edit-free abort, and cap context just under the window (the
     # default hard cap of 140k sat above it).
     editFreeTurnsLimit: 40
-    contextSoftCap: 100000
-    contextHardCap: 120000
+    contextSoftCap: 85000
+    contextHardCap: 98000
   requestTurnTimeoutSeconds: 1800
   # Must stay below execution.activeDeadlineSeconds. When they were equal (both
   # 7200) the Job deadline won the race, the pod took SIGTERM mid-request, and

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
@@ -12,7 +12,7 @@ spec:
   provider: cloud-proxy
   providerConfig:
     baseURL: http://litellm.llm:4000/v1
-    model: nvidia
+    model: nemotron
     apiKeySecretRef:
       name: foreman-agent
       key: LITELLM_API_KEY
@@ -38,6 +38,9 @@ spec:
   maxOutputTokens: 40960
   maxTurns: 80
   maxRetries: 3
+  stuckLoopDetection:
+    contextSoftCap: 180000
+    contextHardCap: 210000
   requestTurnTimeoutSeconds: 900
   requestTimeoutSeconds: 5400
   bashTimeoutSeconds: 60

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -8,7 +8,7 @@ spec:
   provider: cloud-proxy
   providerConfig:
     baseURL: http://litellm.llm:4000/v1
-    model: nvidia
+    model: nemotron
     apiKeySecretRef:
       name: foreman-agent
       key: LITELLM_API_KEY
@@ -37,8 +37,8 @@ spec:
   maxTurns: 80
   maxRetries: 3
   stuckLoopDetection:
-    contextSoftCap: 85000
-    contextHardCap: 98000
+    contextSoftCap: 180000
+    contextHardCap: 210000
   requestTurnTimeoutSeconds: 900
   requestTimeoutSeconds: 5400
   bashTimeoutSeconds: 60

--- a/kubernetes/apps/base/llm/litellm/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/kustomization.yaml
@@ -8,9 +8,10 @@ resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./llama-nvidia.yaml
+  - ./llama-strix-nemotron.yaml
   # - ./llama-nvidia-muse.yaml
   # - ./llama-strix.yaml
-  - ./llama-strix-dsv4f.yaml
+  # - ./llama-strix-dsv4f.yaml
   - ./llama-vision.yaml
   - ./ocirepository.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/base/llm/litellm/llama-strix-nemotron.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-strix-nemotron.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: llama-strix-nemotron
+spec:
+  source: hf://ggml-org/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF
+  files:
+    - NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Q8_0.gguf
+  format: gguf
+  quantization: Q8_0
+  hardware:
+    accelerator: rocm
+    gpu:
+      enabled: true
+      vendor: amd
+      layers: 99
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: llama-strix-gpu
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: llama-strix-nemotron
+  labels:
+    krr/ignore: "true"
+spec:
+  modelRef: llama-strix-nemotron
+  modelCache:
+    claimName: llmkube-skirk-cache
+  runtime: llamacpp
+  image: docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:0d4df8387ccb224200d7b086d5089b64b41a65d1e609618df39112d74b5fc4de
+  rolloutPolicy:
+    waitForIdle: false
+  command:
+    - llama-server
+  replicas: 1
+  priority: high
+  nodeSelector:
+    topology.kubernetes.io/gpus: amd
+  tolerations:
+    - key: llm-workload
+      operator: Exists
+      effect: NoSchedule
+  contextSize: 262144
+  parallelSlots: 2
+  flashAttention: true
+  jinja: true
+  cacheTypeK: q8_0
+  cacheTypeV: q8_0
+  batchSize: 6144
+  uBatchSize: 2048
+  resources:
+    cpu: "500m"
+    memory: 28Gi
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  extraArgs:
+    - --alias
+    - llama-strix-nemotron
+    - --image-min-tokens
+    - "1024"
+    - --cont-batching
+    - --cache-prompt
+    - --kv-unified
+    - --checkpoint-min-step
+    - "32768"
+    - --threads
+    - "16"
+    - --threads-batch
+    - "21"
+    - --load-mode
+    - none
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 360
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 6
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 6


### PR DESCRIPTION
## Summary

- **Coder** moves from `dsv4f-local` to `nvidia` (Qwen3.8-27B on the 3090).
- **Reviewer** moves from `nvidia` to `nemotron` (Nemotron 3.5 Lightning 30B-A3B on skirk); manifest restored from `a58dff529^` with `replicas: 1`.
- **dsv4f** commented out of the litellm kustomization — file retained, not deleted.
- Context caps resized for both agents against their new serving windows.

## Why

repo-bench v1: **Qwen3.8-27B 0.9360 vs dsv4f-local 0.9380** — 0.002 apart, inside judging error — at **2.1× the speed** (268s vs 574s median wall). A 27B dense ties a ~300B MoE, so dsv4f no longer earns the whole Strix box.

Nemotron is 30B total / **3B active**. skirk is bandwidth-bound, so decode tracks *active* parameters — fast there while still using the box's capacity, which a 12B would not. Lineage is decorrelated from a Qwen coder; Ornith would not have been (`qwen35moe`).

## On Nemotron's 0.6945

That score does not transfer to this role, and it was the worse of two quants:

| | composite | note |
|---|---|---|
| Q4_K_M | 0.8095 | n=19 |
| Q8_0 | 0.6945 | n=20 |

The failure mode is **scope, not accuracy**. Judge notes: *"grounding is excellent — transport.py:51/53/66/82 … verified exact, including line numbers. What costs it points is scope: it repeatedly answers the single-repo half of a cross-repo question and stops."* Single-repo questions average **0.88**, multi-repo **0.66**. Reviewing one diff against one issue in one repo is the 0.88 shape. Treat either number as ±0.1 given the quant swing.

## Context caps

The guard fires on prompt tokens, and generation shares the same window:

```
coder     nvidia    140032 − 40960 (--n-predict)   →  85000 / 98000
reviewer  nemotron  262144 − 40960 (maxOutput)     → 180000 / 210000
```

The reviewer's previous inherited default of 90000 sat inside its working range and was terminating legitimate reviews (`alert-triage-14`, `bridge-93` both died on `ContextSoftCap` with GO'd code and no PR). At 180000 the cap is a runaway backstop — observed reviews run 5–20k prompt tokens.

Reviewer sizing assumes `contextSize` is **per-slot** under `--kv-unified`. Confirm against `n_ctx_slot` in the llama-server startup log after rollout; if it reports 131072 rather than 262144, these need lowering to ~78000/88000.

## Verification

- Not applied. No `kubectl` changes; awaiting Flux.
- **Untested and decisive:** whether Nemotron reliably emits `submit_result` with a *verbatim* `extra.issueAsk`. repo-bench used no tool schema, so tool conformance is unmeasured in both directions. This is the failure mode that broke Muse (truncation) and `bridge-142` (*"Unable to retrieve exact issue body quote"*) — watch the first few reviews for it specifically, not for verdict quality.

## Note

Commit is **unsigned** — 1Password could not be unlocked; done at the author's explicit request.
