### PR TITLE
feat(openclaw): protect external image ui

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -112,6 +112,34 @@ spec:
                 cpu: 10m
               limits:
                 memory: 1Gi
+    rawResources:
+      openclaw-imageui-oidc:
+        enabled: true
+        forceRename: openclaw-imageui-oidc
+        manifest:
+          apiVersion: gateway.envoyproxy.io/v1alpha1
+          kind: SecurityPolicy
+          metadata:
+            name: openclaw-imageui-oidc
+          spec:
+            targetRefs:
+              - group: gateway.networking.k8s.io
+                kind: HTTPRoute
+                name: openclaw-imageui
+            oidc:
+              provider:
+                issuer: https://sso.jory.dev/application/o/opencode/
+              clientIDRef:
+                group: ""
+                kind: Secret
+                name: opencode-oidc
+              clientSecret:
+                group: ""
+                kind: Secret
+                name: opencode-oidc
+              redirectURL: https://generate.jory.dev/oauth2/callback
+              logoutPath: /logout
+              scopes: ["openid", "email", "profile"]
     persistence:
       openclaw-home:
         type: emptyDir
@@ -202,9 +230,12 @@ spec:
               - name: "{{ .Release.Name }}"
                 port: &codeserverPort 12321
       imageui:
+        annotations:
+          gatus.home-operations.com/endpoint: |
+            conditions: ["[STATUS] == 302"]
         hostnames: ["generate.jory.dev"]
         parentRefs:
-          - name: envoy-internal
+          - name: envoy-external
             namespace: network
         rules:
           - backendRefs:

--- a/terraform/authentik/applications.tofu
+++ b/terraform/authentik/applications.tofu
@@ -143,12 +143,19 @@ locals {
       property_mappings = local.default_property_mappings
     },
     OpenCode = {
-      client_id         = module.onepassword_application["OpenCode"].fields["OPENCODE_CLIENT_ID"]
-      client_secret     = module.onepassword_application["OpenCode"].fields["OPENCODE_CLIENT_SECRET"]
-      group             = "ai"
-      icon_url          = "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/png/opencode.png"
-      redirect_uri      = "https://opencode.${var.CLUSTER_DOMAIN}/oauth2/callback"
-      launch_url        = "https://opencode.${var.CLUSTER_DOMAIN}"
+      client_id     = module.onepassword_application["OpenCode"].fields["OPENCODE_CLIENT_ID"]
+      client_secret = module.onepassword_application["OpenCode"].fields["OPENCODE_CLIENT_SECRET"]
+      group         = "ai"
+      icon_url      = "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/png/opencode.png"
+      redirect_uri  = "https://opencode.${var.CLUSTER_DOMAIN}/oauth2/callback"
+      launch_url    = "https://opencode.${var.CLUSTER_DOMAIN}"
+      additional_redirect_uris = [
+        {
+          matching_mode     = "strict"
+          redirect_uri_type = "authorization"
+          url               = "https://generate.${var.CLUSTER_DOMAIN}/oauth2/callback"
+        }
+      ]
       property_mappings = local.default_property_mappings
     },
     Open-WebUI = {


### PR DESCRIPTION
Protect direct ComfyUI generation access before moving generate.jory.dev external. The OpenClaw image UI route now uses envoy-external with Envoy Authentik OIDC, and the existing OpenCode client allows the generate callback.

Validation:
- flate test hr openclaw --path ./kubernetes/clusters/main
- tofu fmt -check -diff terraform/authentik
- tofu validate