### PR TITLE
chore(renovate): remove stale dependency groups

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -19,17 +19,6 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
-      minimumGroupSize: 2,
-    },
-    {
-      description: "Cilium Group",
-      groupName: "Cilium",
-      matchDatasources: ["docker"],
-      matchPackageNames: ["/cilium/"],
-      group: {
-        commitMessageTopic: "{{{groupName}}} group",
-      },
-      minimumGroupSize: 2,
     },
     {
       description: "CoreDNS Group",
@@ -39,7 +28,6 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
-      minimumGroupSize: 2,
     },
     {
       description: "External Secrets Operator Group",
@@ -49,33 +37,12 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
-      minimumGroupSize: 2,
     },
     {
       description: "Flux Operator Group",
       groupName: "Flux Operator",
       matchDatasources: ["docker"],
       matchPackageNames: ["/flux-operator/", "/flux-instance/"],
-      group: {
-        commitMessageTopic: "{{{groupName}}} group",
-      },
-      minimumGroupSize: 2,
-    },
-    {
-      description: "Gateway API CRDs Group",
-      groupName: "gateway-api-crds",
-      matchDatasources: ["docker"],
-      matchPackageNames: ["/gateway-api-crds/"],
-      group: {
-        commitMessageTopic: "{{{groupName}}} group",
-      },
-      minimumGroupSize: 2,
-    },
-    {
-      description: "Keda Group",
-      groupName: "keda",
-      matchDatasources: ["docker"],
-      matchPackageNames: ["/keda/"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
@@ -89,7 +56,6 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
-      minimumGroupSize: 2,
     },
     {
       description: "Kubernetes Group",


### PR DESCRIPTION
## What
- remove stale `gateway-api-crds` and `keda` group rules
- remove the single-dependency `Cilium` group
- stop delaying single-package Cert-Manager, CoreDNS, External Secrets, and kube-prometheus-stack updates

## Why
The group audit found no current dependencies for `gateway-api-crds` or `keda`. Cilium is a single OCI chart, so its `minimumGroupSize: 2` never produces a useful group. The remaining multi-package groups retain their thresholds.

## Validation
- `git diff --check`
- audited current manifests and recent Renovate PRs