### PR TITLE
fix(renovate): stop writing Helm tarball checksums into OCIRepository digests

### DIFF
--- a/.renovate/packageRules.json5
+++ b/.renovate/packageRules.json5
@@ -22,6 +22,7 @@
       overrideDatasource: "helm",
       overridePackageName: "{{replace '.*/' '' packageName}}",
       registryUrls: ["https://kubernetes-sigs.github.io/metrics-server"],
+      pinDigests: false,
     },
     {
       description: "ocharted proxy: external-dns",
@@ -30,6 +31,7 @@
       overrideDatasource: "helm",
       overridePackageName: "{{replace '.*/' '' packageName}}",
       registryUrls: ["https://kubernetes-sigs.github.io/external-dns"],
+      pinDigests: false,
     },
     {
       description: "ocharted proxy: descheduler",
@@ -38,6 +40,7 @@
       overrideDatasource: "helm",
       overridePackageName: "{{replace '.*/' '' packageName}}",
       registryUrls: ["https://kubernetes-sigs.github.io/descheduler"],
+      pinDigests: false,
     },
     {
       description: "ocharted proxy: headlamp",
@@ -46,6 +49,7 @@
       overrideDatasource: "helm",
       overridePackageName: "{{replace '.*/' '' packageName}}",
       registryUrls: ["https://kubernetes-sigs.github.io/headlamp"],
+      pinDigests: false,
     },
     {
       description: "ocharted proxy: nvidia-device-plugin",
@@ -54,6 +58,7 @@
       overrideDatasource: "helm",
       overridePackageName: "{{replace '.*/' '' packageName}}",
       registryUrls: ["https://nvidia.github.io/k8s-device-plugin"],
+      pinDigests: false,
     },
     {
       description: "ocharted proxy: ceph-csi-drivers",
@@ -62,6 +67,7 @@
       overrideDatasource: "helm",
       overridePackageName: "{{replace '.*/' '' packageName}}",
       registryUrls: ["https://ceph.github.io/ceph-csi-operator"],
+      pinDigests: false,
     },
     {
       description: "ocharted proxy: k8s-gpu-dra-driver",
@@ -70,6 +76,7 @@
       overrideDatasource: "helm",
       overridePackageName: "{{replace '.*/' '' packageName}}",
       registryUrls: ["https://rocm.github.io/k8s-gpu-dra-driver"],
+      pinDigests: false,
     },
   ],
 }

--- a/kubernetes/apps/base/kube-system/metrics-server/ocirepository.yaml
+++ b/kubernetes/apps/base/kube-system/metrics-server/ocirepository.yaml
@@ -11,5 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 3.14.0
-    digest: c2ca1185c01e6e7f53dd1b7d131f0c9b3fa50e003ed068b784563a1b5a3422a1
   url: oci://ocharted.jory.dev/kubernetes-sigs.github.io/metrics-server/metrics-server


### PR DESCRIPTION
metrics-server has been stuck on **3.13.1 since 2026-08-19T15:12:34Z** while git said 3.14.0. Not an ocharted outage — ocharted is healthy and the chart is upstream. The source controller never gets that far:

```
failed to determine artifact digest: cannot parse hash:
"c2ca1185c01e6e7f53dd1b7d131f0c9b3fa50e003ed068b784563a1b5a3422a1"
```

That hex is the chart tarball checksum from `https://kubernetes-sigs.github.io/metrics-server/index.yaml`, byte-for-byte. Flux's `spec.ref.digest` wants an OCI manifest digest, so it cannot parse it and the OCIRepository never reconciles. `flate`'s "not found" was a downstream symptom.

The mechanism is the `overrideDatasource: "helm"` ocharted rules: version lookup goes to the upstream Helm repo, the helm datasource's digest is `index.yaml`'s SHA-256, and the flux manager writes it into `ref.digest`. #9197 added it to metrics-server and #9223 added the same to nvidia-device-plugin (0.20.0's hex matches that index too) — which is why the revert in #9246 fixed nvidia: it removed the digest line.

So: drop the digest from metrics-server (tag-only, like nvidia is now), and set `pinDigests: false` on all seven ocharted rules so the next bump of any of them can't repeat it.

The digest is removed rather than prefixed with `sha256:` — prefixing would parse and then fail verification against the real manifest, since it isn't a manifest digest at all.

`renovate-config-validator` accepts `pinDigests` here. It also prints 14 "Invalid configuration option" complaints for `overrideDatasource`/`overridePackageName`, but those are pre-existing: 14 on unmodified main, 14 after this change.