### PR TITLE
fix(llm): persist toolhive auth clients

### DIFF
--- a/kubernetes/apps/base/llm/toolhive/config/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/externalsecret.yaml
@@ -36,3 +36,21 @@ spec:
   dataFrom:
     - extract:
         key: toolhive
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-config-redis
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        password: "{{ .TOOLHIVE_CONFIG_REDIS_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: toolhive

--- a/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
@@ -13,6 +13,14 @@ spec:
     signingKeySecretRefs:
       - key: signing-key
         name: toolhive-auth
+    storage:
+      redis:
+        aclUserConfig:
+          passwordSecretRef:
+            key: password
+            name: toolhive-config-redis
+        addr: toolhive-config-dragonfly.llm:6379
+      type: redis
     upstreamProviders:
       - name: authentik
         oauth2Config:

--- a/kubernetes/apps/main/llm/toolhive.yaml
+++ b/kubernetes/apps/main/llm/toolhive.yaml
@@ -38,6 +38,7 @@ metadata:
 spec:
   components:
     - ../../../../../components/dragonfly
+    - ../../../../../components/dragonfly/authentication
     - ../../../../../components/gpu
   dependsOn:
     - name: dragonfly-operator
@@ -53,6 +54,7 @@ spec:
   postBuild:
     substitute:
       APP: *name
+      DRAGONFLY_PASSWORD_SECRET: toolhive-config-redis
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/components/dragonfly/authentication/kustomization.yaml
+++ b/kubernetes/components/dragonfly/authentication/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# Consumers must provide DRAGONFLY_PASSWORD_SECRET through postBuild substitution.
+patches:
+  - target:
+      group: dragonflydb.io
+      version: v1alpha1
+      kind: Dragonfly
+    patch: |-
+      - op: add
+        path: /spec/authentication
+        value:
+          passwordFromSecret:
+            key: password
+            name: ${DRAGONFLY_PASSWORD_SECRET}


### PR DESCRIPTION
ToolHive dynamic OAuth client registrations were stored in memory, so remote clients lost their registration after an auth-server pod restart. This configures the existing Dragonfly component as password-protected Redis storage for the embedded auth server and adds a reusable Dragonfly authentication component.

Before merge, add a generated `TOOLHIVE_CONFIG_REDIS_PASSWORD` field to the `toolhive` 1Password item.

Validation: ToolHive Kustomizations rendered successfully and the generated Dragonfly, ExternalSecret, and VirtualMCPServer fields were verified. The full `flate test all` run still reports unrelated OCI credential failures for 16 other resources.