### PR TITLE
test(llm): match fp8 KV precision to the 3090 for a clean A/B

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-strix-fp8.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-strix-fp8.yaml
@@ -64,7 +64,7 @@ spec:
     - -ctk
     - q8_0
     - -ctv
-    - turbo4
+    - q8_0
     - -dev
     - Vulkan0
     - -ctxcp


### PR DESCRIPTION
Switches `-ctv turbo4` (4-bit) to `q8_0` so both lanes run `K=q8_0 V=q8_0` — the comparison becomes weights-only: ROCmFP8 8.25 bpw vs UD-Q4_K_XL ~4.5.

The four-suite run split cleanly: single-shot reasoning held or won (coding **+0.070**, troubleshooting −0.009), protocol adherence lost (reviewing −0.046, agentic −0.084). On agentic the per-answer `correct` rate was **higher** than the 3090 (0.556 vs 0.514) while probe-first fell (9/12 vs 12/13), and every zero was an assert-without-probe. That is what a degraded V cache does.

Costs +0.5 GiB at 65536. Expect a decode hit too — turbo4 is part of why this lane reaches 26 t/s — so the speed sweep needs re-running before any speed claim carries over.

Unsigned (1Password locked).