### PR TITLE
feat(opencode): bound context and remap roles off the Go plan

### DIFF
--- a/kubernetes/apps/base/llm/opencode/configmap.yaml
+++ b/kubernetes/apps/base/llm/opencode/configmap.yaml
@@ -30,6 +30,8 @@ data:
     {
       "$schema": "https://opencode.ai/config.json",
       "model": "litellm-anthropic/auto",
+      "compaction": { "auto": true, "prune": true, "preserve_recent_tokens": 20000, "reserved": 16384 },
+      "tool_output": { "max_lines": 800, "max_bytes": 16384 },
       "plugin": [
         ["@eleboucher/opencode-memini@0.7.19", { "base_url": "http://memini.llm:8080", "namespace": "opencode", "auto_update": false }]
       ],
@@ -39,32 +41,32 @@ data:
           "description": "Reasoning coordinator — plans, then delegates to role subagents (explorer/fixer/fixer-bigctx/oracle/reviewer)",
           "mode": "primary",
           "model": "litellm/reasoning-pool",
-          "prompt": "You are a coordinator. Do the high-level reasoning and synthesis yourself; delegate the legwork to role subagents via the task tool.\n\nCONTRACTS: when you delegate, hand each sub a self-contained brief — objective, the decisions already settled (inline the exact values), the files it owns, what's out of scope, and the observable check that proves success. A sub should never have to infer scope or re-derive a decision you already made.\n\nCAPACITY POLICY: `explorer`, `fixer-bigctx`, and `oracle` sit on the Opencode Go plan, which is metered in DOLLARS, not flat-rate. Their cost is real and they are not interchangeable: `explorer` (mimo-v2.5) is the cheapest by a wide margin — fan it out freely and in parallel, this is how you buy context. `fixer-bigctx` and especially `oracle` are materially more expensive per token; use them deliberately rather than by default, and prefer several `explorer` passes over one speculative `oracle` call. `fixer` (nvidia) is the low-latency lane for small scoped edits and the only lane that can read images, but it is heavily contended by an automated pipeline, so keep its jobs small and bounded.\n\nROLES:\n- `explorer` (mimo-v2.5 — 256k ctx): default recon. Codebase search, 'where/how is X', parallel scouting. Read-only. Cheapest lane available — fan out several at once; this is the cheapest way to buy context. It is the weakest reasoner, so give it locating and summarising work, not judgement calls.\n- `oracle` (dsv4p — 1M ctx, prepaid, strongest analysis tier): hard debugging, root-cause, architecture. Read-mostly; return analysis, don't sprawl into edits.\n- `fixer-bigctx` (dsv4f — 1M ctx): primary bulk coding lane. Large context, independent implementation attempts, alternative fixes, extra parallel coding capacity. Mid-priced of the Go lanes and capped tighter than the others, so prefer `explorer` for anything that is really recon.\n- `fixer` (nvidia — Qwen3.8-27B, 140k, multimodal): fast local coder and the only image-capable lane. Prefer it for small, well-bounded edits where latency matters, and route anything involving images here.\n- `reviewer` (MiniMax M3): independent second opinion and creative/prose.\n\nPARALLEL CODING: default to `fixer-bigctx` for substantive implementation and run several instances concurrently rather than narrowing scope. Use `fixer` alongside it for the small fast edits. Route anything involving images to `fixer`, the only lane that can read them.\n\nCOUNCIL (high-stakes review): get independent verdicts from different model families — `oracle` (DeepSeek), `reviewer` (MiniMax), and `fixer`/`fixer-bigctx` (Qwen) — then reconcile. Never let one model grade its own work."
+          "prompt": "You are a coordinator. Do the high-level reasoning and synthesis yourself; delegate the legwork to role subagents via the task tool.\n\nCONTRACTS: hand each sub a self-contained brief — objective, the decisions already settled (inline the exact values), the files it owns, what's out of scope, and the observable check that proves success. A sub should never have to infer scope or re-derive a decision you already made. Ask for a compact handoff back — findings, file paths, the change that matters — not a full transcript.\n\nROLES:\n- `explorer` (MiniMax M3 — 1M ctx, flat-rate plan): default recon, read-only scouting, 'where/how is X'. It is the one lane with real concurrency (3-4 at once), so fan out here.\n- `fixer` (llama-nvidia — local, free, 145k, vision-capable): small scoped edits and anything involving images. One slot, heavily contended by an automated pipeline — keep its jobs small and bounded.\n- `fixer-bigctx` (llama-strix — local, free, 262k): bulk coding lane. One slot, so concurrent calls just queue; run one at a time.\n- `oracle` (glm-5.3): hard debugging, root-cause, architecture. The only rate-capped lane left (~80 prompts / 5h, shared with other consumers) — use it deliberately, never by default.\n- `reviewer` (llama-strix-nemotron — local, free, two slots): independent second opinion and prose.\n\nCOUNCIL (high-stakes review): collect independent verdicts from different model families — MiniMax (`explorer`), Qwen on Strix (`fixer-bigctx`), Qwen on the 3090 (`fixer`), GLM (`oracle`), Nemotron (`reviewer`) — then reconcile. Never let one model grade its own work."
         },
         "explorer": {
-          "description": "Default recon — codebase scouting, search, 'where/how is X', read-only. MiMo V2.5 (256k ctx), the cheapest Go lane: fan out freely, several at a time. Weakest reasoner — locating and summarising, not judgement.",
+          "description": "Default recon — codebase scouting, search, 'where/how is X', read-only. MiniMax M3 (1M ctx, flat-rate). The one lane with real concurrency: fan out 3-4 at a time.",
           "mode": "subagent",
-          "model": "litellm/mimo-v2.5"
+          "model": "litellm-anthropic/MiniMax-M3"
         },
         "fixer": {
-          "description": "Fast scoped edits — Qwen3.8-27B local on the 3090 (140k, multimodal). Low latency; prefer it for small, well-bounded changes, and for anything involving images.",
+          "description": "Fast scoped edits — Qwen3.8-27B local on the 3090 (145k, vision-capable). One slot and heavily contended by an automated pipeline: keep jobs small and bounded. Route anything involving images here.",
           "mode": "subagent",
           "model": "litellm/llama-nvidia"
         },
         "fixer-bigctx": {
-          "description": "Primary bulk coding lane — DeepSeek V4 Flash (1M ctx). Large context, independent implementation attempts, alternative fixes, parallel coding capacity. Falls back to GPT-5.6 Luna when its cap is spent.",
+          "description": "Bulk coding lane — Qwen3.6-35B-A3B local on Strix (262k). Free, but one slot: concurrent calls queue, so run one at a time.",
           "mode": "subagent",
-          "model": "litellm/dsv4f"
+          "model": "litellm/llama-strix"
         },
         "oracle": {
-          "description": "Hard debugging / architecture — DeepSeek V4 Pro (1M ctx, prepaid, strongest analysis tier). Read-mostly deep analysis; return a recommendation, don't sprawl into edits",
+          "description": "Hard debugging / architecture — GLM 5.3 (1M ctx). The only rate-capped lane left (~80 prompts / 5h, shared with other consumers): use deliberately. Read-mostly deep analysis; return a recommendation, don't sprawl into edits",
           "mode": "subagent",
-          "model": "litellm/dsv4p"
+          "model": "litellm/glm-5.3"
         },
         "reviewer": {
-          "description": "Independent review / creative — MiniMax M3 (distinct family from the Qwen coders and the DeepSeek analysis lanes). Second opinions and prose.",
+          "description": "Independent review / creative — Nemotron 3.5 Lightning 30B-A3B local on Strix (free, two slots). Distinct family from the Qwen coders and the MiniMax explorer. Second opinions and prose.",
           "mode": "subagent",
-          "model": "litellm-anthropic/MiniMax-M3"
+          "model": "litellm/llama-strix-nemotron"
         },
         "lean": {
           "description": "Minimal MCP context — toolhive router only (reaches other MCPs via call_tool)",


### PR DESCRIPTION
Two changes to the cluster opencode config.

## 1. Context bounding

The coordinator was sending ~217k input tokens per request. `prune` defaults false, so subagent output never leaves coordinator context, and `tool_output.max_bytes` defaults to 50 KiB (~12k tokens per subagent return).

```json
"compaction": { "auto": true, "prune": true, "preserve_recent_tokens": 20000, "reserved": 16384 },
"tool_output": { "max_lines": 800, "max_bytes": 16384 }
```

Both are top-level. Verified against `https://opencode.ai/config.json`: `prune` nests under `compaction`, the key is `preserve_recent_tokens`, and neither block exists on `$defs.AgentConfig` — global is the only placement available. Mirrors joryirving/dotfiles#69.

## 2. Role remap off Opencode Go

| role | before | after |
|---|---|---|
| `explorer` | `litellm/mimo-v2.5` | `litellm-anthropic/MiniMax-M3` |
| `fixer` | `litellm/llama-nvidia` | unchanged |
| `fixer-bigctx` | `litellm/dsv4f` | `litellm/llama-strix` |
| `oracle` | `litellm/dsv4p` | `litellm/glm-5.3` |
| `reviewer` | `litellm-anthropic/MiniMax-M3` | `litellm/llama-strix-nemotron` |

All five names cross-checked against `litellmmodel` in the `llm` namespace. `MiniMax-M3` keeps the `litellm-anthropic/` prefix (that provider block is where it is declared); the rest are `litellm/`.

## 3. Coordinator prompt

Rewritten: the old CAPACITY POLICY described Go dollar metering, mimo as the cheapest lane, and dsv4f/dsv4p economics — all wrong after this. New text keys on slot counts and rate caps instead: fan out only on `explorer` (real concurrency), serialise on the single-slot local lanes, spend `oracle` deliberately. COUNCIL guidance kept, family list updated to MiniMax / Qwen (strix) / Qwen (nvidia) / GLM / Nemotron. CONTRACTS kept, plus a line asking subs for compact handoffs.

401 words to 249 (2664 to 1593 chars), re-sent every coordinator turn.

## Note

The brief listed `fixer-bigctx` (llama-strix) as vision-capable. Left that claim out: llama-strix declares `mmproj:` without a matching `files:` entry, so the projector never downloads and vision is silently dead there. `fixer` (llama-nvidia) remains the image lane. Worth fixing separately.

Validated: embedded JSON parses, `kustomize build` clean.
