### PR TITLE
feat(opencode): give the pod memini memory

### DIFF
--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -3,6 +3,15 @@
   customManagers: [
     {
       customType: "regex",
+      description: "opencode plugins pinned in the ConfigMap JSON (no comments possible inside it)",
+      managerFilePatterns: ["/(^|/)llm/opencode/configmap\\.yaml$/"],
+      matchStrings: [
+        "\"(?<depName>@[^\"/]+/[^\"@]+)@(?<currentValue>\\d+\\.\\d+\\.\\d+)\"",
+      ],
+      datasourceTemplate: "npm",
+    },
+    {
+      customType: "regex",
       description: "Process annotated dependencies",
       managerFilePatterns: ["/\\.yaml(?:\\.j2)?$/"],
       matchStrings: [

--- a/kubernetes/apps/base/llm/opencode/configmap.yaml
+++ b/kubernetes/apps/base/llm/opencode/configmap.yaml
@@ -30,6 +30,9 @@ data:
     {
       "$schema": "https://opencode.ai/config.json",
       "model": "litellm-anthropic/auto",
+      "plugin": [
+        ["@eleboucher/opencode-memini@0.7.18", { "base_url": "http://memini.llm:8080", "namespace": "opencode", "auto_update": false }]
+      ],
       "enabled_providers": ["litellm-anthropic", "litellm", "opencode"],
       "agent": {
         "coordinator": {

--- a/kubernetes/apps/base/llm/opencode/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/opencode/externalsecret.yaml
@@ -19,6 +19,10 @@ spec:
       remoteRef:
         key: context7
         property: OPENCODE_API_KEY
+    - secretKey: MEMINI_API_KEY
+      remoteRef:
+        key: opencode
+        property: OPENCODE_API_KEY
     - secretKey: GITHUB_TOKEN
       remoteRef:
         key: github-miso


### PR DESCRIPTION
Same plugin the dotfiles config loads, so the pod recalls and captures like your Mac does — pinned to `0.7.18`, pointed at `http://memini.llm:8080` rather than the public hostname, with `auto_update: false` so the pinned version stays pinned (the plugin defaults to checking npm, and it executes in-process).

`MEMINI_API_KEY` is env-only by the plugin's design, so it comes from `op://Kubernetes/opencode/OPENCODE_API_KEY` — the same value the `memini-api-keys` secret already grants the `opencode` namespace.

Verified in the real image against the live memini before writing any of this, since the pod has no node and plugins are fetched at runtime by opencode's embedded runtime:

```
handshake: namespace resolved key=opencode namespace=probe-repo source=toplevel cwd=probe-repo
POST /v1/handshake  200
POST /v1/search     200
POST /v1/memories   201
```

Two things learned while testing, worth knowing rather than discovering later:

**Memory is scoped per repo, not per the configured namespace.** The server resolves the namespace from the session's project (`source=toplevel cwd=probe-repo`) even with `namespace: "opencode"` set. So a session in `~/projects/home-ops` gets `home-ops` memory — shared with your Mac working in the same repo, which is the useful behaviour.

**Sessions outside a git repo get no memory.** The handshake needs `project.cwd_basename` and returns `400` without it, which is what a session started in `~/projects` (the default dir, not itself a repo) will hit. It degrades with a log warning rather than failing the session, but memory only works once you are in one of the clones.

Renovate keeps the pin fresh via a customManager, since JSON inside the ConfigMap cannot carry an annotation comment. Verified it matches exactly the plugin line — one hit, `@eleboucher/opencode-memini` @ `0.7.18` — and does not false-positive on `base_url` or on model ids like `chatgpt/gpt-5.6-sol`.