### PR TITLE
fix(foreman): run the dispatch bridge overnight only

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
       foreman-dispatch-bridge:
         type: cronjob
         cronjob:
-          schedule: "*/15 * * * *"
+          schedule: "*/15 20-23,0-7 * * *"
           timeZone: America/Edmonton
           concurrencyPolicy: Forbid
           successfulJobsHistory: 1


### PR DESCRIPTION
## Summary
- Bridge CronJob moves from `*/15 * * * *` to `*/15 20-23,0-7 * * *`. 48 ticks between 20:00 and 07:45 instead of 96 around the clock.

`timeZone: America/Edmonton` was already set, so the window is local time.

## Notes
- `concurrencyPolicy: Forbid` is unchanged, so the window narrowing cannot overlap ticks.
- Stopping the cron only stops new claims. A Workload in flight at 08:00 is owned by the Foreman controller and runs to completion; it is not interrupted.