### PR TITLE
feat(llm): manage litellm virtual keys in git

### DIFF
--- a/kubernetes/apps/base/llm/litellm/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./grafanadashboard.yaml
   - ./litellmproxy.yaml
   - ./models
+  - ./virtualkeys
   - ./httproute.yaml
   - ./llama-nvidia.yaml
   # - ./llama-nvidia-muse.yaml

--- a/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
+++ b/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
@@ -127,3 +127,7 @@ spec:
     - ZAI_API_KEY
     - REDIS_HOST
     - REDIS_PORT
+  apiAccess:
+    masterKeyRef:
+      name: litellm
+      key: LITELLM_MASTER_KEY

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/alert-triage.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/alert-triage.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: alert-triage
+spec:
+  proxyRef: litellm
+  keyAlias: Alert Triage
+  secretName: litellm-key-alert-triage
+  secretKey: api-key
+  models:
+  - self-hosted
+  - nvidia
+  - vision
+  - dsv4f
+  - reasoning-pool
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: alert-triage
+spec:
+  secretStoreRefs:
+  - name: onepassword
+    kind: ClusterSecretStore
+  selector:
+    secret:
+      name: litellm-key-alert-triage
+  data:
+  - match:
+      secretKey: api-key
+      remoteRef:
+        remoteKey: alert-triage
+        property: LITELLM_ALERT_TRIAGE_API_KEY

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/dispatch.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/dispatch.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: dispatch
+spec:
+  proxyRef: litellm
+  keyAlias: Dispatch
+  secretName: litellm-key-dispatch
+  secretKey: api-key
+  models:
+  - vision
+  - self-hosted
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: dispatch
+spec:
+  secretStoreRefs:
+  - name: onepassword
+    kind: ClusterSecretStore
+  selector:
+    secret:
+      name: litellm-key-dispatch
+  data:
+  - match:
+      secretKey: api-key
+      remoteRef:
+        remoteKey: litellm
+        property: LITELLM_DISPATCH_API_KEY

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/foreman.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/foreman.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: foreman
+spec:
+  proxyRef: litellm
+  keyAlias: Foreman
+  secretName: litellm-key-foreman
+  secretKey: api-key
+  models:
+  - nvidia
+  - MiniMax-M3-chat
+  - nemotron
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: foreman
+spec:
+  secretStoreRefs:
+  - name: onepassword
+    kind: ClusterSecretStore
+  selector:
+    secret:
+      name: litellm-key-foreman
+  data:
+  - match:
+      secretKey: api-key
+      remoteRef:
+        remoteKey: litellm
+        property: LITELLM_FOREMAN_API_KEY

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/hermes.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/hermes.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: hermes
+spec:
+  proxyRef: litellm
+  keyAlias: Hermes
+  secretName: litellm-key-hermes
+  secretKey: api-key
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: hermes
+spec:
+  secretStoreRefs:
+  - name: onepassword
+    kind: ClusterSecretStore
+  selector:
+    secret:
+      name: litellm-key-hermes
+  data:
+  - match:
+      secretKey: api-key
+      remoteRef:
+        remoteKey: litellm
+        property: LITELLM_HERMES_API_KEY

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./alert-triage.yaml
+  - ./dispatch.yaml
+  - ./foreman.yaml
+  - ./hermes.yaml
+  - ./memini.yaml
+  - ./openclaw.yaml
+  - ./opencode.yaml
+  - ./pr-review.yaml
+  - ./repo-wiki.yaml
+  - ./toolhive.yaml
+  - ./zed.yaml

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/memini.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/memini.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: memini
+spec:
+  proxyRef: litellm
+  keyAlias: Memini
+  secretName: litellm-key-memini
+  secretKey: api-key
+  models:
+  - memini-embed
+  - rerank
+  - self-hosted
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: memini
+spec:
+  secretStoreRefs:
+  - name: onepassword
+    kind: ClusterSecretStore
+  selector:
+    secret:
+      name: litellm-key-memini
+  data:
+  - match:
+      secretKey: api-key
+      remoteRef:
+        remoteKey: litellm
+        property: LITELLM_MEMINI_API_KEY

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/openclaw.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/openclaw.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: openclaw
+spec:
+  proxyRef: litellm
+  keyAlias: Openclaw
+  secretName: litellm-key-openclaw
+  secretKey: api-key
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: openclaw
+spec:
+  secretStoreRefs:
+  - name: onepassword
+    kind: ClusterSecretStore
+  selector:
+    secret:
+      name: litellm-key-openclaw
+  data:
+  - match:
+      secretKey: api-key
+      remoteRef:
+        remoteKey: litellm
+        property: LITELLM_OPENCLAW_API_KEY

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/opencode.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/opencode.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: opencode
+spec:
+  proxyRef: litellm
+  keyAlias: Opencode
+  secretName: litellm-key-opencode
+  secretKey: api-key
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: opencode
+spec:
+  secretStoreRefs:
+  - name: onepassword
+    kind: ClusterSecretStore
+  selector:
+    secret:
+      name: litellm-key-opencode
+  data:
+  - match:
+      secretKey: api-key
+      remoteRef:
+        remoteKey: litellm
+        property: LITELLM_OPENCODE_API_KEY

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/pr-review.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/pr-review.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: pr-review
+spec:
+  proxyRef: litellm
+  keyAlias: Github Actions PR Reviewer
+  secretName: litellm-key-pr-review
+  secretKey: api-key
+  models:
+  - self-hosted
+  - dsv4f
+  - MiniMax-M2.7
+  - nvidia
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: pr-review
+spec:
+  secretStoreRefs:
+  - name: onepassword
+    kind: ClusterSecretStore
+  selector:
+    secret:
+      name: litellm-key-pr-review
+  data:
+  - match:
+      secretKey: api-key
+      remoteRef:
+        remoteKey: litellm
+        property: LITELLM_PR_REVIEW_API_KEY

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/repo-wiki.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/repo-wiki.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: repo-wiki
+spec:
+  proxyRef: litellm
+  keyAlias: Repo-Wiki
+  secretName: litellm-key-repo-wiki
+  secretKey: api-key
+  models:
+  - self-hosted
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: repo-wiki
+spec:
+  secretStoreRefs:
+  - name: onepassword
+    kind: ClusterSecretStore
+  selector:
+    secret:
+      name: litellm-key-repo-wiki
+  data:
+  - match:
+      secretKey: api-key
+      remoteRef:
+        remoteKey: litellm
+        property: LITELLM_REPO_WIKI_API_KEY

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/toolhive.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/toolhive.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: toolhive
+spec:
+  proxyRef: litellm
+  keyAlias: ToolHive
+  secretName: litellm-key-toolhive
+  secretKey: api-key
+  models:
+  - toolhive-embed
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: toolhive
+spec:
+  secretStoreRefs:
+  - name: onepassword
+    kind: ClusterSecretStore
+  selector:
+    secret:
+      name: litellm-key-toolhive
+  data:
+  - match:
+      secretKey: api-key
+      remoteRef:
+        remoteKey: litellm
+        property: LITELLM_TOOLHIVE_API_KEY

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/zed.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/zed.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: zed
+spec:
+  proxyRef: litellm
+  keyAlias: Zed
+  secretName: litellm-key-zed
+  secretKey: api-key
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: zed
+spec:
+  secretStoreRefs:
+  - name: onepassword
+    kind: ClusterSecretStore
+  selector:
+    secret:
+      name: litellm-key-zed
+  data:
+  - match:
+      secretKey: api-key
+      remoteRef:
+        remoteKey: litellm
+        property: LITELLM_ZED_API_KEY


### PR DESCRIPTION
Eleven `LiteLLMVirtualKey` + `PushSecret` pairs, so keys **and their model scoping** stop living only in the LiteLLM DB.

Scoping is the point — invisible to a diff, so a model rename silently breaks scoped consumers. That already bit us: #9183 renamed the rerank alias, leaving the Memini key scoped to `memini-rerank`, which no longer exists as a `model_name`. Fixed here.

| key | models |
|---|---|
| Alert Triage | self-hosted, nvidia, vision, dsv4f, reasoning-pool |
| Dispatch | vision, self-hosted |
| Foreman | nvidia, MiniMax-M3-chat, nemotron |
| Hermes | *(all)* |
| Memini | memini-embed, **rerank**, self-hosted |
| Opencode | *(all)* |
| Openclaw | *(all)* |
| PR Review | self-hosted, dsv4f, MiniMax-M2.7, nvidia |
| Repo-Wiki | self-hosted |
| ToolHive | toolhive-embed |
| Zed | *(all)* |

Each PushSecret writes back to the 1Password property the existing ExternalSecrets already read — **no consumer manifests change**.

Targets were read from 1Password and the consuming ExternalSecrets, not inferred, which caught two guesses that would have been wrong: the field is `LITELLM_PR_REVIEW_API_KEY` (not `PR_REVIEWER`), and **alert-triage extracts from its own `alert-triage` item**, so a PushSecret aimed at `litellm` would have created an orphan field and left it on the old key.

Adds `spec.apiAccess` (required by the controller regardless of `applyMode`).

⚠️ The controller **generates** keys, it cannot adopt existing ones. New values replace the current ones at each property; old keys stay in the DB and need deleting by hand once consumers roll.

JJ omitted — has a DB key but no 1Password field and no consumer in this repo, so nowhere verified to push it.
