### PR TITLE
fix(llm): give the managed virtual keys distinct aliases

### DIFF
--- a/kubernetes/apps/base/llm/litellm/virtualkeys/alert-triage.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/alert-triage.yaml
@@ -5,7 +5,7 @@ metadata:
   name: alert-triage
 spec:
   proxyRef: litellm
-  keyAlias: Alert Triage
+  keyAlias: Alert Triage (managed)
   secretName: litellm-key-alert-triage
   secretKey: api-key
   models:

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/dispatch.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/dispatch.yaml
@@ -5,7 +5,7 @@ metadata:
   name: dispatch
 spec:
   proxyRef: litellm
-  keyAlias: Dispatch
+  keyAlias: Dispatch (managed)
   secretName: litellm-key-dispatch
   secretKey: api-key
   models:

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/foreman.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/foreman.yaml
@@ -5,7 +5,7 @@ metadata:
   name: foreman
 spec:
   proxyRef: litellm
-  keyAlias: Foreman
+  keyAlias: Foreman (managed)
   secretName: litellm-key-foreman
   secretKey: api-key
   models:

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/hermes.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/hermes.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hermes
 spec:
   proxyRef: litellm
-  keyAlias: Hermes
+  keyAlias: Hermes (managed)
   secretName: litellm-key-hermes
   secretKey: api-key
 ---

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/memini.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/memini.yaml
@@ -5,7 +5,7 @@ metadata:
   name: memini
 spec:
   proxyRef: litellm
-  keyAlias: Memini
+  keyAlias: Memini (managed)
   secretName: litellm-key-memini
   secretKey: api-key
   models:

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/openclaw.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/openclaw.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openclaw
 spec:
   proxyRef: litellm
-  keyAlias: Openclaw
+  keyAlias: Openclaw (managed)
   secretName: litellm-key-openclaw
   secretKey: api-key
 ---

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/opencode.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/opencode.yaml
@@ -5,7 +5,7 @@ metadata:
   name: opencode
 spec:
   proxyRef: litellm
-  keyAlias: Opencode
+  keyAlias: Opencode (managed)
   secretName: litellm-key-opencode
   secretKey: api-key
 ---

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/pr-review.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/pr-review.yaml
@@ -5,7 +5,7 @@ metadata:
   name: pr-review
 spec:
   proxyRef: litellm
-  keyAlias: Github Actions PR Reviewer
+  keyAlias: Github Actions PR Reviewer (managed)
   secretName: litellm-key-pr-review
   secretKey: api-key
   models:

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/repo-wiki.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/repo-wiki.yaml
@@ -5,7 +5,7 @@ metadata:
   name: repo-wiki
 spec:
   proxyRef: litellm
-  keyAlias: Repo-Wiki
+  keyAlias: Repo-Wiki (managed)
   secretName: litellm-key-repo-wiki
   secretKey: api-key
   models:

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/toolhive.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/toolhive.yaml
@@ -5,7 +5,7 @@ metadata:
   name: toolhive
 spec:
   proxyRef: litellm
-  keyAlias: ToolHive
+  keyAlias: ToolHive (managed)
   secretName: litellm-key-toolhive
   secretKey: api-key
   models:

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/zed.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/zed.yaml
@@ -5,7 +5,7 @@ metadata:
   name: zed
 spec:
   proxyRef: litellm
-  keyAlias: Zed
+  keyAlias: Zed (managed)
   secretName: litellm-key-zed
   secretKey: api-key
 ---


### PR DESCRIPTION
All eleven failed to generate:

```
POST /key/generate: 400
Key with alias 'Foreman' already exists. Unique key aliases across all keys are required.
```

Aliases were transcribed verbatim from the DB, so they collide with the keys they replace.

Deleting the old keys first would clear it but leaves a window with no valid key (delete → PushSecret → ESO refresh → restart). Suffixing lets old and new coexist, so cutover happens as each consumer picks up the rotated property.

Drop the suffix later if you want the plain names back, once the originals are deleted.