### PR TITLE
fix(foreman): move coder-frontier off the MiniMax shim to reasoning-pool

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -8,7 +8,7 @@ spec:
   provider: cloud-proxy
   providerConfig:
     baseURL: http://litellm.llm:4000/v1
-    model: MiniMax-M3-chat
+    model: reasoning-pool
     apiKeySecretRef:
       name: foreman-agent
       key: LITELLM_API_KEY

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/foreman.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/foreman.yaml
@@ -12,6 +12,7 @@ spec:
   - llama-nvidia
   - MiniMax-M3-chat
   - llama-strix-nemotron
+  - reasoning-pool
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret


### PR DESCRIPTION
Moves the frontier coder off the MiniMax OpenAI-compatible shim.

`MiniMax-M3-chat` points at `https://api.minimax.io/v1`, a shim over a model that natively speaks Anthropic thinking blocks. It never returns `reasoning_content`; reasoning comes back inline as `<think>…</think>` in `content` on every call. LiteLLM strips the balanced pair only on **non-streaming** responses. The foreman agent is streaming-only — `pkg/foreman/agent/oai/types.go:199`, *"The client always sets Stream=true on the wire"*, and `client.go:53`, *"Wire protocol is SSE (text/event-stream) only"* — so `coder-frontier` has been ingesting raw think blocks on every turn since it was wired up.

## Summary
- `foreman/agents/coder-frontier.yaml`: `model: MiniMax-M3-chat` → `reasoning-pool`.
- `litellm/virtualkeys/foreman.yaml`: add `reasoning-pool` to the key's `models`. Without this the call 403s with `key_model_access_denied`, which is silent from the caller's side and cost 21 hours on 2026-08-20.

## Notes

`MiniMax-M3-chat` stays in the key scope because `coder-revision` still uses it.

Recorded for the reviewer rather than as an objection: `litellm/models/reasoning-pool-4.yaml` is `model: openai/MiniMax-M3` against `apiBase: https://api.minimax.io/v1` — the same shim, as one rung of the pool. Traffic that lands on that rung will still see inline think blocks. Jory's call, made knowingly.

The alternative — `MiniMax-M3` on the Anthropic surface (`api.minimax.io/anthropic/v1/messages`) — was tested and rejected: a streaming tool-calling request through litellm returns **HTTP 500** with zero SSE chunks, which for a streaming-only agent is a hard failure on every run.

Foreman cannot bypass litellm for this. `api/foreman/v1alpha1/agent_types.go` restricts `AgentProvider` to `local;cloud-proxy`, both OpenAI-compatible HTTP; there is no Anthropic client in the agent. Native Anthropic support is being requested upstream separately.

## Verification
- After merge and reconcile, the key scope needs `POST /key/update` — the litellm operator applies `spec.models` only at key creation (home-operations/litellm-operator#109), so a spec edit alone does not change the live key.
- Then confirm with a real completion on the `foreman` key against `reasoning-pool` before trusting it.

https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh
