### PR TITLE
fix(llm): point llama-strix-fp8 at an engine image that can start

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-strix-fp8.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-strix-fp8.yaml
@@ -30,7 +30,7 @@ spec:
   modelCache:
     claimName: llmkube-skirk-cache
   runtime: llamacpp
-  image: ghcr.io/julianmb/q38rocm:1.1.0
+  image: ghcr.io/joryirving/q38rocm-engine:rocm7.14-v1.0.0
   rolloutPolicy:
     waitForIdle: false
     idleTimeoutSeconds: 86400


### PR DESCRIPTION
Their published image has no ROCm runtime — `libhipblas.so.3`, `librocblas.so.5`, `libamdhip64.so.7` all missing, so `llama-server` cannot exec regardless of backend.

Swaps to `ghcr.io/joryirving/q38rocm-engine:rocm7.14-v1.0.0` — their v1.0.0 engine tarball on kyuz0 `rocm-7.14`, plus vulkan-loader/mesa for the RADV Wave64 path. Verified all libs resolve.

Still commented out of the kustomization; running it means dedicating skirk again.

Unsigned (1Password locked).