### PR TITLE
fix(renovate): limit docker tag pages

### DIFF
--- a/kubernetes/apps/base/renovate/renovate-jobs/misospace.yaml
+++ b/kubernetes/apps/base/renovate/renovate-jobs/misospace.yaml
@@ -54,6 +54,8 @@ spec:
         ["mise"]
     - name: RENOVATE_PLATFORM_COMMIT_ENABLED
       value: "true"
+    - name: RENOVATE_DOCKER_MAX_PAGES
+      value: "10"
     - name: DOCKERHUB_USERNAME
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
Renovate falls back from Docker Hub metadata pagination to the registry tags endpoint for hexpm/elixir, which has nearly one million tags and times out at n=10000. Limit Docker tag metadata pagination to 10 pages so the active bake-file dependency remains managed without the external-host-error fallback.