### PR TITLE
feat(opencode): front the web UI with authentik SSO

### DIFF
--- a/kubernetes/apps/base/llm/opencode/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/opencode/externalsecret.yaml
@@ -11,10 +11,6 @@ spec:
   target:
     name: *name
   data:
-    - secretKey: OPENCODE_SERVER_PASSWORD
-      remoteRef:
-        key: opencode
-        property: password
     - secretKey: LITELLM_API_KEY
       remoteRef:
         key: litellm
@@ -31,3 +27,41 @@ spec:
       remoteRef:
         key: github-miso
         property: GITHUB_TOKEN
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name opencode-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+  data:
+    - secretKey: client-id
+      remoteRef:
+        key: opencode
+        property: OPENCODE_CLIENT_ID
+    - secretKey: client-secret
+      remoteRef:
+        key: opencode
+        property: OPENCODE_CLIENT_SECRET
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name opencode-htpasswd
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+  data:
+    - secretKey: .htpasswd
+      remoteRef:
+        key: opencode
+        property: HTPASSWD

--- a/kubernetes/apps/base/llm/opencode/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/opencode/helmrelease.yaml
@@ -70,7 +70,7 @@ spec:
       app:
         annotations:
           gatus.home-operations.com/endpoint: |
-            conditions: ["[STATUS] == 401"]
+            conditions: ["[STATUS] == 302"]
         hostnames: ["opencode.jory.dev"]
         parentRefs:
           - name: envoy-internal

--- a/kubernetes/apps/base/llm/opencode/httproute.yaml
+++ b/kubernetes/apps/base/llm/opencode/httproute.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: opencode-api
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      conditions: ["[STATUS] == 401"]
+spec:
+  hostnames:
+    - opencode-api.jory.dev
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: opencode
+          port: 4096

--- a/kubernetes/apps/base/llm/opencode/kustomization.yaml
+++ b/kubernetes/apps/base/llm/opencode/kustomization.yaml
@@ -6,4 +6,6 @@ resources:
   - ./configmap.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/base/llm/opencode/securitypolicy.yaml
+++ b/kubernetes/apps/base/llm/opencode/securitypolicy.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: opencode-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: opencode
+  oidc:
+    provider:
+      issuer: https://sso.jory.dev/application/o/opencode/
+    clientIDRef:
+      group: ""
+      kind: Secret
+      name: opencode-oidc
+    clientSecret:
+      group: ""
+      kind: Secret
+      name: opencode-oidc
+    redirectURL: https://opencode.jory.dev/oauth2/callback
+    logoutPath: /logout
+    scopes: ["openid", "email", "profile"]
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: opencode-api-basic-auth
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: opencode-api
+  basicAuth:
+    users:
+      group: ""
+      kind: Secret
+      name: opencode-htpasswd


### PR DESCRIPTION
Draft — merge only after #9295 is applied, since the OIDC filter needs the authentik application to exist.

The basic-auth popup cannot be filled by the 1Password extension (it is a browser-native dialog, not a form). opencode's `OPENCODE_SERVER_PASSWORD` is also a single global setting, so a browser authenticated by SSO could not also satisfy it — which is why both doors move to the gateway:

| host | policy | used by |
|---|---|---|
| `opencode.jory.dev` | `oidc` → sso.jory.dev | browser (SSO form, 1Password or passkey) |
| `opencode-api.jory.dev` | `basicAuth` (htpasswd) | `opencode attach` |

`OPENCODE_SERVER_PASSWORD` is dropped from the ExternalSecret so the server stops demanding basic auth itself. The password in `op://Kubernetes/opencode/password` is unchanged and still what you type — it is now hashed into the htpasswd secret and checked by Envoy instead of by opencode, so `opencode attach https://opencode-api.jory.dev` keeps working with the same credential.

Notes on the shape of it:

`opencode-api` is a standalone HTTPRoute rather than a second `route:` entry in the HelmRelease. app-template only suffixes resource names when there is more than one route, so adding a second key would have renamed the existing `opencode` HTTPRoute to `opencode-app` and churned DNS for nothing.

`clientIDRef` rather than an inline `clientID`, so neither half of the credential sits in git.

The gatus condition on the browser route moves from `[STATUS] == 401` to `302` — an unauthenticated request is now redirected to authentik rather than challenged. The API route keeps `401`.

In-cluster access on the ClusterIP stays unauthenticated, same as litellm and vmcp; the gateway is the boundary.

Requires `OPENCODE_CLIENT_ID`, `OPENCODE_CLIENT_SECRET` and `HTPASSWD` on the `opencode` 1Password item.