### PR TITLE
feat(bridge): ship 0.7.0 and give the local coder a second slot

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
           app:
             image:
               repository: ghcr.io/misospace/foreman-dispatch-bridge
-              tag: 0.6.32@sha256:5926918bba719b9c8c65a210ff1c4487812ace81db5a38c1f361ce892b786679
+              tag: 0.7.0@sha256:8d43d9c26e17ff9ebaf3f982018e079406c57ea5f0514ff35397a6e711edcd32
             env:
               DISPATCH_URL: http://dispatch.llm:3000
               # Dash, not slash (like saffron-normal): agents auto-register, but a "/"
@@ -47,7 +47,7 @@ spec:
               # (cloud-proxy -> litellm -> MiniMax-M3). Ignored by older bridges.
               ESCALATION_LANE: frontier
               LANE_CODER_AGENTS: '{"*":["coder"],"frontier":["coder-frontier"]}'
-              CODER_AGENT_SLOTS: '{"coder":1,"coder-frontier":4}'
+              CODER_AGENT_SLOTS: '{"coder":2,"coder-frontier":4}'
               FOREMAN_NAMESPACE: llm
               MAX_IN_PROGRESS: "14"
               VERIFY_ENABLED: "false"


### PR DESCRIPTION
## Summary
- Bump the bridge to 0.7.0, which carries the terminal-since annotation-key fix (#204).
- Raise `CODER_AGENT_SLOTS` for `coder` from 1 to 2.

## Why

The 0.6.32 image predates #204, so every terminal Workload currently fails its
terminal-since stamp with a 422 (`foreman.llmkube.dev/terminal-since/Completed`
has two slashes; an annotation key allows one). Prune never sees a stamp, and all
12 terminal Workloads in `llm` are unpruned as a result.

Separately, `coder` was the throughput binder. Today it ran 8 code tasks
totalling 96 minutes across a 353-minute window, so the 3090 sat idle ~73% of
the time. `run_once` drains a lane to capacity within one tick, so with
`{"coder":1}` each tick claims exactly one issue and then breaks out on a full
slot; ticks that overlap an 18-23 minute code task claim nothing. No
`local:capped:` line appears in the tick logs, confirming `MAX_IN_PROGRESS: 14`
was never the constraint.

## Verification
- Values-only change; no schema or template changes. Flux will roll the CronJob
  on the next reconcile, and the change takes effect on the following `*/15` tick.

## Notes
- 2, not 4, deliberately. The single slot existed to protect LCP prompt-cache
  locality: alternating workloads on one backend drop cache similarity to ~0.15
  and cost a 32-77s prompt reprocess per switch. At 27% utilization there is
  headroom to pay that, but this wants measuring before going higher.
- Worth watching after this lands: `coder` task durations (for per-stream
  slowdown from two concurrent streams on one 3090) and whether prune starts
  clearing terminal Workloads.
