### PR TITLE
feat(authentik): add the OpenCode application

### DIFF
--- a/terraform/authentik/applications.tofu
+++ b/terraform/authentik/applications.tofu
@@ -13,6 +13,7 @@ locals {
     "Miso-Chat",
     "Miso-Gallery",
     "Open-WebUI",
+    "OpenCode",
     "Paperless",
     "Portainer",
     "RomM",
@@ -139,6 +140,15 @@ locals {
       icon_url          = "https://raw.githubusercontent.com/joryirving/miso-gallery/main/assets/miso-gallery-logo.png"
       redirect_uri      = "https://miso-gallery.${var.CLUSTER_DOMAIN}/auth/oidc/callback"
       launch_url        = "https://miso-gallery.${var.CLUSTER_DOMAIN}/auth/oidc"
+      property_mappings = local.default_property_mappings
+    },
+    OpenCode = {
+      client_id         = module.onepassword_application["OpenCode"].fields["OPENCODE_CLIENT_ID"]
+      client_secret     = module.onepassword_application["OpenCode"].fields["OPENCODE_CLIENT_SECRET"]
+      group             = "ai"
+      icon_url          = "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/png/opencode.png"
+      redirect_uri      = "https://opencode.${var.CLUSTER_DOMAIN}/oauth2/callback"
+      launch_url        = "https://opencode.${var.CLUSTER_DOMAIN}"
       property_mappings = local.default_property_mappings
     },
     Open-WebUI = {


### PR DESCRIPTION
First half of moving the opencode pod off HTTP basic auth. The popup is a browser-native dialog, so the 1Password extension cannot fill it; Envoy's OIDC filter in front of the web UI gives a real login form instead.

Follows the existing pattern exactly — entry in `local.oauth_apps`, client credentials read from the `opencode` 1Password item, `ai` group, implicit-consent authorization flow via the shared resource block.

`redirect_uri` is `/oauth2/callback`, which is where the Envoy SecurityPolicy will land the callback.

**Apply this before merging the cluster-side PR.** Until the application exists in authentik, the SecurityPolicy has no issuer to discover and the browser route fails closed. The API route for `opencode attach` is unaffected either way.

Needs `OPENCODE_CLIENT_ID` and `OPENCODE_CLIENT_SECRET` on the `opencode` item in the Kubernetes vault first, or the plan will fail on the missing fields.