### PR TITLE
fix(foreman): stop reviewers joining lines into the issueAsk quote

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
@@ -135,7 +135,11 @@ spec:
         returned by fetch_issue that states the requested CHANGE or acceptance criteria —
         quote the imperative fix (a "## Fix" / "## Acceptance" / "Recommendation" line, or
         the title's directive), NOT the "## Problem"/background that describes existing
-        code. It MUST be a verbatim substring of the body; before submitting, re-read the
+        code. Take the quote from ONE line of the body: do not join bullets, collapse a
+        list, reflow wrapped text, or compose your own summary — a joined or reworded
+        line reads correctly but is not a substring and fails verification. If no single
+        line is ideal, quote the closest one verbatim rather than writing a better one.
+        It MUST be a verbatim substring of the body; before submitting, re-read the
         body and confirm your quote appears in it character for character. Quoting the
         problem or existing-code fails harness verification and DEMOTES your approval to
         NO-GO — so quote what the issue asks you to DO, not the situation it describes.

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -118,7 +118,11 @@ spec:
         returned by fetch_issue that states the requested CHANGE or acceptance criteria —
         quote the imperative fix (a "## Fix" / "## Acceptance" / "Recommendation" line, or
         the title's directive), NOT the "## Problem"/background that describes existing
-        code. It MUST be a verbatim substring of the body; before submitting, re-read the
+        code. Take the quote from ONE line of the body: do not join bullets, collapse a
+        list, reflow wrapped text, or compose your own summary — a joined or reworded
+        line reads correctly but is not a substring and fails verification. If no single
+        line is ideal, quote the closest one verbatim rather than writing a better one.
+        It MUST be a verbatim substring of the body; before submitting, re-read the
         body and confirm your quote appears in it character for character. Quoting the
         problem or existing-code fails harness verification and DEMOTES your approval to
         NO-GO — so quote what the issue asks you to DO, not the situation it describes.


### PR DESCRIPTION
## Summary
- Adds an explicit single-line rule to the `extra.issueAsk` instruction in both reviewer prompts.

## Why
Two reviews tonight reached APPROVE and were both demoted to NO-GO with `demotionReason: issueAsk could not be verified as covering the fetched issue body`. In both cases `issueAskMethod: rewritten` and `issueAskVerified: false`.

The prompt already says the quote MUST be a verbatim substring and to re-read the body character for character, so more emphasis was not the gap. The models were *trying* to quote and flattened structure while doing it:

miso-gallery#365 body:
```
- Add tests for:
  - `find_duplicate_media()` with known duplicate files (same content, different names)
  - `find_duplicate_media()` with unique files (no duplicates expected)
```
model's claim: `Add tests for: find_duplicate_media() with known duplicate files, ...`

That is three lines joined into one. It reads like a faithful quote and is not a substring.

pr-reviewer-action#438's claim was `test: cover Forgejo gh_api compare endpoint in translation table`, a commit-message-style line composed rather than copied.

## Why it is not self-correcting
An unverified issueAsk demotes a GO unless the deterministic scope check vouches for the diff. Both issues were test-coverage issues, where the diff creates a new test file and the issue names the file under test, so `scopeMatched: []` and no vouch was available. Both rails failed together, the coder was re-dispatched, and miso-gallery#365 burned its budget to `Failed`.

The scope-vouch half is an upstream gap and is filed separately; this covers the half we own.

## Verification
- Both files parse; prompts intact at 5682 and 6480 chars.
- Asserted present: the new "do not join bullets" text and the existing "verbatim substring" requirement.

## Note
Needs `kubectl rollout restart deployment/foreman-default-agent` after merge — Agent CRs are cached at pod start. The deployment is `foreman-default-agent` now, not `foreman-agent`, since #9179.