### PR TITLE
fix(llm): persist toolhive oauth secrets

### DIFF
--- a/kubernetes/apps/base/llm/toolhive/config/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/externalsecret.yaml
@@ -31,6 +31,7 @@ spec:
     template:
       data:
         client-secret: "{{ .TOOLHIVE_CLIENT_SECRET }}"
+        hmac-secret: "{{ .TOOLHIVE_HMAC_SECRET }}"
         signing-key: "{{ .TOOLHIVE_SIGNING_KEY }}"
   dataFrom:
     - extract:

--- a/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
@@ -6,6 +6,9 @@ metadata:
   name: mcp-gateway-internal
 spec:
   authServerConfig:
+    hmacSecretRefs:
+      - key: hmac-secret
+        name: toolhive-auth
     issuer: https://mcp.jory.dev
     signingKeySecretRefs:
       - key: signing-key


### PR DESCRIPTION
ToolHive currently generates its OAuth HMAC secret ephemerally, which invalidates authorization codes and refresh tokens whenever the pod restarts. This wires a durable HMAC value from the existing 1Password-backed `toolhive-auth` Secret into the embedded authorization server.

Validated with `git diff --check` and `flate test all --path ./kubernetes/clusters/main`; all Kustomizations and ToolHive resources passed. The full run also reported unrelated existing OCI credential failures for charts hosted through `ocharted.jory.dev`.
