### PR TITLE
docs(llm): refresh routing and context-cost strategy

### DIFF
--- a/docs/src/notes/llm-strategy.md
+++ b/docs/src/notes/llm-strategy.md
@@ -2,10 +2,13 @@
 
 How the LLM fleet is subscribed, wired, and used — and where smart-routing is headed.
 
-Everything funnels through **LiteLLM** (`kubernetes/apps/base/llm/litellm/configmap.yaml`) at
-`http://litellm.llm:4000`. Clients address stable aliases; LiteLLM forwards to the upstream a given
-subscription or local server expects. This doc is the reference for keeping those aliases meaningful
-and for designing intent-based routing on top of them.
+Everything funnels through **LiteLLM** (`kubernetes/apps/base/llm/litellm/litellmproxy.yaml` and
+`kubernetes/apps/base/llm/litellm/models/*.yaml`) at `http://litellm.llm:4000`. Clients address stable
+aliases; LiteLLM forwards to the upstream a given subscription or local server expects. This doc is the
+reference for keeping those aliases meaningful and for designing intent-based routing on top of them.
+
+This is a strategy snapshot, not a live quota ledger. Provider pricing, rolling allowances, and
+Prometheus counters are perishable; dated observations below are labeled as such.
 
 ## Subscriptions
 
@@ -16,11 +19,11 @@ Moonshot is the token-metered failover behind the Kimi Coding subscription.
 | ------------------- | -------------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | **ChatGPT Plus**    | ~$25 CAD/mo                                  | unpublished rolling + weekly quota, with tier-weighted usage                  | rolling (3h chat) + weekly (Codex) | GPT-5.6 Sol, Terra, Luna                                                      | Sol frontier; Luna is the reasoning-pool lead                                 |
 | **MiniMax Plus**    | ~$200 USD/yr ($20/mo, annual = 2mo free)     | 300 prompts / 5h                                                             | rolling 5h                         | M3 and M2.7, via the Anthropic endpoint                                      | Agentic reasoning workhorse                                                   |
-| **Opencode Go**     | $10 USD/mo                                   | $12 / 5h, $30 / wk, $60 / mo (dollar-denominated)                            | rolling 5h / wk / mo               | DeepSeek V4 Flash/Pro, MiMo v2.5/Pro, Qwen3.7-plus (frontier models moved to dedicated subs) | Cheap lane only (dsv4f workhorse) — go's $ cap is reserved for cheap models  |
-| **GLM Coding Lite** | ~$151 USD/yr (promotional, region-dependent) | ~80 prompts / 5h                                                             | rolling 5h                         | GLM-5.2, GLM-4.7, GLM-4.5-Air                                                | GLM coding access; fallback lane                                              |
-| **Kimi Coding**     | ~$180 USD/yr ($15/mo; ~$261 CAD/12mo)                            | plan allowance                                                               | plan-defined                       | Kimi K2.7 Code, Kimi K3                                                       | Primary Kimi coding and frontier lanes                                         |
-| **Moonshot (Kimi)** | pay-per-use                                  | none (per-key RPM/TPM only)                                                  | n/a                                | kimi-k2.7-code, kimi-k3                                                       | Token-metered fallback behind Kimi Coding                                      |
-| **Neuralwatt**      | pay-per-use ($5/kWh energy billing)          | account credit; API-key allowances available                                | n/a                                | GLM-5.2                                                                      | Metered GLM capacity after flat plans                                           |
+| **Opencode Go**     | $10 USD/mo                                   | $12 / 5h, $30 / wk, $60 / mo (dollar-denominated)                            | rolling 5h / wk / mo               | DeepSeek V4 Flash/Pro, MiMo v2.5/Pro, Qwen3.7-plus                              | High-volume coding/reasoning lane; current pricing is no longer assumed cheap |
+| **GLM Coding Lite** | ~$151 USD/yr (promotional, region-dependent) | ~80 prompts / 5h                                                             | rolling 5h                         | GLM-5.3 on the Z.AI coding endpoint; GLM-5.2 remains a Neuralwatt fallback       | OpenClaw main primary; cache-sensitive long-context lane                       |
+| **Kimi Coding**     | ~$180 USD/yr ($15/mo; ~$261 CAD/12mo)        | plan allowance                                                               | plan-defined                       | Kimi K2.7 Code, Kimi K3                                                         | Primary Kimi coding and frontier lanes                                          |
+| **Moonshot (Kimi)** | pay-per-use                                  | none (per-key RPM/TPM only)                                                  | n/a                                | kimi-k2.7-code, kimi-k3                                                         | Token-metered fallback behind Kimi Coding                                       |
+| **Neuralwatt**      | pay-per-use ($5/kWh energy billing)          | account credit; API-key allowances available                                | n/a                                | GLM-5.2, DeepSeek V4 Flash                                                     | Intentional PAYG fallback and capacity insurance                               |
 
 Caveats worth remembering:
 
@@ -35,6 +38,13 @@ Caveats worth remembering:
 - All 5h caps are **rolling windows** (oldest usage falls off continuously), not calendar resets.
 - Kimi subscription traffic uses equivalent Moonshot list prices for cost comparison: K2.7 Code is
   $0.19 cached input / $0.95 cache miss / $4 output per MTok; K3 is $0.30 / $3 / $15.
+- The upstream DSV4F repricing reported in August 2026 changed the economics materially: roughly 8x
+  higher uncached input and 40x higher cache-read pricing than the former baseline. Treat the provider
+  account and current invoice as authoritative; LiteLLM model metadata can lag provider pricing.
+- Cached input is cheaper billing-wise but still consumes upstream subscription/token allocation. A
+  high K3 cache-hit ratio does not make a context-heavy diagnostic session quota-free.
+- Opencode is LilDrunkenSmurf's ad-hoc interactive coding workload, so its Luna/K3 usage is intentional
+  rather than unattended fleet waste. Neuralwatt is an intentional PAYG fallback, not an accidental leak.
 
 ## Model inventory
 
@@ -57,7 +67,7 @@ Aliases as defined in the LiteLLM configmap, grouped by where they run.
 | ---------------------- | ----------------------------- | ------------------------------- | -------- | -------------------------------------------------- |
 | `MiniMax`              | MiniMax Plus                  | MiniMax-M3 (Anthropic endpoint) | 1M       | Big-context generation                             |
 | `MiniMax-M2.7`         | MiniMax Plus                  | MiniMax-M2.7                    | 204.8k   | Agentic reasoning workhorse                        |
-| `glm-5.2`              | GLM Coding Lite → Neuralwatt | glm-5.2                         | 1M       | GLM big-context; Neuralwatt is metered fallback    |
+| `glm-5.3`              | GLM Coding Lite              | glm-5.3 (Z.AI)                  | 1M       | OpenClaw main primary; upstream prompt-cache lane |
 | `chatgpt/gpt-5.6-sol`   | ChatGPT Plus                  | gpt-5.6-sol (Codex/OAuth)       | 1.1M     | Flagship frontier                                  |
 | `chatgpt/gpt-5.6-terra` | ChatGPT Plus                  | gpt-5.6-terra (Codex/OAuth)     | 1.05M    | Balanced, explicit-only OpenAI tier                |
 | `chatgpt/gpt-5.6-luna`  | ChatGPT Plus                  | gpt-5.6-luna (Codex/OAuth)      | 1.05M    | Reasoning-pool lead; high-volume OpenAI tier       |
@@ -66,37 +76,49 @@ Aliases as defined in the LiteLLM configmap, grouped by where they run.
 
 ### Neuralwatt (energy-metered PAYG)
 
-| Alias                | Upstream model | Ctx | Role                               |
-| -------------------- | -------------- | --- | ---------------------------------- |
-| `neuralwatt/glm-5.2` | glm-5.2        | 1M  | Direct long-context reasoning lane |
+| Alias                    | Upstream model     | Ctx | Role                                          |
+| ------------------------ | ------------------ | --- | --------------------------------------------- |
+| `neuralwatt/glm-5.2`     | glm-5.2            | 1M  | Direct long-context reasoning fallback        |
+| `dsv4f` (Neuralwatt rung) | deepseek-v4-flash | 1M  | PAYG fallback when OpenCode Go is unavailable |
 
 Neuralwatt charges this account for measured GPU energy rather than tokens. PAYG is $5/kWh;
 prefix-cache hits avoid prefill work and therefore reduce the charged energy. Neuralwatt also publishes
-token prices for compatibility, but those are not the billing basis here, so LiteLLM intentionally has no
-static token-cost metadata for these deployments. Use Neuralwatt's usage API/dashboard for authoritative
-cost and energy until its response-level `cost` and `energy` extensions are exported into Prometheus.
+token prices for compatibility, but those are not the billing basis here. Use Neuralwatt's usage
+API/dashboard for authoritative cost and energy; LiteLLM and Prometheus are routing/volume telemetry,
+not the billing authority.
 
 ### Cloud (Opencode Go gateway, `opencode.ai/zen/go/v1`)
 
 | Alias                               | Upstream model    | Ctx (in)    | Role                                                |
 | ----------------------------------- | ----------------- | ----------- | --------------------------------------------------- |
-| `dsv4f`                             | deepseek-v4-flash | 1M          | High-volume cheap lane; OpenClaw subagent/heartbeat |
+| `dsv4f`                             | deepseek-v4-flash | 1M          | OpenClaw subagent/heartbeat and reasoning-pool rung; cache-sensitive after repricing |
 | `dsv4p`                             | deepseek-v4-pro   | 1M          | Heavier DeepSeek                                    |
 | `mimo-v2.5` / `mimo-v2.5-pro`       | mimo-v2.5(-pro)   | 262k        | Lighter analysis lane                               |
 | `qwen3.7-plus`                      | qwen3.7-plus      | 1M          | Big-context Qwen via gateway                        |
 
-**Provider failover** (LiteLLM `order:`, transparent to callers): `glm-5.2` → z.ai then Neuralwatt;
-`kimi-k2.7` → Kimi Coding then Moonshot;
-`kimi-k3` → Kimi Coding then Moonshot. **OpenCode Go is not a frontier-pool rung** (K3/GLM burn its
-dollar cap too fast); DSV4F holds the third reasoning-pool rung, and DSV4P is now reachable only by
-explicit selection. This reacts when an
-upstream rejects requests; it cannot detect that an unpublished rolling allowance is merely _close_ to
-exhausted. `go-minimax-m3` / `go-minimax-m2.7` were removed entirely (redundant with the flat MiniMax
-plan + the native `MiniMax-M3-chat` endpoint).
+**Provider failover** (LiteLLM `order:`, transparent to callers): `kimi-k2.7` and `kimi-k3` use their
+Kimi Coding deployments before Moonshot; `frontier-pool` and `dsv4f` have explicit ordered PAYG rungs;
+`glm-5.3` is the OpenClaw main primary and `glm-5.2` remains a Neuralwatt fallback lane. This reacts
+when an upstream rejects requests; it cannot detect that an unpublished rolling allowance is merely
+_close_ to exhausted. `go-minimax-m3` / `go-minimax-m2.7` were removed entirely (redundant with the
+flat MiniMax plan + the native `MiniMax-M3-chat` endpoint).
+
+The current ordered pools are deliberately separate:
+
+| Pool | Order | Members | Effective input context | Policy |
+| ---- | ----- | ------- | ----------------------- | ------ |
+| `reasoning-pool` | 1 -> 2 -> 3 | GPT-5.6 Luna -> DSV4F (OpenCode Go) -> MiniMax-M3 | 1M | Strong reasoning lane; M3 is the flat-plan floor |
+| `frontier-pool` | 1 -> 6 | GPT-5.6 Sol -> Kimi K3 sub -> Kimi K3 Moonshot -> GLM-5.3 -> DSV4F Neuralwatt -> GLM-5.2 Neuralwatt | 1M | Frontier escalation for Opencode/Zed; no MiniMax downgrade |
+
+Kimi-for-Coding was removed from `reasoning-pool`: its 262k context limit made it the pool's
+conservative ceiling even though Kimi K3 itself is a 1M standalone/frontier model. The Kimi Coding
+subscription remains available through the Kimi aliases and `frontier-pool`.
 
 ## Model capability ranking
 
-Benchmark snapshot as of **2026-07-30** — perishable. Numbers are mostly **vendor
+Benchmark snapshot as of **2026-07-30** — perishable. The table retains the comparable GLM-5.2
+benchmark row, while the production OpenClaw main route is GLM-5.3. Do not use the benchmark row as a
+proxy for current provider pricing, cache behavior, or quota consumption. Numbers are mostly **vendor
 self-reported on non-overlapping harnesses** (SWE-bench Pro ≠ Verified; Terminal-Bench
 2.0 ≠ 2.1; GPT SWE-Pro drops ~15pts under standardized scaffolding), so treat deltas as
 **directional**, not precise, and re-pull when models bump. `n/p` = not published.
@@ -148,17 +170,18 @@ independence and format reliability, not on a coding leaderboard.
 
 Reading it for routing:
 
-- **Frontier tier** (`gpt-5.6-sol`, `kimi-k3`, `glm-5.2`) — strict subscription/PAYG escalation;
+- **Frontier tier** (`gpt-5.6-sol`, `kimi-k3`, `glm-5.3`) — strict subscription/PAYG escalation;
   Sol is the ceiling, K3 is the independent coding/frontier lane, and GLM is the long-horizon fallback.
-  MiniMax intentionally does not appear here.
-- **Reasoning tier** (`gpt-5.6-luna`, `kimi-k2.7`, `dsv4f`, `MiniMax-M3`) — a separate ordered
-  lane for strong, economical reasoning work. DSV4F is the OpenCode Go rung; MiniMax is the
-  flat-plan floor. Luna is pinned to `xhigh` reasoning effort (see below).
-- **Cheap/fast** (`dsv4f`, `mimo-v2.5`) — near-frontier coding at low cost;
-  `dsv4f` is the standout (SWE-V 79, LiveCodeBench 91.6, cheapest). Since V4 Flash went GA it
-  no longer belongs only in this tier: repo-bench re-scored it 0.895 → 0.957, at or above the
-  previous top cluster, while V4 Pro stayed at 0.864 — and Flash is 12.4× cheaper per token.
-  That inversion is why the reasoning tier and Hermes' fallback chain now reach for Flash, not Pro.
+  Neuralwatt supplies the PAYG safety rungs. MiniMax intentionally does not appear here.
+- **Reasoning tier** (`gpt-5.6-luna`, `dsv4f`, `MiniMax-M3`) — a separate ordered lane for strong
+  reasoning work. Luna leads, DSV4F is the OpenCode Go rung, and MiniMax is the flat-plan floor. The
+  pool now has a 1M effective context because the 262k Kimi-for-Coding member was removed.
+- **Cheap/fast** (`dsv4f`, `mimo-v2.5`) — near-frontier coding at low cost; `dsv4f` remains a strong
+  workhorse, but the August 2026 provider repricing means it is no longer safe to call it cheapest
+  without accounting for cache hits and prompt size. Since V4 Flash went GA it no longer belongs only
+  in this tier: repo-bench re-scored it 0.895 -> 0.957, at or above the previous top cluster, while V4
+  Pro stayed at 0.864. That inversion is why the reasoning tier and Hermes' fallback chain reach for
+  Flash, not Pro.
 - **Local** — `nvidia` (Qwen3.6-27B dense) is the local quality + speed pick; `self-hosted`
   (35B-A3B) trails it everywhere and earns its place only on the 262k context window.
 - **`reviewer` is a deliberate family split, not a quality pick.** Foreman's coder runs
@@ -175,10 +198,10 @@ Reading it for routing:
 
 | Consumer               | In repo?                                    | Points at                                                                                    |
 | ---------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| **OpenClaw**           | yes (`.../llm/openclaw/app/configmap.yaml`) | Miso `MiniMax-M3`; Saffron `glm-5.2`; subagent + heartbeat `dsv4f`; image `self-hosted`      |
+| **OpenClaw**           | yes (`.../llm/openclaw/app/configmap.yaml`) | Miso/main `glm-5.3`; Saffron `reasoning-pool`; subagents `dsv4f`; heartbeat `llama-nvidia`; image `self-hosted` |
 | **Hermes**             | yes (`.../llm/hermes/configmap.yaml`)       | default `kimi-k3`; compression/extract/approval/session-search `self-hosted`                 |
 | **Foreman**            | yes (`.../llm/foreman/agents/*.yaml`)       | `coder` → `nvidia`; `coder-strix` + `coder-revision` → `self-hosted`; `coder-frontier` → `MiniMax-M3-chat`; reviewers → `reviewer` |
-| **Opencode** (CLI/Zen) | no (workstation)                            | LiteLLM aliases directly; biggest single `user_agent` cluster after the agents               |
+| **Opencode** (CLI/Zen) | no (workstation)                            | LiteLLM aliases directly; ad-hoc interactive coding, not unattended fleet traffic             |
 | **Zed**                | no (workstation)                            | LiteLLM aliases directly                                                                     |
 
 ### OpenClaw cron fleet
@@ -213,7 +236,7 @@ Issue-worker pipelines (pick up issues and open PRs):
 ## Current routing + observed usage
 
 Routing today is `simple-shuffle` with hand-written availability fallbacks
-(configmap `router_settings`). `simple-shuffle` spreads a synchronized fan-out
+(`kubernetes/apps/base/llm/litellm/litellmproxy.yaml`). `simple-shuffle` spreads a synchronized fan-out
 evenly across a group's deployments; `least-busy` increments its in-flight
 counter _after_ the routing decision, so a burst reads equal counts and piles
 onto the first deployment — wrong for the 2-instance `self-hosted` group.
@@ -221,23 +244,71 @@ onto the first deployment — wrong for the 2-instance `self-hosted` group.
 ```yaml
 routing_strategy: simple-shuffle
 fallbacks:
-    - self-hosted: [nvidia]
-    - nvidia: [self-hosted]
-    - dsv4f: [nvidia]
+    - llama-strix: [llama-nvidia]
+    - llama-nvidia: [llama-strix]
+    - dsv4f: [llama-nvidia]
+    - auto: [dsv4f, MiniMax-M3-chat]
+context_window_fallbacks:
+    - llama-nvidia: [llama-strix]
+    - llama-strix: [dsv4f]
 ```
 
-Observed 30-day traffic (Prometheus, `litellm_*_metric_total`), top models:
+Observed 7-day traffic (Prometheus, 2026-08-23; `litellm_total_tokens_metric_total`, cached input
+included; all consumers combined):
 
-| Model                       | Tokens (30d) | Requests (30d) |
-| --------------------------- | -----------: | -------------: |
-| self-hosted                 |        1.07B |         27,250 |
-| MiniMax-M2.7                |         946M |         14,483 |
-| MiniMax-M3                  |         834M |          9,812 |
-| deepseek-v4-flash (`dsv4f`) |         811M |          9,049 |
-| nvidia                      |         161M |          4,798 |
+| Model                       | Reported tokens (7d) |
+| --------------------------- | -------------------: |
+| gpt-5.6-luna                |               329.0M |
+| MiniMax-M3                  |               313.6M |
+| llama-nvidia                |               219.8M |
+| deepseek-v4-flash (`dsv4f`) |               203.7M |
+| glm-5.3                     |                74.5M |
+| llama-strix-nemotron        |                45.0M |
+| mimo-v2.5                   |                22.8M |
+| MiniMax-M2.7                |                13.7M |
+| k3                          |                 7.4M |
 
-Kimi subscription traffic is valued at the equivalent Moonshot API rates in LiteLLM even though the
-plan itself is flat-rate.
+These are volume counters, not provider invoices. Kimi subscription traffic is valued at equivalent
+Moonshot API rates in LiteLLM even though the plan itself is flat-rate. Cached input still counts against
+upstream allocations.
+
+### Cache accounting
+
+There are two different caches in this stack:
+
+- LiteLLM's Redis response cache is enabled with a 300-second TTL. This is exact-request reuse at the
+  proxy layer and is separate from provider prefix caching.
+- OpenClaw requests set `cache_prompt: true` for GLM, K3, DSV4F, and the local model aliases. Providers
+  may report prefix-cache reads in response usage, but they do not all expose that usage consistently.
+
+GLM-5.3 is the important example. Prometheus showed zero `litellm_input_cached_tokens_metric_total`
+for GLM, but a direct probe through LiteLLM on 2026-08-23 returned approximately 60k-145k cached
+prefix tokens on repeated direct requests. Streaming usage chunks omitted or under-reported
+`cached_tokens`. The zero Prometheus value is therefore not proof that Z.AI caching is disabled. Use
+Z.AI's billing/usage dashboard to verify discounted billing for streamed requests; do not route main
+away from GLM based on that counter alone.
+
+### Context economics and guardrails
+
+OpenClaw main intentionally stays on GLM-5.3. Saffron uses the 1M `reasoning-pool`; subagents use
+DSV4F and heartbeats use the local NVIDIA model. This preserves the quality lanes instead of routing
+main away from GLM merely because one provider's streaming usage telemetry is incomplete.
+
+The OpenClaw ConfigMap's lossless-claw settings are now tuned for the actual failure mode:
+
+- `proactiveThresholdCompactionMode: inline`, `contextThreshold: 0.75`, `freshTailCount: 64`, and
+  `freshTailMaxTokens: 24000` keep compaction work on the active turn and retain a bounded tail.
+- `leafChunkTokens: 20000`, `sweepDeadlineMs: 300000`, and `compactUntilUnderDeadlineMs: 600000` give
+  leaf summarization enough time without allowing an unbounded sweep.
+- `largeFileThresholdTokens: 6000` externalizes oversized tool results at ingest, before a diagnostic
+  turn can accumulate dozens of large `exec` results. `stubLargeToolPayloads` remains false because
+  there was no historical sidecar corpus to restub; old bloated sessions are not retroactively fixed.
+- Model entries set `cache_prompt: true`, but cache savings do not reduce the upstream allocation consumed
+  by a large prompt. Input-size discipline is still required even when the prefix cache is healthy.
+
+The operational rule is simple: cap log/tool output, avoid replaying giant diagnostic dumps into a single
+turn, and start a fresh session after a context incident. A single turn can exceed a model window before
+`afterTurn()` compaction gets a chance to run.
 
 ### Slot accounting on the local pools
 
@@ -275,7 +346,7 @@ Tiers (three effective tiers; REASONING is folded into COMPLEX):
 | ------------------ | ----------------------------------- | -------------------------------------------- |
 | SIMPLE             | `self-hosted` (Strix 35B-A3B)       | Trivia — 0.4s, local, free                   |
 | MEDIUM             | `MiniMax-M3-chat`                   | Flat sub, ~1.1s, no weekly quota to burn     |
-| COMPLEX            | `reasoning-pool`                    | Luna → Kimi-for-Coding → DSV4F → M3          |
+| COMPLEX            | `reasoning-pool`                    | Luna -> DSV4F -> MiniMax-M3                  |
 | REASONING          | `reasoning-pool`                    | Folded — no classifier could separate it     |
 | default (miss)     | `MiniMax-M3-chat`                   | `classifier_fallback: default_model`         |
 
@@ -283,8 +354,8 @@ Classifier is `reviewer` (Mellum2-12B, ~0.5s) — a software-engineering model c
 software-engineering axis, and the cheapest thing in the fleet to put in every request's path.
 
 `frontier-pool` is deliberately **not** a tier target: `auto` must not compete with interactive
-sessions for the weekly ChatGPT/Kimi caps. COMPLEX still reaches Luna and Kimi automatically
-through `reasoning-pool`'s top rungs once those caps reset.
+sessions for the weekly ChatGPT/Kimi caps. COMPLEX reaches Luna and DSV4F through `reasoning-pool`;
+Kimi K3 remains in `frontier-pool` or explicit selection rather than being a reasoning-pool rung.
 
 ### Measured (2026-08-07, LiteLLM 1.95.0)
 
@@ -353,13 +424,14 @@ References: LiteLLM [Auto Routing](https://docs.litellm.ai/docs/proxy/auto_routi
 
 The `frontier-pool` alias is the "grab the smartest model with room left" lane for opencode/Zed — pick
 it and ask it to do things; LiteLLM routes to the best-available frontier model and falls down the chain
-a strict `order:` chain (429 → cooldown → next). Subscriptions first, then their PAYG counterparts:
+a strict `order:` chain (429/403 -> cooldown -> next). Subscriptions first, then their PAYG counterparts:
 
 1. `gpt-5.6-sol` — flagship frontier (ChatGPT Plus sub)
 2. `kimi-k3` @ Kimi Coding — dedicated Kimi sub (flat)
 3. `kimi-k3` @ Moonshot — PAYG backup
-4. `glm-5.2` @ z.ai — GLM Coding Lite sub
-5. `glm-5.2` @ Neuralwatt — PAYG backup
+4. `glm-5.3` @ Z.AI — GLM Coding Lite sub
+5. `dsv4f` @ Neuralwatt — PAYG DeepSeek fallback
+6. `glm-5.2` @ Neuralwatt — PAYG GLM fallback
 
 Implemented as one **self-contained `order:` group**, not router fallbacks referencing the shared
 groups. It intentionally has no MiniMax floor: a frontier request fails rather than silently degrading
@@ -389,19 +461,19 @@ Caveats:
 Two per-deployment behaviours are pinned in the configmap without inline comment; the reasoning lives
 here.
 
-**Luna is pinned to `xhigh` reasoning effort** via `extra_body: {reasoning: {effort: xhigh}}` on the
+**Luna is configured with `max` reasoning effort** via `extra_body: {reasoning: {effort: max}}` on the
 `reasoning-pool` rung. The nested `extra_body` form is deliberate:
 
 - `extra_body` is merged onto the wire *after* the provider transform, so it survives the `chatgpt/`
   provider's strict allow-list (which permits nested `reasoning` but strips `reasoning_effort`).
-- A bare `reasoning_effort: "xhigh"` string does work on LiteLLM v1.94.0, but `"max"` does **not** —
-  `_map_reasoning_effort` has no `max` branch, returns `None`, and the whole `reasoning` field is
-  dropped silently, landing on the `medium` default. `max` is a real gpt-5.6 effort above `xhigh`, so
-  if it is ever wanted it must use the `extra_body` form too. The Codex client only exposes `xhigh`.
+- A prior LiteLLM 1.94 test found that a bare `reasoning_effort: "max"` could be dropped by the
+  provider mapper. Keep the nested `extra_body` form and re-check the wire request after provider or
+  LiteLLM upgrades rather than assuming the requested effort was applied.
 - This is a default, not an override: client kwargs are merged last and win. A true hard override
   would need a proxy `async_pre_call_hook`.
 - Effort costs subscription quota. The ChatGPT plan meters reasoning work, and Luna leads the tier at
-  `order: 1`, so it fronts every COMPLEX-classified request. Drop it to `high` if the window runs dry.
+  `order: 1`, so it fronts every COMPLEX-classified request. Lower it from `max` only as an explicit
+  quota/quality tradeoff.
 
 **DeepSeek V4 Flash runs with thinking default-on.** The `thinking: {type: disabled}` workaround for
 [litellm#26395](https://github.com/BerriAI/litellm/issues/26395) was removed after retesting the live


### PR DESCRIPTION
## What changed

Refresh `docs/src/notes/llm-strategy.md` against the current LiteLLM/OpenClaw configuration and the recent context/quota investigation.

- Document the current `reasoning-pool` (`Luna -> DSV4F -> MiniMax-M3`) and `frontier-pool` (`Sol -> K3 -> GLM-5.3 -> Neuralwatt`) ordering.
- Record the removal of Kimi-for-Coding from the reasoning pool and the resulting 1M effective context.
- Correct OpenClaw consumer routing: main on GLM-5.3, Saffron on reasoning-pool, subagents on DSV4F, heartbeats on local NVIDIA.
- Clarify that Opencode is ad-hoc interactive usage and Neuralwatt is intentional PAYG fallback capacity.
- Add current cache/accounting guidance, including the GLM streaming telemetry caveat and K3 allocation behavior.
- Add the lossless-claw context guardrails and the 2026-08 DSV4F repricing note.
- Refresh the 7-day Prometheus volume snapshot and correct the frontier/reasoning effort notes.

This is documentation only; no runtime configuration changes are included.

## Verification

- `git diff --check`
- Cross-checked current `origin/main` configuration under `kubernetes/apps/base/llm/`.
