### PR TITLE
feat(toolhive): host the dispatch MCP server

### DIFF
--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/dispatch-mcp/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/dispatch-mcp/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-dispatch
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        token: "{{ .DISPATCH_AGENT_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: dispatch

--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/dispatch-mcp/kustomization.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/dispatch-mcp/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/dispatch-mcp/mcpserver.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/dispatch-mcp/mcpserver.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: dispatch
+spec:
+  image: ghcr.io/misospace/dispatch-mcp:sha-e4eaba8@sha256:11fee95712142758e1ff4c608ff0c7104ab391926fec5f96e8ea6ec63a8b1bed
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    - name: DISPATCH_URL
+      value: http://dispatch.llm:3000
+  secrets:
+    - name: toolhive-dispatch
+      key: token
+      targetEnvName: DISPATCH_AGENT_TOKEN
+  resources:
+    requests:
+      cpu: 25m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/main/llm/toolhive.yaml
+++ b/kubernetes/apps/main/llm/toolhive.yaml
@@ -91,6 +91,24 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: dispatch-mcp
+spec:
+  dependsOn:
+    - name: toolhive
+    - name: dispatch
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/dispatch-mcp
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: flux-mcp
 spec:
   dependsOn:


### PR DESCRIPTION
Cluster side of misospace/dispatch#824 and #825. The dispatch tools join the `mcp-tools` group, so they reach every client through the vmcp gateway — the opencode pod, Claude Code and zed on mcp.jory.dev — and nobody needs `tsx src/mcp/server.ts` from a local checkout any more.

**No opencode config change**: the pod already has `toolhive` pointed at the gateway, so the tools simply appear.

`DISPATCH_URL` is the in-cluster service rather than the public hostname — `https://dispatch.jory.dev/mcp` 307s to `/login?callbackUrl=/mcp`, since the app has no HTTP MCP transport at all; the server is stdio-only and talks to the REST API. Token comes from the `dispatch` 1Password item, same shape as `toolhive-github`.

Verified the published image before pinning it: `sha-e4eaba8` contains exactly the four-file closure, and the same image answered a real `initialize` / `tools/list` / `get_queue` round trip against your live deployment (13 tools).

**One caveat on the pin.** There is no semver tag yet — the workflow publishes `main` and `sha-*` on merge, and semver only on a `v*` tag, which is waiting on release PR #817 (`release: 0.5.41`). So this pins `sha-e4eaba8@sha256:11fee957…`, which is immutable and correct but **invisible to Renovate**, since the docker datasource cannot version-compare a `sha-` tag. Merge #817 and I will repin to `0.5.41@sha256:…`, matching how ha-mcp and unifi-network-mcp are pinned — then updates flow normally. Happy to hold this PR until then instead, if you would rather not have a temporarily unmanaged pin.

`DISPATCH_AGENT_NAME` is intentionally unset, so callers pass `agentName` explicitly rather than every client sharing one identity — see the discussion in misospace/dispatch#824.