### PR TITLE
fix(toolhive): revive MCP read-only rules voided by role aggregation

### DIFF
--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/flux-mcp/rbac.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/flux-mcp/rbac.yaml
@@ -18,6 +18,19 @@ subjects:
     name: flux-mcp
     namespace: llm
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flux-mcp-readonly-explicit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubectl-mcp-readonly-explicit
+subjects:
+  - kind: ServiceAccount
+    name: flux-mcp
+    namespace: llm
+---
 # Write access limited to Flux API groups: enables the MCP
 # reconcile/suspend/resume tools (annotation/spec patches) and
 # apply/delete of Flux objects, but nothing outside Flux CRDs.

--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/kubectl-mcp/rbac.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/kubectl-mcp/rbac.yaml
@@ -4,12 +4,18 @@ kind: ServiceAccount
 metadata:
   name: kubectl-mcp-readonly
 ---
-# Broad read-only access for kubectl MCP. Kubernetes Secrets (core v1) are excluded.
+# Broad read-only access for kubectl MCP, split across two ClusterRoles. Kubernetes
+# Secrets (core v1) are excluded from both.
 #
-# - aggregationRule: same selector as built-in "view" — expands with operators that ship
-#   rbac.authorization.k8s.io/aggregate-to-view ClusterRoles (CRDs, etc.).
-# - Non-core apiGroups: resources "*" is safe for Secret *objects* (they only exist in group "").
-# - Core group "": explicit resource list — secrets omitted; exec/proxy-style subresources omitted.
+# The split is mandatory, not stylistic: a ClusterRole carrying an aggregationRule has
+# its rules field owned by the aggregation controller, which overwrites any rules written
+# alongside it. Both roles are bound to the same ServiceAccount.
+#
+# - kubectl-mcp-readonly: aggregation only, same selector as built-in "view" — expands with
+#   operators that ship rbac.authorization.k8s.io/aggregate-to-view ClusterRoles.
+# - kubectl-mcp-readonly-explicit: the rules the aggregation does not cover.
+#   Non-core apiGroups: resources "*" is safe for Secret *objects* (they only exist in group "").
+#   Core group "": explicit resource list — secrets omitted; exec/proxy-style subresources omitted.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -18,6 +24,12 @@ aggregationRule:
   clusterRoleSelectors:
     - matchLabels:
         rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubectl-mcp-readonly-explicit
 rules:
   - nonResourceURLs:
       - /api
@@ -87,6 +99,7 @@ rules:
       - coordination.k8s.io
       - csi.ceph.io
       - deviceplugin.intel.com
+      - direwolf.games-on-whales.github.io
       - discovery.k8s.io
       - dragonflydb.io
       - events.k8s.io
@@ -95,6 +108,7 @@ rules:
       - externaldns.k8s.io
       - flowcontrol.apiserver.k8s.io
       - fluxcd.controlplane.io
+      - foreman.llmkube.dev
       - fpga.intel.com
       - gateway.envoyproxy.io
       - gateway.networking.k8s.io
@@ -104,9 +118,13 @@ rules:
       - groupsnapshot.storage.k8s.io
       - helm.toolkit.fluxcd.io
       - image.toolkit.fluxcd.io
+      - inference.llmkube.dev
+      - infra.contrib.fluxcd.io
       - k8s.cni.cncf.io
       - keda.sh
+      - kopiur.home-operations.com
       - kustomize.toolkit.fluxcd.io
+      - litellm.home-operations.com
       - metrics.k8s.io
       - monitoring.coreos.com
       - monitoring.giantswarm.io
@@ -126,6 +144,7 @@ rules:
       - storage.k8s.io
       - talos.dev
       - toolhive.stacklok.dev
+      - towonel.io
       - tuppr.home-operations.com
       - upgrade.cattle.io
     resources:
@@ -143,6 +162,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kubectl-mcp-readonly
+subjects:
+  - kind: ServiceAccount
+    name: kubectl-mcp-readonly
+    namespace: llm
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubectl-mcp-readonly-explicit
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubectl-mcp-readonly-explicit
 subjects:
   - kind: ServiceAccount
     name: kubectl-mcp-readonly


### PR DESCRIPTION
A ClusterRole carrying an `aggregationRule` has its `rules` field owned by the aggregation controller, which overwrites anything written alongside it. `kubectl-mcp-readonly` has both, so every rule in it has been dead since it was written — the effective grant was plain `view`.

Evidence: the manifest grants `rbac.authorization.k8s.io` and `apiextensions.k8s.io` as `"*"`/get,list,watch, and the live cluster denies both to `system:serviceaccount:llm:kubectl-mcp-readonly`.

## Summary
- Split the rules into a second, non-aggregated `kubectl-mcp-readonly-explicit` ClusterRole so they take effect; the original keeps `aggregationRule` with `rules: []`.
- Bind the new role to both the `kubectl-mcp-readonly` and `flux-mcp` service accounts, matching the existing reuse.
- Add the CRD groups the list was missing: `foreman.llmkube.dev`, `inference.llmkube.dev`, `direwolf.games-on-whales.github.io`, `infra.contrib.fluxcd.io`, `kopiur.home-operations.com`, `litellm.home-operations.com`, `towonel.io`.

## Notes
Still read-only: the new role grants only get/list/watch, core `secrets` are omitted, and the added groups are CRDs (Secret objects exist only in the core group). This is what has been making foreman Workloads and AgenticTasks invisible through the gateway — queries returned "no resources" rather than a 403.

## Verification
- Both files parse; verbs on the new role are exactly get/list/watch; no rule names core `secrets`.

https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh