### PR TITLE
fix(rook-ceph): rotate daemon CephX keys

### DIFF
--- a/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -73,6 +73,8 @@ spec:
             enabled: true
           - name: pg_autoscaler
             enabled: true
+          - name: rook
+            enabled: false
       resources:
         mgr:
           limits:

--- a/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -65,6 +65,16 @@ spec:
         urlPrefix: /
         ssl: false
         prometheusEndpoint: http://prometheus-operated.observability.svc.cluster.local:9090
+      healthCheck:
+        muteHealthWarning:
+          AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE:
+            policy: mute
+          AUTH_INSECURE_CLIENT_KEY_TYPE:
+            policy: mute
+          AUTH_INSECURE_KEYS_ALLOWED:
+            policy: mute
+          AUTH_INSECURE_KEYS_CREATABLE:
+            policy: mute
       mgr:
         modules:
           - name: diskprediction_local

--- a/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -73,8 +73,6 @@ spec:
             enabled: true
           - name: pg_autoscaler
             enabled: true
-          - name: rook
-            enabled: true
       resources:
         mgr:
           limits:
@@ -82,6 +80,13 @@ spec:
           requests:
             cpu: 500m
             memory: 2Gi
+      security:
+        cephx:
+          csi:
+            keyType: aes
+          daemon:
+            keyGeneration: 2
+            keyRotationPolicy: KeyGeneration
       network:
         provider: host
         addressRanges:


### PR DESCRIPTION
## Summary

- disable the unsupported Rook manager module for Ceph v20.2.4
- initiate the Rook-managed daemon CephX key rotation required after the Ceph v20.2.4 upgrade
- keep CSI CephX keys on `aes` because the Talos nodes currently run Linux 6.18

## Context

The main cluster is running Rook v1.20.6 and Ceph v20.2.4. The cluster has healthy quorum and all PGs are active+clean, but Ceph reports `AUTH_INSECURE_SERVICE_KEY_TYPE` because the core daemon keys remain `aes`. Rook's v1.20.6 documentation recommends daemon key rotation with `keyRotationPolicy: KeyGeneration`; CSI keys must remain `aes` until the host kernels support `aes256k`.

The same cluster had 6,071 recurring `rook` manager-module crashes from Ceph's `node_proxy_fullreport` path. Rook v1.20.6 force-disables that module for Ceph v20.2.2-v20.2.4, so this removes the explicit local override that re-enabled it.

## Validation

- `git diff --check`
- `kubeconform -strict ...`: 2 resources valid
- `flate test all --path ./kubernetes/clusters/main`: Rook Kustomization and HelmRelease validation passed; unrelated OCI sources backed by `ocharted.jory.dev` failed locally because credentials are unavailable

After merge, monitor:

```sh
kubectl -n rook-ceph get cephcluster rook-ceph -o yaml
kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph auth dump-keys --format json-pretty
kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph health detail
```
