### PR TITLE
feat(litellm): add pi virtual key

### DIFF
--- a/kubernetes/apps/base/llm/litellm/virtualkeys/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./memini.yaml
   - ./openclaw.yaml
   - ./opencode.yaml
+  - ./pi.yaml
   - ./pr-review.yaml
   - ./repo-wiki.yaml
   - ./toolhive.yaml

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/pi.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/pi.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: pi
+spec:
+  proxyRef: litellm
+  keyAlias: Pi
+  secretName: litellm-key-pi
+  secretKey: api-key
+  models:
+  - auto
+  - chatgpt/gpt-5.6-luna
+  - chatgpt/gpt-5.6-sol
+  - chatgpt/gpt-5.6-terra
+  - dsv4f
+  - dsv4p
+  - frontier-pool
+  - glm-5.3
+  - kimi-k2.7
+  - kimi-k3
+  - llama-nvidia
+  - llama-strix
+  - llama-strix-nemotron
+  - llama-vision
+  - mimo-v2.5
+  - mimo-v2.5-pro
+  - MiniMax-M2.7
+  - MiniMax-M3
+  - MiniMax-M3-chat
+  - reasoning-pool
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: pi
+spec:
+  secretStoreRefs:
+  - name: onepassword
+    kind: ClusterSecretStore
+  selector:
+    secret:
+      name: litellm-key-pi
+  data:
+  - match:
+      secretKey: api-key
+      remoteRef:
+        remoteKey: litellm
+        property: LITELLM_PI_API_KEY


### PR DESCRIPTION
Pi currently authenticates with `LITELLM_OPENCODE_API_KEY`, so its spend and request volume are indistinguishable from Opencode in LiteLLM telemetry. This gives pi its own key.

The scope is every model declared in pi's provider config (`dot_pi/agent/models.json.tmpl`), not just the ones its subagents pin — the model picker can select any of them mid-session, and a scope missing a model fails silently:

`auto`, `chatgpt/gpt-5.6-luna`, `chatgpt/gpt-5.6-sol`, `chatgpt/gpt-5.6-terra`, `dsv4f`, `dsv4p`, `frontier-pool`, `glm-5.3`, `kimi-k2.7`, `kimi-k3`, `llama-nvidia`, `llama-strix`, `llama-strix-nemotron`, `llama-vision`, `mimo-v2.5`, `mimo-v2.5-pro`, `MiniMax-M2.7`, `MiniMax-M3`, `MiniMax-M3-chat`, `reasoning-pool`

All 20 cross-checked against live `LiteLLMModel` `spec.modelName` in `llm`; no misses.

The dotfiles side (pointing pi at `LITELLM_PI_API_KEY`) is a separate change.
