### PR TITLE
feat(llm): expose toolhive with oauth

### DIFF
--- a/kubernetes/apps/base/llm/hermes/configmap.yaml
+++ b/kubernetes/apps/base/llm/hermes/configmap.yaml
@@ -63,7 +63,8 @@ data:
         - hermes-telegram
     mcp_servers:
       toolhive:
-        url: http://vmcp-mcp-gateway-internal.llm:4483/mcp
+        auth: oauth
+        url: https://mcp.jory.dev/mcp
       composio:
         url: https://connect.composio.dev/mcp
         enabled: true

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -281,12 +281,12 @@ data:
           "admin-http-rpc": { enabled: true },
           "lossless-claw": {
             enabled: true,
-            llm: { allowModelOverride: true, allowedModels: [ "litellm/self-hosted" ], },
-            subagent: { allowModelOverride: true, allowedModels: [ "litellm/self-hosted" ], },
+            llm: { allowModelOverride: true, allowedModels: [ "litellm/summary" ], },
+            subagent: { allowModelOverride: true, allowedModels: [ "litellm/summary" ], },
             config: {
               contextThreshold: 0.75,
               delegationTimeoutMs: 1000000,
-              expansionModel: "litellm/self-hosted",
+              expansionModel: "litellm/summary",
               freshTailCount: 64,
               freshTailMaxTokens: 24000,
               ignoreSessionPatterns: [
@@ -302,7 +302,7 @@ data:
               pruneHeartbeatOk: true,
               skipStatelessSessions: true,
               statelessSessionPatterns: [ "agent:*:subagent:**" ],
-              summaryModel: "litellm/self-hosted",
+              summaryModel: "litellm/summary",
               summaryTimeoutMs: 1000000,
               transcriptGcEnabled: false,
             },
@@ -401,8 +401,9 @@ data:
       mcp: {
         servers: {
           toolhive: {
-            url: "http://vmcp-mcp-gateway-internal.llm:4483/mcp",
+            url: "https://mcp.jory.dev/mcp",
             transport: "streamable-http",
+            auth: "oauth",
             headers: {
               Accept: "application/json, text/event-stream",
             },

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -281,12 +281,12 @@ data:
           "admin-http-rpc": { enabled: true },
           "lossless-claw": {
             enabled: true,
-            llm: { allowModelOverride: true, allowedModels: [ "litellm/summary" ], },
-            subagent: { allowModelOverride: true, allowedModels: [ "litellm/summary" ], },
+            llm: { allowModelOverride: true, allowedModels: [ "litellm/self-hosted" ], },
+            subagent: { allowModelOverride: true, allowedModels: [ "litellm/self-hosted" ], },
             config: {
               contextThreshold: 0.75,
               delegationTimeoutMs: 1000000,
-              expansionModel: "litellm/summary",
+              expansionModel: "litellm/self-hosted",
               freshTailCount: 64,
               freshTailMaxTokens: 24000,
               ignoreSessionPatterns: [
@@ -302,7 +302,7 @@ data:
               pruneHeartbeatOk: true,
               skipStatelessSessions: true,
               statelessSessionPatterns: [ "agent:*:subagent:**" ],
-              summaryModel: "litellm/summary",
+              summaryModel: "litellm/self-hosted",
               summaryTimeoutMs: 1000000,
               transcriptGcEnabled: false,
             },

--- a/kubernetes/apps/base/llm/toolhive/config/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/externalsecret.yaml
@@ -16,3 +16,22 @@ spec:
   dataFrom:
     - extract:
         key: litellm
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-auth
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        client-secret: "{{ .TOOLHIVE_CLIENT_SECRET }}"
+        signing-key: "{{ .TOOLHIVE_SIGNING_KEY }}"
+  dataFrom:
+    - extract:
+        key: toolhive

--- a/kubernetes/apps/base/llm/toolhive/config/httproute.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/httproute.yaml
@@ -8,7 +8,7 @@ spec:
   hostnames:
     - mcp.jory.dev
   parentRefs:
-    - name: envoy-internal
+    - name: envoy-external
       namespace: network
   rules:
     - backendRefs:

--- a/kubernetes/apps/base/llm/toolhive/config/kustomization.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./httproute.yaml
+  - ./mcpoidcconfig.yaml
   - ./mcp-telemetry.yaml
   - ./mcpgroup.yaml
   - ./podmonitor.yaml

--- a/kubernetes/apps/base/llm/toolhive/config/mcpoidcconfig.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/mcpoidcconfig.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpoidcconfig_v1beta1.json
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPOIDCConfig
+metadata:
+  name: mcp-gateway
+spec:
+  inline:
+    issuer: https://mcp.jory.dev
+  type: inline

--- a/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
@@ -1,9 +1,28 @@
 ---
-apiVersion: toolhive.stacklok.dev/v1alpha1
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/virtualmcpserver_v1beta1.json
+apiVersion: toolhive.stacklok.dev/v1beta1
 kind: VirtualMCPServer
 metadata:
   name: mcp-gateway-internal
 spec:
+  authServerConfig:
+    issuer: https://mcp.jory.dev
+    signingKeySecretRefs:
+      - key: signing-key
+        name: toolhive-auth
+    upstreamProviders:
+      - name: authentik
+        oidcConfig:
+          clientId: toolhive
+          clientSecretRef:
+            key: client-secret
+            name: toolhive-auth
+          issuerUrl: https://sso.jory.dev/application/o/toolhive/
+          scopes:
+            - openid
+            - profile
+            - email
+        type: oidc
   groupRef:
     name: mcp-tools
   config:
@@ -17,7 +36,13 @@ spec:
       embeddingService: http://litellm.llm:4000/v1
       embeddingServiceTimeout: 60s
   incomingAuth:
-    type: anonymous
+    oidcConfigRef:
+      audience: https://mcp.jory.dev
+      name: mcp-gateway
+      resourceUrl: https://mcp.jory.dev
+      scopes:
+        - openid
+    type: oidc
   outgoingAuth:
     source: discovered
   podTemplateSpec:

--- a/terraform/authentik/applications.tofu
+++ b/terraform/authentik/applications.tofu
@@ -16,6 +16,7 @@ locals {
     "Paperless",
     "Portainer",
     "RomM",
+    "ToolHive",
     "Waypoint",
     "WorkAdventure",
   ]
@@ -176,6 +177,16 @@ locals {
       redirect_uri      = "https://romm.${var.CLUSTER_DOMAIN}/api/oauth/openid"
       launch_url        = "https://romm.${var.CLUSTER_DOMAIN}"
       property_mappings = concat(local.default_property_mappings, [authentik_property_mapping_provider_scope.email_verified.id])
+    },
+    ToolHive = {
+      # This must match authServerConfig.upstreamProviders[].oidcConfig.clientId.
+      client_id         = "toolhive"
+      client_secret     = module.onepassword_application["ToolHive"].fields["TOOLHIVE_CLIENT_SECRET"]
+      group             = "ai"
+      icon_url          = "https://github.com/stacklok.png"
+      redirect_uri      = "https://mcp.${var.CLUSTER_DOMAIN}/oauth/callback"
+      launch_url        = "https://mcp.${var.CLUSTER_DOMAIN}"
+      property_mappings = local.default_property_mappings
     },
     Waypoint = {
       client_id         = module.onepassword_application["Waypoint"].fields["WAYPOINT_CLIENT_ID"]


### PR DESCRIPTION
ToolHive is currently cluster-internal and anonymous. This exposes `mcp.jory.dev` through the external Envoy Gateway and requires OAuth/OIDC, with ToolHive issuing MCP access tokens and Authentik handling the user login. OpenClaw and Hermes now use the public endpoint with OAuth.

Before merge, create the `toolhive` item in the Kubernetes 1Password vault with:
- `TOOLHIVE_CLIENT_SECRET`: the Authentik upstream OAuth client secret
- `TOOLHIVE_SIGNING_KEY`: a PEM signing key for ToolHive's embedded authorization server

Terraform creates the Authentik `toolhive` client, restricted to the `ai` group, with callback `https://mcp.jory.dev/oauth/callback`. OpenCode/Zed dotfiles are intentionally out of scope for this home-ops PR.

Checks:
- `kubectl kustomize` passed for ToolHive, OpenClaw, and Hermes
- OpenClaw JSON5 config validation passed
- `tofu fmt -check` and `tofu validate` passed
- `flate` passed the changed ToolHive/OpenClaw/Hermes resources; the full main-cluster run also reports 16 pre-existing OCI mirror credential failures