### PR TITLE
fix(litellm): drop temperature on the gpt-5 deployments

### DIFF
--- a/kubernetes/apps/base/llm/litellm/models/chatgpt-gpt-5.6-luna.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/chatgpt-gpt-5.6-luna.yaml
@@ -8,6 +8,9 @@ spec:
   proxyRef: litellm
   params:
     model: chatgpt/gpt-5.6-luna
+    additional:
+      additional_drop_params:
+      - temperature
   info:
     mode: responses
     maxInputTokens: 1050000

--- a/kubernetes/apps/base/llm/litellm/models/chatgpt-gpt-5.6-sol.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/chatgpt-gpt-5.6-sol.yaml
@@ -8,6 +8,9 @@ spec:
   proxyRef: litellm
   params:
     model: chatgpt/gpt-5.6-sol
+    additional:
+      additional_drop_params:
+      - temperature
   info:
     mode: responses
     maxInputTokens: 1100000

--- a/kubernetes/apps/base/llm/litellm/models/chatgpt-gpt-5.6-terra.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/chatgpt-gpt-5.6-terra.yaml
@@ -8,6 +8,9 @@ spec:
   proxyRef: litellm
   params:
     model: chatgpt/gpt-5.6-terra
+    additional:
+      additional_drop_params:
+      - temperature
   info:
     mode: responses
     maxInputTokens: 1050000

--- a/kubernetes/apps/base/llm/litellm/models/frontier-pool-1.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/frontier-pool-1.yaml
@@ -9,6 +9,8 @@ spec:
   params:
     model: chatgpt/gpt-5.6-sol
     additional:
+      additional_drop_params:
+      - temperature
       order: 1
   info:
     mode: responses

--- a/kubernetes/apps/base/llm/litellm/models/reasoning-pool-1.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/reasoning-pool-1.yaml
@@ -9,6 +9,8 @@ spec:
   params:
     model: chatgpt/gpt-5.6-luna
     additional:
+      additional_drop_params:
+      - temperature
       order: 1
       extra_body:
         reasoning:


### PR DESCRIPTION
**463 `UnsupportedParamsError` in a six-hour log window**, every one identical:

```
litellm.acompletion(model=chatgpt/gpt-5.6-luna)
UnsupportedParamsError: gpt-5 models don't support temperature=0.2.
Only temperature=1 is supported.
```

Before #9210 the global `drop_params` silently stripped it. #9236 removed that setting, so it became a hard error on every call from any caller that sets a temperature.

## Impact is real but not user-visible

Each failure is caught and recovered:

```
Falling back to model_group = {'model': 'reasoning-pool', '_target_order': 2}
Successful fallback b/w models.
```

So this is wasted round-trips and latency, not breakage. But it's **one failed upstream call plus a fallback hop per request** — and it silently reroutes traffic off the intended deployment. Callers asking for `gpt-5.6-luna` have been quietly served by `reasoning-pool` instead.

## Dropped, not forwarded — the opposite of #9308

The distinction is whether the provider can honour the param **at all**:

| model | param | provider behaviour | fix |
|---|---|---|---|
| `glm-5.3` (z.ai) | `reasoning_effort` | supported, does real work (`low` → 0 reasoning tokens, `high` → 187) | **forward** via `allowed_openai_params` |
| `chatgpt/gpt-5.*` | `temperature` | only `1` accepted, ever | **drop** via `additional_drop_params` |

Forwarding temperature here would just relocate the 400 to the provider. There's no value to preserve, so dropping lets the request through at the only temperature the model has.

## Applied to all five, not just the observed one

```
chatgpt-gpt-5.6-luna     chatgpt/gpt-5.6-luna
chatgpt-gpt-5.6-sol      chatgpt/gpt-5.6-sol
chatgpt-gpt-5.6-terra    chatgpt/gpt-5.6-terra
frontier-pool-1          chatgpt/gpt-5.6-sol      (order 1)
reasoning-pool-1         chatgpt/gpt-5.6-luna     (order 1)
```

`luna` is just the busiest. `sol` and `terra` reject temperature identically, and the two pool rungs are the same models behind pool names — fixing only the observed one would leave four latent copies.

Verified: `kustomize build` succeeds, 37 models.

> Committed unsigned — the 1Password SSH agent is locked.