### PR TITLE
fix(foreman): resolve the contradictory findings rule in the reviewer contract

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
@@ -132,8 +132,10 @@ spec:
         problem or existing-code fails harness verification and DEMOTES your approval to
         NO-GO — so quote what the issue asks you to DO, not the situation it describes.
       - extra.filesTouched: the exact path list from git diff --name-only main...HEAD.
-      - extra.findings: an array. Use [] for approval. Each blocker or major finding
-        must name a file and line changed by the diff; use minor for non-blocking notes.
+      - extra.findings: an array. A GO must carry no blocker or major finding; minor
+        notes are allowed on any verdict, including GO — an approval that notes a
+        non-blocking observation is still an approval. Each blocker or major finding
+        must name a file AND a line changed by the diff.
 
     Before submit_result, verify extra.issueAsk is literally present in the fetched
     issue body and that verdict agrees with extra.reviewOutcome. A correct approval

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -115,8 +115,10 @@ spec:
         problem or existing-code fails harness verification and DEMOTES your approval to
         NO-GO — so quote what the issue asks you to DO, not the situation it describes.
       - extra.filesTouched: the exact path list from git diff --name-only main...HEAD.
-      - extra.findings: an array. Use [] for approval. Each blocker or major finding
-        must name a file and line changed by the diff; use minor for non-blocking notes.
+      - extra.findings: an array. A GO must carry no blocker or major finding; minor
+        notes are allowed on any verdict, including GO — an approval that notes a
+        non-blocking observation is still an approval. Each blocker or major finding
+        must name a file AND a line changed by the diff.
 
     Before submit_result, verify extra.issueAsk is literally present in the fetched
     issue body and that verdict agrees with extra.reviewOutcome. A correct approval


### PR DESCRIPTION
## Summary
- Replace the contradictory `extra.findings` rule in both reviewer agents' system prompts.

## Why
The contract told the reviewer two incompatible things one clause apart:

> `extra.findings`: an array. **Use [] for approval.** Each blocker or major finding must name a file and line changed by the diff; **use minor for non-blocking notes.**

A GO carrying a minor note violates the first clause, and minor notes on a NO-GO are pointless because the PR is already being rejected — so there was no verdict on which a minor finding was legal. A reviewer that correctly approves while noting a non-blocking observation was non-conformant by construction.

Now: a GO must carry no blocker or major finding, minors are allowed on any verdict including GO, and blockers/majors must name a file **and** a line the diff touched.

## Notes
- The "and a line" part was already in the contract but is now emphasised, because it is the half that catches a finding citing a real file at a fabricated location.
- Applied to `reviewer` and `reviewer-fork`, which carried identical text.
- Agent CRs are cached at pod start, so this needs `kubectl rollout restart deployment/foreman-agent` to take effect once reconciled.
- Surfaced by an external conformance harness built against this contract: a mechanical checker cannot hold both clauses at once, which is how the contradiction became visible.

## Verification
- Both files parse as YAML; `systemPrompt` intact at 4593 and 5397 chars with the old text absent and the new text present.
- No behaviour change to verdict, `reviewOutcome`, `issueAsk` or `filesTouched` rules.
