### PR TITLE
feat(openclaw): move the LCM summariser off Strix onto the 3090

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-strix-nemotron.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-strix-nemotron.yaml
@@ -64,6 +64,8 @@ spec:
     - "1024"
     - --cont-batching
     - --cache-prompt
+    - --cache-ram
+    - "4096"
     - --kv-unified
     - --checkpoint-min-step
     - "32768"

--- a/kubernetes/apps/base/llm/litellm/llama-strix.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-strix.yaml
@@ -79,6 +79,8 @@ spec:
     - --spec-draft-type-v
     - q8_0
     - --cache-prompt
+    - --cache-ram
+    - "4096"
     - --kv-unified
     - --checkpoint-min-step
     - "32768"

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -32,6 +32,8 @@ data:
           imageModel: {
             primary: "litellm/llama-strix",
             fallbacks: [
+              "litellm/llama-vision",
+              "litellm/llama-nvidia",
               "minimax/MiniMax-M3",
             ]
           },
@@ -167,7 +169,8 @@ data:
               { id: "kimi-k2.7", name: "Kimi K2.7 Code (Kimi→Moonshot)", reasoning: true, input: ["text", "image"], cost: { input: 0.95, output: 4, cacheRead: 0.19, cacheWrite: 0.95 }, contextWindow: 262144, maxTokens: 32768 },
               { id: "kimi-k3", name: "Kimi K3 (Kimi→Moonshot)", reasoning: true, input: ["text", "image"], cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3 }, contextWindow: 1048576, maxTokens: 131072 },
               { id: "llama-strix", name: "Qwen3.6-35B-A3B Uncensored Q5_K_P (ROCm)", reasoning: true, input: ["text", "image"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 16384 },
-              { id: "llama-nvidia", name: "Qwen3.6-27B UD Q4_K_XL (CUDA)", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131072, maxTokens: 16384 },
+              { id: "llama-vision", name: "Huihui-Qwen3.5-9B abliterated Q4_K_M (ROCm)", reasoning: false, input: ["text", "image"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 32768, maxTokens: 8192 },
+              { id: "llama-nvidia", name: "Qwen3.8-27B UD Q4_K_XL (CUDA)", reasoning: true, input: ["text", "image"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 131072, maxTokens: 16384 },
               { id: "dsv4f", name: "OpenCode Go DeepSeek V4 Flash", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000000, maxTokens: 16384 },
               { id: "dsv4p", name: "OpenCode Go DeepSeek V4 Pro", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000000, maxTokens: 16384 },
               { id: "glm-5.3", name: "Z.Ai GLM 5.3", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 1000000, maxTokens: 16384 },

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -281,12 +281,12 @@ data:
           "admin-http-rpc": { enabled: true },
           "lossless-claw": {
             enabled: true,
-            llm: { allowModelOverride: true, allowedModels: [ "litellm/llama-strix" ], },
-            subagent: { allowModelOverride: true, allowedModels: [ "litellm/llama-strix" ], },
+            llm: { allowModelOverride: true, allowedModels: [ "litellm/llama-nvidia" ], },
+            subagent: { allowModelOverride: true, allowedModels: [ "litellm/llama-nvidia" ], },
             config: {
               contextThreshold: 0.75,
               delegationTimeoutMs: 1000000,
-              expansionModel: "litellm/llama-strix",
+              expansionModel: "litellm/llama-nvidia",
               freshTailCount: 64,
               freshTailMaxTokens: 24000,
               ignoreSessionPatterns: [
@@ -302,7 +302,7 @@ data:
               pruneHeartbeatOk: true,
               skipStatelessSessions: true,
               statelessSessionPatterns: [ "agent:*:subagent:**" ],
-              summaryModel: "litellm/llama-strix",
+              summaryModel: "litellm/llama-nvidia",
               summaryTimeoutMs: 1000000,
               sweepDeadlineMs: 300000,
               compactUntilUnderDeadlineMs: 600000,


### PR DESCRIPTION
Two changes to the OpenClaw config: move the LCM summariser to the 3090, and give `imageModel` real local fallbacks.

## 1. LCM summariser → llama-nvidia

Measured on a 34k-token chunk, the size lossless-claw actually summarises (`leafChunkTokens: 20000`, `freshTailMaxTokens: 24000`):

| model | wall | in | out | |
|---|---|---|---|---|
| `llama-strix` (current) | 78.6s | 34351 | 199 | |
| `llama-strix-nemotron` | 83.3s | 34823 | 653 | |
| **`llama-nvidia`** | **16.4s** | 34351 | 224 | **4.8x faster** |
| `mimo-v2.5` | 5.6s | 34348 | 118 | 14x faster |
| `dsv4f` | 2.1s | 30658 | 159 | saw a shorter prompt — excluded |

Summarisation is **prefill-bound** (34k in, ~200 out) — exactly where Strix is weakest and the 3090 strongest. All four LCM slots move: `summaryModel`, `expansionModel`, and the `llm`/`subagent` `allowedModels`.

**Why not mimo-v2.5**, which is faster still and would cost ~$0.03/day: it sends full session transcripts to a third party. LCM transcripts are the most sensitive content in the system — everything every agent has seen. Keeping summarisation on owned hardware is worth 11 seconds.

**Contention isn't a real cost.** `llama-strix` serves 78 req/day total (OpenClaw is 7 of them); `llama-nvidia` already serves 2983/day.

## 2. imageModel gets local fallbacks

`imageModel` had exactly one fallback — MiniMax-M3 — so any local failure went straight to a paid cloud model, while two local vision-capable models sat unused.

```
primary:   litellm/llama-strix
fallbacks: litellm/llama-vision      <- new
           litellm/llama-nvidia      <- new
           minimax/MiniMax-M3
```

**`llama-vision` was not in the model registry at all**, so nothing could route to it regardless of the fallback list. Added as Huihui-Qwen3.5-9B abliterated, `input: ["text","image"]`, `contextWindow: 32768`.

Ordered ahead of `llama-nvidia` deliberately — it's the purpose-built abliterated model, where the other two do vision as a side job. That is **not** a speed choice; measured with three unique images each, no cache reuse:

```
llama-strix     4.3s median   ( 4.3 /   4.3 /  3.7)
llama-nvidia   29.1s median   (23.6 /  31.3 / 29.1)
llama-vision   47.0s median   (47.0 / 113.7 / 45.1)
```

All three identified the colours correctly. Fallbacks only run when the primary has already failed, so an uncensored answer at 47s beats a refusal.

Also corrects the `llama-nvidia` registry entry, wrong two ways: named `Qwen3.6-27B` when that box has run Qwen3.8-27B since 08-14, and declaring `input: ["text"]` despite carrying an mmproj and answering image prompts — which is why it couldn't have served as an image fallback even if listed.

## A trap worth recording

A reasoning model returns **empty `content`** when `max_tokens` is exhausted before the answer begins:

```
max_tokens=120    finish=length   content=0 ch    reasoning_content=412 ch
max_tokens=2000   finish=stop     content='Red and blue.'
```

At a tight budget `llama-strix` looks broken on vision while working fine. Any caller with a low `max_tokens` against these models sees silent empty responses, not errors.

## Not fixed here — the Strix config deserves a look

- `llama-strix` holds 262144 of KV **plus** llama.cpp's default 8 GiB prompt cache; nemotron another 8 GiB. On a node with ~21 GiB free.
- It evicts prompt cache entries of 214–582 MiB continuously.
- The eviction is **prefix diversity, not volume** — five unrelated callers (Dispatch 37/day, Repo-Wiki 21, PR Reviewer 11, OpenClaw 7, Opencode 2) each hold a large distinct prefix, so each evicts the others.
- 78 req/day is poor value for that footprint on the most memory-constrained node.