### PR TITLE
feat(nemotron): drop to Q4_0 and enable MTP speculative decoding

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-strix-nemotron.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-strix-nemotron.yaml
@@ -6,9 +6,10 @@ metadata:
 spec:
   source: hf://ggml-org/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF
   files:
-    - NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Q8_0.gguf
+    - NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Q4_0.gguf
+    - mtp-NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Q4_0.gguf
   format: gguf
-  quantization: Q8_0
+  quantization: Q4_0
   hardware:
     accelerator: rocm
     gpu:
@@ -49,6 +50,11 @@ spec:
   jinja: true
   cacheTypeK: q8_0
   cacheTypeV: q8_0
+  speculativeDecoding:
+    type: draft-mtp
+    draftModel: mtp-NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Q4_0.gguf
+    nDraftMax: 3
+    pMin: 0.75
   batchSize: 6144
   uBatchSize: 2048
   resources:


### PR DESCRIPTION
`llama-strix-nemotron` was running with **no speculative decoding at all**, while `ggml-org/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF` — the repo it already pulls from — ships MTP drafter sidecars next to the main GGUF.

## Changes

| | before | after |
|---|---|---|
| weights | Q8_0, 31.28 GiB | Q4_0, 17.60 GiB |
| drafter | none | `mtp-…-Q4_0.gguf`, 1.08 GiB |
| spec decoding | none | `draft-mtp`, nDraftMax 3, pMin 0.75 |

Net saving is about **12.6 GiB of UMA** on skirk, which also buys headroom for llama-strix's second slot (#9365).

The drafter is listed in the Model's `files:` as well as in `draftModel:`. The CRD is explicit that `draftModel` "names a file already present in the target model's spec.files" — naming it only in `draftModel` would leave it undownloaded, the same trap that silently disabled vision when an mmproj was wired without a `files:` entry.

`nDraftMax`/`pMin` mirror what llama-strix already runs with MTP.

## Worth a look after rollout

Q4_0 is a legacy quant — `Q4_K_M` is generally better quality at a similar size, but ggml-org only publishes BF16/Q4_0/Q8_0 here, and taking Q4_K_M from bartowski or unsloth would mean sourcing the drafter from a different repo than the weights. Matching the official repo was the safer call, but this is a reviewer model, so if review quality drops noticeably that tradeoff is the first thing to revisit.