### PR TITLE
fix(foreman): move the reviewer PR body to extra.prBody and correct the harness claim

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
@@ -81,9 +81,9 @@ spec:
     change does not — do not demand a Go test for a Helm or YAML change. You are
     read-only. Decide honestly from the diff, then call submit_result:
     - request-changes: give specific, diff-grounded reasons.
-    - approve (GO): foreman opens the PR using your summary verbatim as the body, so your
-      summary MUST BE the full PR body and MUST follow this repo's pull request template
-      exactly — these four headings, in this order:
+    - approve (GO): foreman opens the PR using extra.prBody verbatim as the body, so
+      extra.prBody MUST BE the full PR body and MUST follow this repo's pull request
+      template exactly — these four headings, in this order:
 
         ## What
         <one or two lines: what the diff changes>
@@ -119,8 +119,16 @@ spec:
     STEP 3 — terminal payload. Call submit_result exactly once. Do not invent fields
     such as commit_message. Always send:
       - verdict: GO for approve, NO-GO for request-changes, ERROR if review was impossible.
-      - summary: for GO, the complete PR body required above; for NO-GO or ERROR, a
-        concise actionable explanation.
+      - summary: ONE sentence, 280 characters or fewer, on ANY verdict. It is
+        truncated at 280 bytes, so it is the wrong place for a PR description —
+        put that in extra.prBody. This line is what shows up in logs, status and
+        the audit record.
+      - extra.prBody (GO only): the full PR description required above, in Markdown,
+        with no length limit. This is what foreman uses as the pull request body.
+        Omitting it falls back to summary, which means the PR description becomes a
+        truncated fragment of one sentence. Writing it does not make you the PR
+        author: you supply the text, foreman opens the PR and applies the target
+        repo's template.
       - extra.reviewOutcome: APPROVE for GO, REQUEST-CHANGES for a fixable NO-GO,
         or REJECT only when retrying cannot fix the scope mismatch.
       - extra.issueAsk: copy one exact contiguous quote (≤200 chars) from the issue body
@@ -138,5 +146,8 @@ spec:
         must name a file AND a line changed by the diff.
 
     Before submit_result, verify extra.issueAsk is literally present in the fetched
-    issue body and that verdict agrees with extra.reviewOutcome. A correct approval
-    without this structured evidence is rejected by the harness.
+    issue body and that verdict agrees with extra.reviewOutcome. The harness grounds
+    issueAsk against the issue body it saw you fetch: a quote it cannot find is
+    replaced and marked unverified, and an unverified GO is demoted to NO-GO unless
+    the deterministic scope check independently vouches for the diff. Do not rely on
+    that vouch — quote accurately.

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -78,9 +78,9 @@ spec:
     You are read-only — do not edit the branch; if a change is needed, describe it
     specifically in the review. Then call submit_result:
     - request-changes: give specific, diff-grounded reasons.
-    - approve (GO): foreman opens the PR using your summary as the body, so write a
-      clear, self-contained PR description — enough that a reviewer understands the
-      change without reading every line of the diff:
+    - approve (GO): foreman opens the PR using extra.prBody as the body, so write a
+      clear, self-contained PR description there — enough that a reviewer understands
+      the change without reading every line of the diff:
 
         ## What
         <what the diff changes>
@@ -102,8 +102,16 @@ spec:
     STEP 3 — terminal payload. Call submit_result exactly once. Do not invent fields
     such as commit_message. Always send:
       - verdict: GO for approve, NO-GO for request-changes, ERROR if review was impossible.
-      - summary: for GO, the complete PR body required above; for NO-GO or ERROR, a
-        concise actionable explanation.
+      - summary: ONE sentence, 280 characters or fewer, on ANY verdict. It is
+        truncated at 280 bytes, so it is the wrong place for a PR description —
+        put that in extra.prBody. This line is what shows up in logs, status and
+        the audit record.
+      - extra.prBody (GO only): the full PR description required above, in Markdown,
+        with no length limit. This is what foreman uses as the pull request body.
+        Omitting it falls back to summary, which means the PR description becomes a
+        truncated fragment of one sentence. Writing it does not make you the PR
+        author: you supply the text, foreman opens the PR and applies the target
+        repo's template.
       - extra.reviewOutcome: APPROVE for GO, REQUEST-CHANGES for a fixable NO-GO,
         or REJECT only when retrying cannot fix the scope mismatch.
       - extra.issueAsk: copy one exact contiguous quote (≤200 chars) from the issue body
@@ -121,5 +129,8 @@ spec:
         must name a file AND a line changed by the diff.
 
     Before submit_result, verify extra.issueAsk is literally present in the fetched
-    issue body and that verdict agrees with extra.reviewOutcome. A correct approval
-    without this structured evidence is rejected by the harness.
+    issue body and that verdict agrees with extra.reviewOutcome. The harness grounds
+    issueAsk against the issue body it saw you fetch: a quote it cannot find is
+    replaced and marked unverified, and an unverified GO is demoted to NO-GO unless
+    the deterministic scope check independently vouches for the diff. Do not rely on
+    that vouch — quote accurately.


### PR DESCRIPTION
**Draft: do not merge until LLMKube#1575 lands.** Depends on `extra.prBody` being read by the executor.

## Summary
- Move the PR description from `summary` to `extra.prBody` in both reviewer prompts.
- Redefine `summary` as a one-sentence outcome line, which is what it always was in the schema.
- Replace an inaccurate claim about harness enforcement.

## Why
`summary` is capped at 280 bytes by `MaxSubmitSummaryLen` in `submit_result.go`, and both prompts told the reviewer to put the complete PR body there. Those cannot both hold, so every PR foreman has opened has had its body truncated mid-sentence. An external conformance bench put a number on it: a GO caps at 0.929 today because the structured-body requirement and the length cap fail in opposite directions at equal cost, which is the signature of an unsatisfiable rule rather than a demanding one. LLMKube#1575 adds `extra.prBody`, uncapped, with `summary` as fallback.

Our two reviewers carry hand-written inline prompts, so #1575 reaches them only through this change. Anyone whose Agent has an inline `systemPrompt` gets the plumbing and none of the instruction.

The second change is a correctness fix. The prompt claimed "A correct approval without this structured evidence is rejected by the harness." That is not what happens: `reconcileReviewerIssueAsk` replaces an unfindable quote and marks it unverified, and `enforceReviewerIssueAsk` demotes an unverified GO **unless** the deterministic scope check vouches for the diff. The prompt now describes that accurately and tells the reviewer not to lean on the vouch. A prompt that threatens a penalty which does not always apply teaches the model to discount the rest of it.

## Notes
- `reviewer-fork.yaml` needed different wording for the same edits; its approve block is more prescriptive about the four-heading template, and that template requirement is preserved, just relocated to `prBody`.
- Requires `kubectl rollout restart deployment/foreman-agent` after merge — Agent CRs are cached at pod start. Batches with the `findings` fix from #9112, which is merged but not yet live for the same reason.
- Ordering matters: merged before #1575, PR bodies become a clean one-sentence summary instead of a truncated one. Not harmful, but less useful than today, so this waits.

## Verification
- Both files parse; prompts intact at 5353 and 6151 chars.
- Asserted present: the `prBody` key, the 280-character definition of `summary`, the corrected scope-vouch text. Asserted absent: `rejected by the harness`, and both old "summary as the body" phrasings.
