### PR TITLE
fix(opencode): escape shell vars in the entrypoint for envsubst

### DIFF
--- a/kubernetes/apps/base/llm/opencode/configmap.yaml
+++ b/kubernetes/apps/base/llm/opencode/configmap.yaml
@@ -15,12 +15,12 @@ data:
     git config --global --add safe.directory '*'
 
     umask 077
-    printf 'https://x-access-token:%s@github.com\n' "${GITHUB_TOKEN}" > "${HOME}/.git-credentials"
+    printf 'https://x-access-token:%s@github.com\n' "$${GITHUB_TOKEN}" > "$${HOME}/.git-credentials"
     umask 022
 
-    mkdir -p "${HOME}/projects"
-    if [[ ! -d "${HOME}/projects/home-ops/.git" ]]; then
-      git clone --filter=blob:none https://github.com/joryirving/home-ops.git "${HOME}/projects/home-ops" \
+    mkdir -p "$${HOME}/projects"
+    if [[ ! -d "$${HOME}/projects/home-ops/.git" ]]; then
+      git clone --filter=blob:none https://github.com/joryirving/home-ops.git "$${HOME}/projects/home-ops" \
         || echo "WARN: home-ops clone failed; clone it from a session instead"
     fi
 


### PR DESCRIPTION
`Kustomization/llm/opencode` has been failing since it landed, so no HelmRelease and no pod ever got created:

```
post build failed for 'ConfigMap.v1.[noGrp]/opencode-config':
envsubst error: variable substitution failed:
variable not set (strict mode): "GITHUB_TOKEN"
```

The entrypoint script in the ConfigMap uses `${GITHUB_TOKEN}` and `${HOME}`, which Flux's postBuild envsubst tries to expand at build time. They need `$${VAR}` so envsubst emits a literal `${VAR}` for the shell to expand at runtime. My miss — this is the same trap that broke nvidia-power-limit.

Verified with `flux envsubst --strict` against the kustomize output: main's version exits 1 on `GITHUB_TOKEN`, this branch passes and renders the script with single-dollar `${GITHUB_TOKEN}` / `${HOME}` intact.