### PR TITLE
fix(litellm): restore the moonshot extract for KIMI_CODE_API_KEY

### DIFF
--- a/kubernetes/apps/base/llm/litellm/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/litellm/externalsecret.yaml
@@ -27,6 +27,8 @@ spec:
     - extract:
         key: minimax
     - extract:
+        key: moonshot
+    - extract:
         key: neuralwatt
     - extract:
         key: opencode


### PR DESCRIPTION
Regression from #9364. Removing the drained Moonshot rungs also dropped `- extract: key: moonshot` from `dataFrom` — but that 1Password item supplies **`KIMI_CODE_API_KEY`** as well as `MOONSHOT_API_KEY`. Moonshot AI makes Kimi, so both keys live in the same item; I checked which template lines mentioned moonshot, not which keys the item fed.

The ExternalSecret has been `Ready=False / SecretSyncedError` since:

```
unable to mutate secret litellm: could not apply template:
unable to execute template at key KIMI_CODE_API_KEY:
map has no entry for key "KIMI_CODE_API_KEY"
```

## Impact

Nothing is broken right now — the last good sync predates the change, so the live secret still holds a valid `KIMI_CODE_API_KEY` and the Kimi Coding rungs keep working. But the secret is frozen: no rotation, and if it were ever deleted and recreated the key would come back missing, taking out `kimi-k2.7`, `kimi-k3` and `frontier-pool` rung 2 — which now have no PAYG rung beneath them since the Moonshot removal.

## Fix

Restores the extract. `MOONSHOT_API_KEY` stays out of the template, since nothing references it any more, so the 1Password item is read purely for the Kimi key.