### PR TITLE
fix(litellm): drop the global drop_params, it strips thinking from every request

### DIFF
--- a/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
+++ b/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
@@ -114,7 +114,6 @@ spec:
     num_retries: 2
     retry_after: 5
     set_verbose: false
-    drop_params: true
   generalSettings:
     health_check_endpoint: /v1/health
     store_model_in_db: false


### PR DESCRIPTION
`#9210` set `litellm_settings.drop_params: true`. That silently strips any param LiteLLM considers unsupported for a model, proxy-wide — LiteLLM's own docs use *"strip `context_management` from all incoming requests"* as the illustrative case. It is scoped to neither a param nor a model.

`glm-5.3` and the `dsv4f` rungs are `openai/` entries against a custom `apiBase` with `mode: chat` and no declared reasoning support, so `thinking` reads as unsupported and is removed before dispatch. The providers then answer with reasoning **on** by default, and because these are OpenAI-shaped chat completions that reasoning arrives inline in `content` rather than in a field a client can hide — so it renders into the conversation. That is the reported symptom: reasoning text appearing in chat output.

## Why the setting was added, and why that no longer justifies it

`#9210` was defending against a narrower and, by its own admission, hypothetical failure:

```
litellm.UnsupportedParamsError: openai does not support parameters:
['reasoning_effort'], for model=llama-strix
```

That commit body says, in the same paragraph that names `glm-5.3` and `dsv4f` as hermes' targets, *"No caller in any of the three repos was found sending it"*. A param nothing sends was traded away for one that several callers do send. The search was scoped to `reasoning_effort`; the fix was not scoped at all.

## Why not a narrower fix

There is no narrow global form: `additional_drop_params` is per-model in `litellm_params` only. And the models that produced that 400 — `llama-nvidia`, `llama-strix*`, `llama-vision` — are llmkube `autoRegister` projections with no CR to hang it on, which is why a global switch was reached for in the first place.

So the choice is between mangling every request to prevent a 400 that nothing triggers, or removing the setting and letting a real 400 name the model and the param if it ever happens. This takes the second.

## Risk

This restores param passthrough for every model, so anything that has come to depend on the stripping since `#9210` will surface as a 400 rather than silently working. The setting was commented out for months before `#9210`, so nothing is expected to.