### PR TITLE
fix(openclaw): add Nvidia context headroom

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -56,7 +56,7 @@ data:
             "litellm/chatgpt/gpt-5.6-luna": { alias: "gpt-cheap" },
           },
           contextPruning: { mode: "off" },
-          compaction: { mode: "default", timeoutSeconds: 600, reserveTokensFloor: 30000, memoryFlush: { enabled: true, softThresholdTokens: 80000, prompt: "Extract key decisions, state changes, lessons, blockers to memory/YYYY-MM-DD.md. Format: ## [HH:MM] Topic. Skip routine work. NO_FLUSH if nothing important.", systemPrompt: "Compacting session context. Extract only what's worth remembering. No fluff." },
+          compaction: { mode: "default", timeoutSeconds: 600, reserveTokensFloor: 40000, memoryFlush: { enabled: true, softThresholdTokens: 80000, prompt: "Extract key decisions, state changes, lessons, blockers to memory/YYYY-MM-DD.md. Format: ## [HH:MM] Topic. Skip routine work. NO_FLUSH if nothing important.", systemPrompt: "Compacting session context. Extract only what's worth remembering. No fluff." },
           },
           maxConcurrent: 4,
           subagents: {
@@ -282,6 +282,13 @@ data:
             subagent: { allowModelOverride: true, allowedModels: [ "litellm/llama-nvidia" ], },
             config: {
               contextThreshold: 0.75,
+              contextThresholdOverrides: [
+                {
+                  name: "llama-nvidia-safe",
+                  match: { model: "litellm/llama-nvidia" },
+                  contextThreshold: 0.55,
+                },
+              ],
               delegationTimeoutMs: 1000000,
               expansionModel: "litellm/llama-nvidia",
               freshTailCount: 64,


### PR DESCRIPTION
## Summary

- raise the embedded OpenClaw compaction reserve floor from 30,000 to 40,000 tokens
- compact `litellm/llama-nvidia` sessions at a 0.55 threshold while leaving other models at 0.75

## Why

The Nvidia backend has a smaller effective context window than the larger hosted models. OpenClaw's final system/tool prompt overhead can push Nvidia requests over the limit after LCM's global 0.75 threshold says the assembled conversation still fits. This tuning makes the Nvidia lane compact earlier and preserves more output headroom without changing model routing.

## Validation

- `git diff --check`
- ConfigMap parsed successfully with PyYAML
- Embedded `openclaw.json` assertions passed for `reserveTokensFloor: 40000` and the Nvidia `contextThresholdOverrides` rule
- `flate` was unavailable in the local environment, so cluster rendering tests were not run
