### PR TITLE
refactor(flux): source cluster metadata

### DIFF
--- a/bootstrap/helmfile/apps.yaml
+++ b/bootstrap/helmfile/apps.yaml
@@ -96,11 +96,5 @@ releases:
 
   - name: flux-instance
     namespace: flux-system
-    # flux-instance lives in the cluster-specific dir (not base) because its
-    # HelmRelease values differ per cluster. Override both the chart source
-    # path and the values template to read from the cluster dir.
-    values:
-      - chartPath: "{{ printf \"../../kubernetes/clusters/%s/flux-instance/helmrelease.yaml\" (env \"CLUSTER\") }}"
-      - ./templates/flux-values.yaml.gotmpl
     needs:
       - flux-system/flux-operator

--- a/bootstrap/helmfile/crds.yaml
+++ b/bootstrap/helmfile/crds.yaml
@@ -29,13 +29,9 @@ releases:
 
   - name: envoy-gateway
     namespace: network
-    values:
-      - chartPath: "../../kubernetes/apps/base/network/envoy-gateway/app/ocirepository.yaml"
 
   - name: grafana-operator
     namespace: observability
-    values:
-      - chartPath: "../../kubernetes/apps/base/observability/grafana/operator/ocirepository.yaml"
 
   - name: kube-prometheus-stack
     namespace: observability

--- a/bootstrap/helmfile/templates/flux-values.yaml.gotmpl
+++ b/bootstrap/helmfile/templates/flux-values.yaml.gotmpl
@@ -1,1 +1,0 @@
-{{ exec "yq" (list "select(.kind == \"HelmRelease\").spec.values" (printf "../../kubernetes/clusters/%s/flux-instance/helmrelease.yaml" (requiredEnv "CLUSTER"))) }}

--- a/bootstrap/helmfile/templates/release.yaml.gotmpl
+++ b/bootstrap/helmfile/templates/release.yaml.gotmpl
@@ -3,10 +3,23 @@
   so chart sources are never duplicated in helmfile.
 
   Standard path:  ../../kubernetes/apps/base/<namespace>/<name>/ocirepository.yaml
-  Override path:  set `chartPath` on the release to handle nested dirs
-                  (e.g. envoy-gateway uses app/, grafana-operator uses grafana/operator/)
+  Overrides:      releases whose manifests live in nested or cluster-specific
+                  dirs are mapped explicitly below. helmfile does not expose
+                  release-level values entries while templating release fields,
+                  so the map must live here rather than in the state file.
 */ -}}
-{{- $path := .Values.chartPath | default (printf "../../kubernetes/apps/base/%s/%s/ocirepository.yaml" .Release.Namespace .Release.Name) -}}
-{{- $oci := fromYaml (readFile $path) -}}
-chart: {{ $oci.spec.url }}
-version: {{ $oci.spec.ref.tag }}
+{{- $overrides := dict
+      "network/envoy-gateway" "../../kubernetes/apps/base/network/envoy-gateway/app/ocirepository.yaml"
+      "observability/grafana-operator" "../../kubernetes/apps/base/observability/grafana/operator/ocirepository.yaml"
+      "flux-system/flux-instance" (printf "../../kubernetes/clusters/%s/flux-instance/helmrelease.yaml" (requiredEnv "CLUSTER"))
+-}}
+{{- $path := index $overrides (printf "%s/%s" .Release.Namespace .Release.Name) | default (printf "../../kubernetes/apps/base/%s/%s/ocirepository.yaml" .Release.Namespace .Release.Name) -}}
+{{- $oci := dict -}}
+{{- range regexSplit `(?m)^---\s*$` (readFile $path) -1 -}}
+  {{- $doc := fromYaml . -}}
+  {{- if and $doc (eq (index $doc "kind" | default "") "OCIRepository") -}}
+    {{- $oci = $doc -}}
+  {{- end -}}
+{{- end -}}
+chart: {{ index $oci "spec" "url" }}
+version: {{ index $oci "spec" "ref" "tag" }}

--- a/bootstrap/helmfile/templates/values.yaml.gotmpl
+++ b/bootstrap/helmfile/templates/values.yaml.gotmpl
@@ -1,1 +1,28 @@
-{{ exec "yq" (list "select(.kind == \"HelmRelease\").spec.values" (printf "../../kubernetes/apps/base/%s/%s/helmrelease.yaml" .Release.Namespace .Release.Name)) }}
+{{- /*
+  Extracts values from the app's HelmRelease, then resolves Flux
+  postBuild-substitution variables the same way kustomize-controller would:
+  ${CLUSTER...} from the CLUSTER env, any remaining ${VAR:=default} to its
+  default. Substitution happens on the YAML text before parsing, so scalar
+  types (ints, bools) survive intact.
+
+  readFile (not exec) is required: helmfile renders values templates with the
+  chart cache dir as cwd, so relative paths only resolve via readFile, which
+  is anchored to this template's dir (hence one more ../ than in
+  release.yaml.gotmpl, whose readFile anchors to the state file).
+*/ -}}
+{{- $overrides := dict
+      "network/envoy-gateway" "../../../kubernetes/apps/base/network/envoy-gateway/app/helmrelease.yaml"
+      "observability/grafana-operator" "../../../kubernetes/apps/base/observability/grafana/operator/helmrelease.yaml"
+      "flux-system/flux-instance" (printf "../../../kubernetes/clusters/%s/flux-instance/helmrelease.yaml" (requiredEnv "CLUSTER"))
+-}}
+{{- $path := index $overrides (printf "%s/%s" .Release.Namespace .Release.Name) | default (printf "../../../kubernetes/apps/base/%s/%s/helmrelease.yaml" .Release.Namespace .Release.Name) -}}
+{{- $values := "" -}}
+{{- range regexSplit `(?m)^---\s*$` (readFile $path) -1 -}}
+  {{- $doc := fromYaml . -}}
+  {{- if and $doc (eq (index $doc "kind" | default "") "HelmRelease") -}}
+    {{- $values = toYaml (index $doc "spec" "values" | default dict) -}}
+  {{- end -}}
+{{- end -}}
+{{- $values = regexReplaceAll `\$\{CLUSTER(:=[^}]*)?\}` $values (requiredEnv "CLUSTER") -}}
+{{- $values = regexReplaceAll `\$\{[A-Za-z0-9_]+:=([^}]*)\}` $values `${1}` -}}
+{{ $values }}

--- a/kubernetes/apps/base/cert-manager/cert-manager/helmrelease.yaml
+++ b/kubernetes/apps/base/cert-manager/cert-manager/helmrelease.yaml
@@ -19,3 +19,7 @@ spec:
       enabled: true
       servicemonitor:
         enabled: true
+    webhook:
+      replicaCount: ${REPLICAS:=1}
+      podDisruptionBudget:
+        enabled: ${PDB:=false}

--- a/kubernetes/apps/base/external-secrets/external-secrets/helmrelease.yaml
+++ b/kubernetes/apps/base/external-secrets/external-secrets/helmrelease.yaml
@@ -16,3 +16,5 @@ spec:
     leaderElect: true
     serviceMonitor:
       enabled: true
+    webhook:
+      replicaCount: ${REPLICAS:=1}

--- a/kubernetes/apps/base/kube-system/cilium/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/cilium/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
         enabled: false
       hostRoot: /sys/fs/cgroup
     cluster:
-      name: ${CLUSTER:=main}
+      name: ${CLUSTER_NAME:=default}
     cni:
       exclusive: false
     dashboards:

--- a/kubernetes/apps/base/kube-system/cilium/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/cilium/helmrelease.yaml
@@ -26,9 +26,8 @@ spec:
       automount:
         enabled: false
       hostRoot: /sys/fs/cgroup
-    # cluster:
-    #   id: 1
-    # name: ${CLUSTER:=main}
+    cluster:
+      name: ${CLUSTER:=main}
     cni:
       exclusive: false
     dashboards:
@@ -63,7 +62,7 @@ spec:
         enabled: true
         serviceMonitor:
           enabled: true
-      replicas: 1
+      replicas: ${REPLICAS:=1}
       rollOutPods: true
     pmtuDiscovery:
       enabled: true

--- a/kubernetes/apps/base/kube-system/coredns/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/coredns/helmrelease.yaml
@@ -22,6 +22,7 @@ spec:
     image:
       repository: mirror.gcr.io/coredns/coredns
     k8sAppLabelOverride: kube-dns
+    replicaCount: ${REPLICAS:=1}
     servers:
       - zones:
           - zone: .

--- a/kubernetes/apps/main/cert-manager/cert-manager.yaml
+++ b/kubernetes/apps/main/cert-manager/cert-manager.yaml
@@ -20,6 +20,10 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/base/cert-manager/cert-manager
+  postBuild:
+    substitute:
+      REPLICAS: "2"
+      PDB: "true"
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/main/external-secrets/external-secrets.yaml
+++ b/kubernetes/apps/main/external-secrets/external-secrets.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/external-secrets/external-secrets
+  postBuild:
+    substitute:
+      REPLICAS: "2"
   wait: true
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/kube-system/cilium.yaml
+++ b/kubernetes/apps/main/kube-system/cilium.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/cilium
+  postBuild:
+    substitute:
+      REPLICAS: "2"
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/kube-system/cilium.yaml
+++ b/kubernetes/apps/main/kube-system/cilium.yaml
@@ -8,6 +8,7 @@ spec:
   path: ./kubernetes/apps/base/kube-system/cilium
   postBuild:
     substitute:
+      CLUSTER_NAME: main
       REPLICAS: "2"
   wait: false
   prune: true

--- a/kubernetes/apps/main/kube-system/coredns.yaml
+++ b/kubernetes/apps/main/kube-system/coredns.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/kube-system/coredns
+  postBuild:
+    substitute:
+      REPLICAS: "3"
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/clusters/main/apps.yaml
+++ b/kubernetes/clusters/main/apps.yaml
@@ -30,7 +30,6 @@ spec:
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}
-              SECRET_DOMAIN: ${SECRET_DOMAIN}
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -58,101 +57,6 @@ spec:
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization
-    - # Update Cert-manager replicas
-      patch: |-
-        apiVersion: kustomize.toolkit.fluxcd.io/v1
-        kind: Kustomization
-        metadata:
-          name: not-used
-        spec:
-          patches:
-            - patch: |-
-                apiVersion: helm.toolkit.fluxcd.io/v2
-                kind: HelmRelease
-                metadata:
-                  name: not-used
-                spec:
-                  values:
-                    webhook:
-                      replicaCount: 2
-                      podDisruptionBudget:
-                        enabled: true
-              target:
-                kind: HelmRelease
-                name: cert-manager
-      target:
-        kind: Kustomization
-        name: cert-manager
-    - # Update Cilium Operator replicas
-      patch: |-
-        apiVersion: kustomize.toolkit.fluxcd.io/v1
-        kind: Kustomization
-        metadata:
-          name: not-used
-        spec:
-          patches:
-            - patch: |-
-                apiVersion: helm.toolkit.fluxcd.io/v2
-                kind: HelmRelease
-                metadata:
-                  name: not-used
-                spec:
-                  values:
-                    cluster:
-                      name: main
-                    operator:
-                      replicas: 2
-              target:
-                kind: HelmRelease
-                name: cilium
-      target:
-        kind: Kustomization
-        name: cilium
-    - # Update CoreDNS replicas
-      patch: |-
-        apiVersion: kustomize.toolkit.fluxcd.io/v1
-        kind: Kustomization
-        metadata:
-          name: not-used
-        spec:
-          patches:
-            - patch: |-
-                apiVersion: helm.toolkit.fluxcd.io/v2
-                kind: HelmRelease
-                metadata:
-                  name: not-used
-                spec:
-                  values:
-                    replicaCount: 3
-              target:
-                kind: HelmRelease
-                name: coredns
-      target:
-        kind: Kustomization
-        name: coredns
-    - # Update External-Secrets replicas
-      patch: |-
-        apiVersion: kustomize.toolkit.fluxcd.io/v1
-        kind: Kustomization
-        metadata:
-          name: not-used
-        spec:
-          patches:
-            - patch: |-
-                apiVersion: helm.toolkit.fluxcd.io/v2
-                kind: HelmRelease
-                metadata:
-                  name: not-used
-                spec:
-                  values:
-                    webhook:
-                      replicaCount: 2
-              target:
-                kind: HelmRelease
-                name: external-secrets
-      target:
-        kind: Kustomization
-        name: external-secrets
     - # Net-new CNPG cluster: plain initdb (no Barman recovery).
       # Use the `components.postgres/cnpg=init` label on an app's Flux Kustomization
       # to mark it as a brand-new cluster with no existing data. The component

--- a/kubernetes/clusters/main/apps.yaml
+++ b/kubernetes/clusters/main/apps.yaml
@@ -10,9 +10,9 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/main
   postBuild:
-    substitute:
-      CLUSTER: main
-      SECRET_DOMAIN: jory.dev
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-info
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/clusters/main/cluster-info.yaml
+++ b/kubernetes/clusters/main/cluster-info.yaml
@@ -9,4 +9,3 @@ metadata:
     reconcile.fluxcd.io/watch: Enabled
 data:
   CLUSTER: main
-  SECRET_DOMAIN: jory.dev

--- a/kubernetes/clusters/main/cluster-info.yaml
+++ b/kubernetes/clusters/main/cluster-info.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/v1/configmap_v1.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-info
+  namespace: flux-system
+  labels:
+    reconcile.fluxcd.io/watch: Enabled
+data:
+  CLUSTER: main
+  SECRET_DOMAIN: jory.dev

--- a/kubernetes/clusters/test/apps.yaml
+++ b/kubernetes/clusters/test/apps.yaml
@@ -30,7 +30,6 @@ spec:
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}
-              SECRET_DOMAIN: ${SECRET_DOMAIN}
               STORAGE_HR: ${STORAGE_HR}
               STORAGE_NS: ${STORAGE_NS}
           patches:

--- a/kubernetes/clusters/test/apps.yaml
+++ b/kubernetes/clusters/test/apps.yaml
@@ -10,11 +10,9 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/test
   postBuild:
-    substitute:
-      CLUSTER: test
-      SECRET_DOMAIN: jory.dev
-      STORAGE_HR: democratic-csi
-      STORAGE_NS: storage
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-info
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/clusters/test/cluster-info.yaml
+++ b/kubernetes/clusters/test/cluster-info.yaml
@@ -9,6 +9,5 @@ metadata:
     reconcile.fluxcd.io/watch: Enabled
 data:
   CLUSTER: test
-  SECRET_DOMAIN: jory.dev
   STORAGE_HR: democratic-csi
   STORAGE_NS: storage

--- a/kubernetes/clusters/test/cluster-info.yaml
+++ b/kubernetes/clusters/test/cluster-info.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/v1/configmap_v1.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-info
+  namespace: flux-system
+  labels:
+    reconcile.fluxcd.io/watch: Enabled
+data:
+  CLUSTER: test
+  SECRET_DOMAIN: jory.dev
+  STORAGE_HR: democratic-csi
+  STORAGE_NS: storage

--- a/kubernetes/clusters/utility/apps.yaml
+++ b/kubernetes/clusters/utility/apps.yaml
@@ -30,7 +30,6 @@ spec:
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}
-              SECRET_DOMAIN: ${SECRET_DOMAIN}
               STORAGE_HR: ${STORAGE_HR}
               STORAGE_NS: ${STORAGE_NS}
           patches:

--- a/kubernetes/clusters/utility/apps.yaml
+++ b/kubernetes/clusters/utility/apps.yaml
@@ -10,11 +10,9 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/utility
   postBuild:
-    substitute:
-      CLUSTER: utility
-      SECRET_DOMAIN: jory.dev
-      STORAGE_HR: democratic-csi
-      STORAGE_NS: storage
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-info
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/clusters/utility/cluster-info.yaml
+++ b/kubernetes/clusters/utility/cluster-info.yaml
@@ -9,6 +9,5 @@ metadata:
     reconcile.fluxcd.io/watch: Enabled
 data:
   CLUSTER: utility
-  SECRET_DOMAIN: jory.dev
   STORAGE_HR: democratic-csi
   STORAGE_NS: storage

--- a/kubernetes/clusters/utility/cluster-info.yaml
+++ b/kubernetes/clusters/utility/cluster-info.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/v1/configmap_v1.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-info
+  namespace: flux-system
+  labels:
+    reconcile.fluxcd.io/watch: Enabled
+data:
+  CLUSTER: utility
+  SECRET_DOMAIN: jory.dev
+  STORAGE_HR: democratic-csi
+  STORAGE_NS: storage


### PR DESCRIPTION
Move per-cluster Flux substitutions into watched `cluster-info` ConfigMaps, then consolidate what they carry:

- Drop `SECRET_DOMAIN` entirely — it has no consumers; every hostname in `apps/base` hardcodes the domain.
- Replace the four per-component replica patches in main's `cluster-apps` (cert-manager, cilium, coredns, external-secrets) with `${REPLICAS:=1}`-style values in the base HelmReleases, set from each app's per-cluster ks (existing metrics-server pattern). Cilium `cluster.name` defaults to `default` with main set explicitly via `${CLUSTER_NAME:=default}`, preserving the names every cluster runs today.
- Repair bootstrap helmfile templating and teach it to resolve Flux substitution vars, so the `${VAR:=default}` values bootstrap correctly (this is what broke last time vars were added to bootstrapped charts).

## Notes
- Bootstrap was already broken on helmfile 1.7.3 before this PR: `chartPath` values entries aren't visible while templating release fields, and values-stage `exec` runs from the chart cache dir so the relative `yq` paths never resolved. Templates now use `readFile` (matches upstream onedr0p/home-ops); path overrides live in the templates, replacing `chartPath` and `flux-values.yaml.gotmpl`.
- `values.yaml.gotmpl` resolves `${CLUSTER...}` from env and collapses `${VAR:=default}` on the YAML text before parsing, mirroring kustomize-controller — ints/bools keep their types.
- The removed replica patches were silently clobbering the HelmRelease-defaults patch on those four child Kustomizations (both patches JSON-merge `spec.patches`, last one wins) — those HRs now pick up the install/rollback/upgrade defaults for the first time.

## Verification
- `flate build hr` base-vs-branch: byte-identical rendered manifests for all four charts on all three clusters, cilium included.
- `flate build ks` across all three clusters: only the expected `SECRET_DOMAIN` removals, replica-patch → postBuild moves, and now-explicit chart defaults.
- `helmfile template` for `apps.yaml` passes for all three clusters: replicas render as int `1`, cilium `cluster-name` stays `default` at bootstrap (Flux flips main afterwards, as it always has), no unresolved Flux vars, no PDB at bootstrap, flux-instance chart+values resolve from the cluster dir. `crds.yaml` renders CRDs for every release except cloudflare-dns (ocharted needs auth locally — pre-existing).