### PR TITLE
feat(nemotron): move to the unsloth UD-Q4_K_XL build

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-strix-nemotron.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-strix-nemotron.yaml
@@ -4,12 +4,11 @@ kind: Model
 metadata:
   name: llama-strix-nemotron
 spec:
-  source: hf://ggml-org/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF
+  source: hf://unsloth/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-GGUF
   files:
-    - NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Q4_0.gguf
-    - mtp-NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Q4_0.gguf
+    - NVIDIA-Nemotron-3.5-Lightning-30B-A3B-UD-Q4_K_XL.gguf
   format: gguf
-  quantization: Q4_0
+  quantization: UD-Q4_K_XL
   hardware:
     accelerator: rocm
     gpu:
@@ -52,7 +51,6 @@ spec:
   cacheTypeV: q8_0
   speculativeDecoding:
     type: draft-mtp
-    draftModel: mtp-NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Q4_0.gguf
     nDraftMax: 3
     pMin: 0.75
   batchSize: 6144


### PR DESCRIPTION
Follow-up to #9366. unsloth bakes the MTP block **into the main GGUF** instead of splitting it into a sidecar, so the drafter file and the `draftModel` wiring both disappear — the same arrangement as llama-strix's Native-MTP-Preserved build.

## Verified from the GGUF tensor tables

Read directly from the files rather than taken from the model cards, which describe the model family and not the conversion:

| file | tensors | `blk.52` MTP block |
|---|---:|---|
| unsloth UD-Q4_K_XL | 417 | all 16, incl. 4 `nextn.*` |
| ggml-org Q4_0 (main) | 401 | none |
| ggml-org mtp sidecar | 19 | all 16, plus re-shipped `token_embd`/`output`/`output_norm` |

Nothing in the sidecar's MTP block is missing from the unsloth file.

## Quant

Q4_0 is a legacy format with no imatrix calibration — a poor fit for a model whose entire job is review. UD-Q4_K_XL is imatrix-calibrated (`imatrix_unsloth.gguf`) and holds sensitive tensors at higher precision. This resolves the quality concern flagged in #9366.

## Footprint

| | weights | drafter | total |
|---|---:|---:|---:|
| Q8_0 (original) | 31.28 | — | 31.28 GiB |
| #9366 as merged | 17.60 | 1.08 | 18.68 GiB |
| this PR | 23.75 | — | **23.75 GiB** |

5.07 GiB more than #9366, still 7.53 GiB below where it started. GTT on skirk was 73.5 of 124 before any of this landed.

Also avoids pairing weights and drafter from different repos, which was the other option on the table.