### PR TITLE
fix(llm): disable toolhive cluster mode

### DIFF
--- a/kubernetes/apps/main/llm/toolhive.yaml
+++ b/kubernetes/apps/main/llm/toolhive.yaml
@@ -35,6 +35,8 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: &name toolhive-config
+  labels:
+    components.dragonfly/cluster-mode: non-cluster
 spec:
   components:
     - ../../../../../components/dragonfly

--- a/kubernetes/clusters/main/apps.yaml
+++ b/kubernetes/clusters/main/apps.yaml
@@ -183,3 +183,23 @@ spec:
       target:
         kind: Kustomization
         labelSelector: "components.postgres/cnpg=init"
+    - # Disable Redis Cluster emulation for ToolHive auth storage.
+      # Dragonfly replication remains enabled; this only removes cluster mode
+      # for clients whose Lua scripts are incompatible with emulated clusters.
+      patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: not-used
+        spec:
+          patches:
+            - target:
+                group: dragonflydb.io
+                version: v1alpha1
+                kind: Dragonfly
+              patch: |-
+                - op: remove
+                  path: /spec/args/2
+      target:
+        kind: Kustomization
+        labelSelector: "components.dragonfly/cluster-mode=non-cluster"


### PR DESCRIPTION
ToolHive auth storage uses Lua scripts that Dragonfly rejects when `--cluster_mode=emulated` is enabled. This labels the ToolHive Flux Kustomization and uses the existing main-cluster label-selector patch pattern to remove that flag only from its Dragonfly resource.

The existing two operator-managed Dragonfly replicas, replication, and password authentication remain unchanged.

Validation: the rendered ToolHive Dragonfly has two replicas and no cluster-mode flag. The full `flate test all` run still reports the same 16 unrelated OCI credential failures.