### PR TITLE
fix(llm): fix toolhive auth upstream

### DIFF
--- a/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
@@ -12,17 +12,22 @@ spec:
         name: toolhive-auth
     upstreamProviders:
       - name: authentik
-        oidcConfig:
+        oauth2Config:
+          allowPrivateIPs: true
+          authorizationEndpoint: https://sso.jory.dev/application/o/authorize/
           clientId: toolhive
           clientSecretRef:
             key: client-secret
             name: toolhive-auth
-          issuerUrl: https://sso.jory.dev/application/o/toolhive/
+          redirectUri: https://mcp.jory.dev/oauth/callback
           scopes:
             - openid
             - profile
             - email
-        type: oidc
+          tokenEndpoint: https://sso.jory.dev/application/o/token/
+          userInfo:
+            endpointUrl: https://sso.jory.dev/application/o/userinfo/
+        type: oauth2
   groupRef:
     name: mcp-tools
   config:


### PR DESCRIPTION
The first auth rollout left the old anonymous vMCP pod serving because the replacement pod could not start its embedded auth server. ToolHive 0.43 rejected OIDC discovery for `sso.jory.dev` after it resolved to the cluster's private gateway address `10.69.10.32`.

This keeps the public MCP OAuth/OIDC contract, but configures Authentik as an explicit OAuth2 upstream with its authorization, token, and userinfo endpoints plus `allowPrivateIPs: true`. TLS remains required; `insecureAllowHTTP` is not enabled.

Validation:
- live API-server dry-run accepted the v1beta1 resource
- ToolHive Kustomization rendered successfully
- OpenClaw/Hermes consumer changes are unchanged
- observed unauthenticated initialize success and the crashloop error on the old deployment