### PR TITLE
fix(konflate): avoid multi-cluster PR comment collisions

### DIFF
--- a/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml
+++ b/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml
@@ -14,7 +14,8 @@ spec:
     config:
       clusterPath: ./kubernetes/clusters/${CLUSTER}
       statusChecks: true
-      prComments: true
+      statusCheckName: "Konflate (${CLUSTER})"
+      prComments: ${KONFLATE_PR_COMMENTS:=true}
       publicUrl: "https://${SUBDOMAIN}.jory.dev"
       repo: github://joryirving/home-ops
       mcp: true

--- a/kubernetes/apps/test/flux-system/konflate.yaml
+++ b/kubernetes/apps/test/flux-system/konflate.yaml
@@ -10,6 +10,7 @@ spec:
   postBuild:
     substitute:
       SUBDOMAIN: konflate-${CLUSTER}
+      KONFLATE_PR_COMMENTS: "false"
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/flux-system/konflate.yaml
+++ b/kubernetes/apps/utility/flux-system/konflate.yaml
@@ -10,6 +10,7 @@ spec:
   postBuild:
     substitute:
       SUBDOMAIN: konflate-${CLUSTER}
+      KONFLATE_PR_COMMENTS: "false"
   wait: false
   prune: true
   sourceRef:


### PR DESCRIPTION
## What changed

- give each Konflate instance a cluster-specific GitHub status check name via `Konflate (${CLUSTER})`
- make PR comments configurable through `KONFLATE_PR_COMMENTS`, defaulting to enabled
- disable Konflate PR comments on the `utility` and `test` clusters so only `main` owns the sticky PR summary

## Why

All three Konflate instances target the same GitHub repository and currently identify their sticky PR comment with the same marker. Each webhook delivery can therefore cause one instance to overwrite another instance's rendered summary.

Keeping the sticky comment on `main` avoids that collision until Konflate supports namespaced comment identities upstream. Cluster-specific status check names also prevent the three instances from sharing one check context.

## Impact

- `main`: PR comments remain enabled
- `utility`: PR comments disabled
- `test`: PR comments disabled
- all three clusters retain status checks with distinct names

## Validation

Compared the branch against `main`; the diff is limited to the shared Konflate HelmRelease and the `utility`/`test` Konflate Kustomizations (3 files, 5 changed lines).