### PR TITLE
fix(opencode): start the server in ~/projects

### DIFF
--- a/kubernetes/apps/base/llm/opencode/configmap.yaml
+++ b/kubernetes/apps/base/llm/opencode/configmap.yaml
@@ -24,6 +24,7 @@ data:
         || echo "WARN: home-ops clone failed; clone it from a session instead"
     fi
 
+    cd "$${HOME}/projects"
     exec opencode serve --hostname 0.0.0.0 --port 4096
   opencode.json: |
     {


### PR DESCRIPTION
Sessions inherit the server's working directory, which was `/home/opencode` — a home directory, where opencode refuses to run the file picker:

```
Failed to init file picker: Can not run certain FFF features in a file system
root or home directories. Consider smaller per-project directories.
find file query="" directory=/home/opencode results=0
```

So attaching or opening the web UI without picking a folder started in a directory where file navigation was dead. `cd ~/projects` before exec makes the default the parent of the 13 clones: not a home directory, so the picker works, and every repo is one level down.

A repo would be a better default still, but picking one for you is worse than landing next to all of them.

Verified through `flux envsubst --strict`: the rendered script keeps `cd "${HOME}/projects"` with the runtime variable intact.