### PR TITLE
fix(bridge): grant patch on workloads for the terminal-since stamp

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -71,13 +71,16 @@ spec:
       roles:
         # The bridge creates Workloads and, since v0.3.0, reconciles failed ones:
         # list/get to find Failed Workloads, delete + create to retry them (bounded).
-        # No update/patch — retry is delete-then-recreate, not in-place mutation.
+        # Retry stays delete-then-recreate, not in-place mutation. patch covers one
+        # narrow case: bridge 0.6.28 stamps a bridge-owned terminal-since annotation
+        # so the prune TTL is measured against a timestamp the Foreman controller
+        # does not rewrite (misospace/foreman-dispatch-bridge#170).
         foreman-dispatch-bridge:
           type: Role
           rules:
             - apiGroups: ["foreman.llmkube.dev"]
               resources: ["workloads"]
-              verbs: ["create", "get", "list", "delete"]
+              verbs: ["create", "get", "list", "delete", "patch"]
             # Bridge 0.5.0 reads a failed Workload's task results (reviewer
             # NO-GO findings, coder errors) to build feedback-carrying retries.
             - apiGroups: ["foreman.llmkube.dev"]


### PR DESCRIPTION
bridge#190 (Fix #170: prune TTL never elapses) has the bridge stamp its own `foreman.llmkube.dev/terminal-since/<phase>` annotation on terminal Workloads, so prune age is measured against a timestamp the Foreman controller does not rewrite. That stamp is persisted with a PATCH (`bridge/main.py`, `_list_terminal_candidates`), and the Role grants only `create, get, list, delete`.

The Role's comment stated the exclusion was deliberate — "No update/patch — retry is delete-then-recreate, not in-place mutation" — which held until #190 introduced an in-place mutation, so the comment is updated rather than just the verb.

## Summary
- Add `patch` to the bridge's `workloads` Role, scoped to the same single resource it already manages.
- Rewrite the comment to record why in-place mutation now exists, so the next reader does not restore the exclusion.

## Notes
Failure without this is quiet rather than loud: the PATCH raises, `except client.ApiException` logs `stamp-terminal-since-failed`, and `terminal_since` falls back to `metadata.creationTimestamp`. Tombstones still age out, but from creation rather than from the terminal transition, so a long-lived Workload prunes earlier than the TTL intends.

Pairs with misospace/foreman-dispatch-bridge#192, which fixes the plural on that same PATCH (`agenticworkloads` → `workloads`). Until #192 ships the call 404s regardless of this grant, so neither is useful alone.

Retry behaviour is unchanged — still delete-then-recreate. `patch` is not used for anything else.

## Verification
- File parses; the rendered rule is `['workloads'] ['create', 'get', 'list', 'delete', 'patch']`.
https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh
