### PR TITLE
feat(llm): dedicate skirk to a BF16 Qwen3.8-27B quality test

### DIFF
--- a/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
@@ -13,6 +13,7 @@ spec:
   values:
     controllers:
       comfyui:
+        replicas: 0
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/base/llm/litellm/configmap.yaml
+++ b/kubernetes/apps/base/llm/litellm/configmap.yaml
@@ -24,6 +24,15 @@ data:
           additional_drop_params: ["reasoning_effort"]
           max_parallel_requests: 1
 
+      - model_name: strix-bf16
+        litellm_params:
+          model: openai/llama-strix-bf16
+          api_base: http://llama-strix-bf16.llm:8080/v1
+          api_key: llama-strix-bf16
+          additional_drop_params: ["reasoning_effort"]
+          max_parallel_requests: 1
+          timeout: 3600
+
       - model_name: vision
         model_info:
           mode: chat

--- a/kubernetes/apps/base/llm/litellm/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/kustomization.yaml
@@ -8,9 +8,10 @@ resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./llama-nvidia.yaml
-  - ./llama-strix-nemotron.yaml
+  # - ./llama-strix-nemotron.yaml  # BF16 quality test: slot needed on skirk
   # - ./llama-nvidia-muse.yaml
-  - ./llama-strix.yaml
+  # - ./llama-strix.yaml  # BF16 quality test: slot needed on skirk
+  - ./llama-strix-bf16.yaml
   # - ./llama-strix-dsv4f.yaml
   - ./llama-vision.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/litellm/llama-strix-bf16.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-strix-bf16.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: llama-strix-bf16
+spec:
+  source: hf://unsloth/Qwen3.8-27B-GGUF
+  files:
+    - BF16/Qwen3.8-27B-BF16-00001-of-00002.gguf
+    - BF16/Qwen3.8-27B-BF16-00002-of-00002.gguf
+    - mmproj-BF16.gguf
+  mmproj: mmproj-BF16.gguf
+  format: gguf
+  quantization: BF16
+  hardware:
+    accelerator: rocm
+    gpu:
+      enabled: true
+      vendor: amd
+      layers: 99
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: llama-strix-gpu
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: llama-strix-bf16
+  labels:
+    krr/ignore: "true"
+spec:
+  modelRef: llama-strix-bf16
+  modelCache:
+    claimName: llmkube-skirk-cache
+  runtime: llamacpp
+  image: docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:3da2f2ac44b94cff12f3b1b2be39cd88c0612b393617abfaf7d262e16b14b6c4
+  rolloutPolicy:
+    waitForIdle: false
+    idleTimeoutSeconds: 86400
+  command:
+    - llama-server
+  replicas: 0
+  priority: high
+  nodeSelector:
+    topology.kubernetes.io/gpus: amd
+  tolerations:
+    - key: llm-workload
+      operator: Exists
+      effect: NoSchedule
+  contextSize: 140000
+  parallelSlots: 1
+  flashAttention: true
+  jinja: true
+  cacheTypeK: q8_0
+  cacheTypeV: q8_0
+  reasoningBudget: 32768
+  reasoningBudgetMessage: "Stop reasoning and produce the implementation, tool call, or final answer."
+  batchSize: 6144
+  uBatchSize: 2048
+  resources:
+    cpu: "500m"
+    memory: 32Gi
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  extraArgs:
+    - --alias
+    - llama-strix-bf16
+    - --image-min-tokens
+    - "1024"
+    - --cont-batching
+    - --spec-type
+    - draft-mtp
+    - --spec-draft-p-min
+    - "0.75"
+    - --spec-draft-n-max
+    - "3"
+    - --spec-draft-type-k
+    - q8_0
+    - --spec-draft-type-v
+    - q8_0
+    - --cache-prompt
+    - --kv-unified
+    - --checkpoint-min-step
+    - "32768"
+    - --temp
+    - "1"
+    - --top-p
+    - "0.95"
+    - --top-k
+    - "20"
+    - --min-p
+    - "0"
+    - --presence-penalty
+    - "0"
+    - --repeat-penalty
+    - "1"
+    - --threads
+    - "16"
+    - --threads-batch
+    - "21"
+    - --load-mode
+    - none
+    - --chat-template-kwargs
+    - '{"reasoning_effort":"medium"}'
+    - --n-predict
+    - "40960"
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 720
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 6
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 6

--- a/kubernetes/apps/base/llm/memini/kustomization.yaml
+++ b/kubernetes/apps/base/llm/memini/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./memini-embed.yaml
-  - ./memini-rerank.yaml
+  # - ./memini-rerank.yaml  # BF16 quality test: slot needed on skirk
   - ./memini-summary.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/toolhive/config/kustomization.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/kustomization.yaml
@@ -9,6 +9,6 @@ resources:
   - ./mcp-telemetry.yaml
   - ./mcpgroup.yaml
   - ./podmonitor.yaml
-  - ./toolhive-embed.yaml
+  # - ./toolhive-embed.yaml  # BF16 quality test: slot needed on skirk
   - ./virtualmcpserver.yaml
   - ./dashboard/


### PR DESCRIPTION
Setting up to test 27B BF16 on the strix halo.

Frees the skirk GPU slot (BF16 is 51.77 GiB, only 23.33 GiB free) by commenting the other llmkube models out of their kustomizations. comfyui is scaled to 0 instead, since it owns a PVC.

Lands at `replicas: 0` — scale-up is manual once GTT is free.
