### PR TITLE
feat(litellm): energy-priced neuralwatt rungs, dsv4f PAYG backstop, unblock glm-5.3

### DIFF
--- a/kubernetes/apps/base/llm/litellm/models/dsv4f-1.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/dsv4f-1.yaml
@@ -19,7 +19,7 @@ spec:
     supportsFunctionCalling: true
     supportsPromptCaching: true
     extra:
-      input_cost_per_token: 4.4e-07
-      cache_creation_input_token_cost: 4.4e-07
-      cache_read_input_token_cost: 1.4e-08
-      output_cost_per_token: 1.32e-06
+      input_cost_per_token: 2.2e-07
+      cache_creation_input_token_cost: 2.2e-07
+      cache_read_input_token_cost: 7.0e-09
+      output_cost_per_token: 6.6e-07

--- a/kubernetes/apps/base/llm/litellm/models/dsv4f-4.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/dsv4f-4.yaml
@@ -2,16 +2,16 @@
 apiVersion: litellm.home-operations.com/v1alpha1
 kind: LiteLLMModel
 metadata:
-  name: frontier-pool-5
+  name: dsv4f-4
 spec:
-  modelName: frontier-pool
+  modelName: dsv4f
   proxyRef: litellm
   params:
     model: openai/deepseek-v4-flash
     apiBase: https://api.neuralwatt.com/v1
     apiKey: os.environ/NEURALWATT_API_KEY
     additional:
-      order: 5
+      order: 4
   info:
     mode: chat
     maxInputTokens: 1000000

--- a/kubernetes/apps/base/llm/litellm/models/dsv4p.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/dsv4p.yaml
@@ -22,7 +22,7 @@ spec:
     supportsFunctionCalling: true
     supportsPromptCaching: true
     extra:
-      input_cost_per_token: 1.32e-06
-      cache_creation_input_token_cost: 1.32e-06
-      cache_read_input_token_cost: 4.4e-08
-      output_cost_per_token: 3.96e-06
+      input_cost_per_token: 6.6e-07
+      cache_creation_input_token_cost: 6.6e-07
+      cache_read_input_token_cost: 2.2e-08
+      output_cost_per_token: 1.98e-06

--- a/kubernetes/apps/base/llm/litellm/models/frontier-pool-6.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/frontier-pool-6.yaml
@@ -7,7 +7,7 @@ spec:
   modelName: frontier-pool
   proxyRef: litellm
   params:
-    model: openai/glm-5.2-flex
+    model: openai/glm-5.2
     apiBase: https://api.neuralwatt.com/v1
     apiKey: os.environ/NEURALWATT_API_KEY
     additional:
@@ -17,9 +17,6 @@ spec:
     maxInputTokens: 1048560
     maxOutputTokens: 16384
     supportsFunctionCalling: true
-    supportsPromptCaching: true
     extra:
-      input_cost_per_token: 7.25e-07
-      cache_creation_input_token_cost: 7.25e-07
-      cache_read_input_token_cost: 1.8125e-07
-      output_cost_per_token: 2.25e-06
+      input_cost_per_token: 1.1688e-07
+      output_cost_per_token: 1.1688e-07

--- a/kubernetes/apps/base/llm/litellm/models/frontier-pool-6.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/frontier-pool-6.yaml
@@ -2,24 +2,24 @@
 apiVersion: litellm.home-operations.com/v1alpha1
 kind: LiteLLMModel
 metadata:
-  name: frontier-pool-5
+  name: frontier-pool-6
 spec:
   modelName: frontier-pool
   proxyRef: litellm
   params:
-    model: openai/deepseek-v4-flash
+    model: openai/glm-5.2-flex
     apiBase: https://api.neuralwatt.com/v1
     apiKey: os.environ/NEURALWATT_API_KEY
     additional:
-      order: 5
+      order: 6
   info:
     mode: chat
-    maxInputTokens: 1000000
+    maxInputTokens: 1048560
     maxOutputTokens: 16384
     supportsFunctionCalling: true
     supportsPromptCaching: true
     extra:
-      input_cost_per_token: 1.04e-07
-      cache_creation_input_token_cost: 1.04e-07
-      cache_read_input_token_cost: 2.6e-08
-      output_cost_per_token: 2.07e-07
+      input_cost_per_token: 7.25e-07
+      cache_creation_input_token_cost: 7.25e-07
+      cache_read_input_token_cost: 1.8125e-07
+      output_cost_per_token: 2.25e-06

--- a/kubernetes/apps/base/llm/litellm/models/glm-5.3.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/glm-5.3.yaml
@@ -12,6 +12,8 @@ spec:
     apiKey: os.environ/ZAI_API_KEY
     additional:
       order: 1
+      allowed_openai_params:
+      - reasoning_effort
   info:
     mode: chat
     maxInputTokens: 1000000

--- a/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./dsv4f-1.yaml
   - ./dsv4f-2.yaml
   - ./dsv4f-3.yaml
+  - ./dsv4f-4.yaml
   - ./dsv4f-local.yaml
   - ./dsv4p.yaml
   - ./frontier-pool-1.yaml

--- a/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - ./frontier-pool-3.yaml
   - ./frontier-pool-4.yaml
   - ./frontier-pool-5.yaml
+  - ./frontier-pool-6.yaml
   - ./glm-5.2.yaml
   - ./glm-5.3.yaml
   - ./go-gpt-5.6-luna.yaml


### PR DESCRIPTION
Three changes. **Supersedes the savings claim in this PR's first revision** — that was computed from a token price schedule this account isn't billed on. Corrected below.

## 1. glm-5.3 forwards `reasoning_effort` instead of 400ing

Removing the global `drop_params` in #9236 turned a silent strip into a hard failure, and it hit a real caller:

```
400 litellm.UnsupportedParamsError: openai does not support parameters:
['reasoning_effort'], for model=glm-5.3
... No fallback model group found for original model_group=glm-5.3
```

Fixed with `allowed_openai_params`, not `additional_drop_params` — because z.ai supports the param and it does real work. Measured against the provider directly:

| request | content | reasoning_content | completion tokens |
|---|---|---|---|
| `reasoning_effort=low` | `'9'` | 0 ch | 3 |
| `reasoning_effort=high` | `'9'` | 187 ch | 56 |
| no param | `'**9**'` | 136 ch | 47 |

`low` suppresses reasoning entirely. **Dropping the param would silently discard the caller's intent** — which is the shape of failure that produced the reasoning leak to begin with. Forwarding gives z.ai the control that was actually requested.

The error also reveals glm-5.3 has **no fallback group**, so this 400 was fatal rather than degraded. Separately, the fallback map is a cycle rather than a DAG: `llama-strix` and `llama-nvidia` point at each other and `dsv4f` points back at `llama-nvidia`, so nothing terminates at an always-available sink. Not addressed here.

## 2. neuralwatt rungs priced on energy, not tokens

This account bills **energy**: `$10.00/kWh`, measured `230.93 mWh/request` for deepseek-v4-flash (typical 16k–64k, 87% cache) and `1.87 Wh` for glm-5.2 (typical 64k–256k, 97% cache). The token schedule doesn't apply.

Normalised per token: **5.77 µWh vs 11.69 µWh — glm-5.2 costs 2.02× deepseek-v4-flash**, not the 14× the token prices implied. The raw per-request ratio *looks* like 8.1× only because the portal quotes each model at its own typical size, and glm's reference request is 4× larger.

| order | model | $/M | basis |
|---|---|---|---|
| 1 | `chatgpt/gpt-5.6-sol` | 5.0000 / 30.0000 | token |
| 2 | `openai/k3` (Kimi Coding) | 3.0000 / 15.0000 | token |
| 3 | `openai/kimi-k3` (Moonshot) | 3.0000 / 15.0000 | token |
| 4 | `openai/glm-5.3` (z.ai) | 1.4000 / 4.4000 | token |
| **5** | **`deepseek-v4-flash` (nw)** | **0.0577 / 0.0577** | **energy** |
| **6** | **`glm-5.2` (nw)** | **0.1169 / 0.1169** | **energy** |

Modelled as a flat blended per-token rate because LiteLLM's cost engine is per-token only and cannot represent per-request energy. It's a **proxy**, accurate to roughly ±2× across the size band — energy is dearer than tokens on small requests and cheaper on large ones. No `cache_read` tier on these rungs on purpose: cache-hit rate is already baked into the measured energy, so pricing it again would double-count.

**Flex dropped.** It's a scheduling tier — same model, same energy, the gateway may hold the request when the fleet is busy — so under energy billing it plausibly saves nothing and only adds latency. If adopted later it should be a deliberate per-model choice.

## 3. dsv4f gets an uncapped PAYG rung

| order | model | $/M |
|---|---|---|
| 1 | `deepseek-v4-flash` (opencode go) | 0.2200 / 0.6600 |
| 2 | `gpt-5.6-luna` (opencode go) | 0.2000 / 1.2000 |
| 3 | `mimo-v2.5` (opencode go) | 0.1400 / 0.2800 |
| **4** | **`deepseek-v4-flash` (neuralwatt)** | **0.0577 / 0.0577** |

**This is not cheaper than opencode.** Like-for-like, neuralwatt runs **1.08–1.98× more** per request across realistic profiles, and only wins on small low-cache requests.

It's added for **availability**. All three existing rungs draw on one capped dollar allowance, so they exhaust together, and the group then falls back to `llama-nvidia` — the same 3090 Foreman runs on. Paying ~1.2× on overflow beats hard-failing or pushing cloud overflow onto local hardware.

## Also: corrected opencode Go DeepSeek prices

```
deepseek-v4-flash   $0.440/$1.320 -> $0.220/$0.660   (cache_r $0.014 -> $0.007)
deepseek-v4-pro     $1.320/$3.960 -> $0.660/$1.980   (cache_r $0.044 -> $0.022)
```

`luna` and `mimo-v2.5` on the same endpoint already matched, so this is a provider-side halving on the DeepSeek line, not drift. It matters because LiteLLM already overstates Go spend (it can't see cache hits) and this stacked a second 2× the same way.

## Verification

- `kustomize build` — 83 resources, 37 models
- `deepseek-v4-flash` and `glm-5.2` both answer live completions on neuralwatt
- z.ai accepts `reasoning_effort` at `low` and `high`, with the token counts above

A wrong model name on a backstop rung fails **silently** until every rung above it caps out — worth checking rather than assuming.