### PR TITLE
fix(litellm): correct the MiniMax Anthropic apiBase, it was the full endpoint path

### DIFF
--- a/kubernetes/apps/base/llm/litellm/models/minimax-m2.7.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/minimax-m2.7.yaml
@@ -8,7 +8,7 @@ spec:
   proxyRef: litellm
   params:
     model: minimax/MiniMax-M2.7
-    apiBase: https://api.minimax.io/anthropic/v1/messages
+    apiBase: https://api.minimax.io/anthropic
     apiKey: os.environ/MINIMAX_API_KEY
     additional:
       cache_control_injection_points:

--- a/kubernetes/apps/base/llm/litellm/models/minimax-m3.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/minimax-m3.yaml
@@ -8,7 +8,7 @@ spec:
   proxyRef: litellm
   params:
     model: minimax/MiniMax-M3
-    apiBase: https://api.minimax.io/anthropic/v1/messages
+    apiBase: https://api.minimax.io/anthropic
     apiKey: os.environ/MINIMAX_API_KEY
     additional:
       cache_control_injection_points:


### PR DESCRIPTION
`MiniMax-M3` and `MiniMax-M2.7` have been returning **404 on every call**:

```
MaskedHTTPStatusError: Client error '404 Not Found' for url
'https://api.minimax.io/anthropic/v1/messages/v1/chat/completions'
```

`apiBase` was set to the full endpoint rather than the base URL, and the `minimax/` provider appends its own path. [MiniMax's quickstart](https://platform.minimax.io/docs/guides/quickstart-preparation) documents the base as `ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic`.

Verified against the provider directly, same key and payload:

```
base .../anthropic/v1/messages  + /v1/messages  -> 404 page not found
base .../anthropic              + /v1/messages  -> 200, valid message object
```

Neither alias declares a fallback group, so both fail hard rather than degrading:

```
APIConnectionError: MinimaxException - 404 page not found
No fallback model group found for original model_group=MiniMax-M3
```

## What this implies about traffic

Everything that looked like MiniMax usage has actually been served by `MiniMax-M3-chat` and `reasoning-pool-3`, which point at the OpenAI-compatible base (`https://api.minimax.io/v1`) and were never affected.

So the Anthropic path has been **dead, not degraded** — and any conclusion about "the Anthropic endpoint's behaviour", including thinking leaking into OpenAI-shaped harnesses, was drawn from an endpoint that never answered. That's worth re-testing now the path works, because the fix differs: a broken URL is this PR, whereas a genuine format mismatch would need a shim.

Only the two Anthropic-provider aliases change. `minimax-m3-chat` and `reasoning-pool-3` already use the correct OpenAI base and are untouched.

Verified: `kustomize build` succeeds.