### PR TITLE
feat(llama-strix): add a second slot for concurrent image analysis

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-strix.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-strix.yaml
@@ -47,7 +47,7 @@ spec:
       operator: Exists
       effect: NoSchedule
   contextSize: 262144
-  parallelSlots: 1
+  parallelSlots: 2
   flashAttention: true
   jinja: true
   cacheTypeK: q8_0


### PR DESCRIPTION
Miso uses `llama-strix` as both her conversation model and her image model, so an image request queues behind whatever the conversation is decoding. A second slot removes that head-of-line block.

## The slot is nearly free

With `--kv-unified` the KV cache is one shared buffer sized by `n_ctx`, not per-slot allocations — `llama-kv-cache.cpp:82` sets `n_stream(unified ? 1 : n_seq_max)` and cells are `kv_size × n_stream`:

| mode | `n_ctx_seq` | `n_stream` | total cells |
|---|---|---|---|
| `--kv-unified` | `n_ctx` (262144) | 1 | 262144 |
| non-unified | `n_ctx / slots` | slots | 262144 |

So KV stays at 262144 either way and each slot still addresses the full window — confirmed live by `llama-strix-nemotron`, which logs `n_ctx_slot = 262144` at 2 slots. GTT on skirk is 73.5 of 124 GiB.

MTP splits across slots on the deployed build (b10603 / c060ca974): `common_speculative_init` takes `n_parallel`, and server-context notes "MTP supports splitting".

## What it does not fix

Prefill does not parallelise, so a deep prefill on either slot still stalls the other. The win is that image work starts prefill immediately instead of waiting out the conversation's decode.

Worth watching after rollout: `--cache-ram 4096` is already evicting prompt-cache entries of ~220 MiB every second or two at one slot, and two slots double the competing prompt streams. That cap was set deliberately for UMA headroom, so it is left alone here rather than bundled into this change.