### PR TITLE
fix(llm): repair three regressions from the litellm-operator migration

### DIFF
--- a/kubernetes/apps/base/llm/litellm/httproute.yaml
+++ b/kubernetes/apps/base/llm/litellm/httproute.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: litellm
+  name: litellm-external
 spec:
   hostnames:
     - litellm.jory.dev

--- a/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
@@ -25,12 +25,11 @@ resources:
   - ./kimi-k3-1.yaml
   - ./kimi-k3-2.yaml
   - ./memini-embed.yaml
-  - ./memini-rerank.yaml
-  - ./mimo-v2.5.yaml
   - ./mimo-v2.5-pro.yaml
+  - ./mimo-v2.5.yaml
   - ./minimax-m2.7.yaml
-  - ./minimax-m3.yaml
   - ./minimax-m3-chat.yaml
+  - ./minimax-m3.yaml
   - ./muse.yaml
   - ./nemotron.yaml
   - ./neuralwatt-glm-5.2.yaml
@@ -40,6 +39,7 @@ resources:
   - ./reasoning-pool-2.yaml
   - ./reasoning-pool-3.yaml
   - ./reasoning-pool-4.yaml
+  - ./rerank.yaml
   - ./self-hosted.yaml
   - ./strix-fp8.yaml
   - ./summary.yaml

--- a/kubernetes/apps/base/llm/litellm/models/rerank.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/rerank.yaml
@@ -2,9 +2,9 @@
 apiVersion: litellm.home-operations.com/v1alpha1
 kind: LiteLLMModel
 metadata:
-  name: memini-rerank
+  name: rerank
 spec:
-  modelName: memini-rerank
+  modelName: rerank
   proxyRef: litellm
   params:
     model: infinity/memini-rerank

--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
               MEMINI_LLM_MODEL: summary
               MEMINI_REEMBED_ON_MODEL_CHANGE: true
               MEMINI_RERANK: http://litellm.llm:4000/v1
-              MEMINI_RERANK_MODEL: memini-rerank
+              MEMINI_RERANK_MODEL: rerank
               MEMINI_RERANK_MAX_CONCURRENCY: 2
               MEMINI_RERANK_TIMEOUT: 12s
               MEMINI_RERANK_POOL: "8"

--- a/kubernetes/apps/main/llm/litellm.yaml
+++ b/kubernetes/apps/main/llm/litellm.yaml
@@ -10,6 +10,7 @@ spec:
     - ../../../../components/postgres
     - ../../../../components/kopiur/backup
   dependsOn:
+    - name: litellm-operator
     - name: llmkube
   healthCheckExprs:
     - apiVersion: dragonflydb.io/v1alpha1


### PR DESCRIPTION
Three regressions from #9178, none visible in a manifest diff.

**`memini-rerank` → `rerank`.** autoRegister adopts projected models **by name**, so our explicit CR was taken over and `infinity/memini-rerank` rewritten to `openai/memini-rerank` + `/v1`. Rerank is not OpenAI-shaped:

```
ValueError: Unsupported provider: openai
```

memini falls back to composite ordering on rerank failure, so recall degraded silently. `MEMINI_RERANK_MODEL` moves with the rename.

**HTTPRoute `litellm` → `litellm-external`.** With `spec.route` nil the operator deletes any HTTPRoute matching the proxy name, without checking ownership — flux created it, the operator deleted it, external access went down. Upstream: home-operations/litellm-operator#108.

**`dependsOn: litellm-operator`.** The two Kustomizations raced by 4s on rollout and it did not self-heal — kustomize-controller had a 14-day-old discovery cache and failed the same dry-run for 35 min until restarted.

Commit is unsigned (1Password locked).
