### PR TITLE
feat(test): add a misospace-scoped runner scale set for CI

### DIFF
--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/externalsecret.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name misospace-runner-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        github_token: "{{ .GITHUB_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: github-miso

--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/helmrelease.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/helmrelease.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name misospace-runner-${CLUSTER}
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gha-runner-scale-set-misospace
+  interval: 15m
+  dependsOn: []
+  values:
+    containerMode:
+      type: kubernetes
+      kubernetesModeWorkVolumeClaim:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: local-hostpath
+        resources:
+          requests:
+            storage: 25Gi
+    controllerServiceAccount:
+      name: actions-runner-controller
+      namespace: actions-runner-system
+    githubConfigSecret: misospace-runner-secret
+    githubConfigUrl: https://github.com/misospace
+    runnerScaleSetName: misospace-${CLUSTER}
+    maxRunners: ${misospaceMaxRunners:=2}
+    minRunners: ${misospaceMinRunners:=0}
+    template:
+      spec:
+        containers:
+          - name: runner
+            image: ghcr.io/joryirving/actions-runner:2.336.0@sha256:1495127fbb7e148fb288587d96f07305c7cc93f15b2dc43187cfe13f1a875eeb
+            command: ["/home/runner/run.sh"]
+            env:
+              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                value: "false"
+        serviceAccountName: *name

--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/kustomization.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/ocirepository.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gha-runner-scale-set-misospace
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.2
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set

--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/rbac.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/rbac.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: misospace-runner-${CLUSTER}
+---
+# Scoped deliberately: this runner serves an org whose repos are not this repo,
+# so it gets what an ephemeral PR environment needs and nothing else. The
+# home-ops runner is cluster-admin because it manages the cluster itself; this
+# one only stands up and tears down its own namespaces.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: misospace-runner-${CLUSTER}
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/exec", "services", "configmaps", "secrets", "persistentvolumeclaims", "serviceaccounts", "events"]
+    verbs: ["*"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "replicasets"]
+    verbs: ["*"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: misospace-runner-${CLUSTER}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: misospace-runner-${CLUSTER}
+subjects:
+  - kind: ServiceAccount
+    name: misospace-runner-${CLUSTER}
+    namespace: actions-runner-system

--- a/kubernetes/apps/test/actions-runner-system/actions-runner-controller.yaml
+++ b/kubernetes/apps/test/actions-runner-system/actions-runner-controller.yaml
@@ -34,3 +34,26 @@ spec:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: actions-runner-controller-runners-misospace
+spec:
+  dependsOn:
+    - name: actions-runner-controller
+    - name: democratic-csi
+      namespace: storage
+  interval: 1h
+  path: ./kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace
+  postBuild:
+    substitute:
+      misospaceMaxRunners: "2"
+      misospaceMinRunners: "0"
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system


### PR DESCRIPTION
## Summary
- Add a second GHA runner scale set scoped to the `misospace` org, referenced only from the test cluster.
- Scope its ServiceAccount to namespace lifecycle plus workloads, not `cluster-admin`.

## Why

Groundwork for per-PR smoke environments for the misospace apps. The plan is that
a PR workflow runs on this runner, creates a `pr-<n>` namespace on test, deploys
the app plus a throwaway Postgres from the PR's own tree, asserts, and deletes the
namespace. Nothing persistent, nothing on main, and no home-ops PR per app.

That is aimed at the failure this week: dispatch 0.5.41 shipped three regressions
that CI passed. The tightened CSP blocked the inline theme initialiser
(`layout.tsx:37`), the sync lock wedged on a stale row, and the groomer 500s on
its own validation. All three needed a running app to catch; none of them were
reachable by a unit test.

The existing scale set is `githubConfigUrl: joryirving/home-ops`, so misospace
repos cannot use it today.

## How

`runners/` is shared by all three clusters, so this adds a sibling
`runners-misospace/` rather than patching it. Only
`kubernetes/apps/test/actions-runner-system/` references the new path, so main and
utility are unchanged.

Reuses the existing `github-miso` 1Password item for `github_token`, so no new
secret material. Its own `OCIRepository` (same chart, same 0.14.2 tag) rather than
sharing the one in `runners/`, so the two Kustomizations stay independent.

`minRunners: 0` — this pool should cost nothing when no PR is open, unlike the
home-ops pool which keeps one warm.

## Notes

- **The token scope is the one thing I could not verify.** ARC needs org-level
  registration permission for `githubConfigUrl: https://github.com/misospace`. If
  `GITHUB_TOKEN` in `github-miso` is a fine-grained PAT without org scope, the
  listener will fail to register and the fallback is either a broader PAT or a
  GitHub App (the `MISO_APP_ID` app used by release-please would do). Worth
  checking the listener logs after the first reconcile rather than assuming.
- Deliberately not `cluster-admin`. The home-ops runner has it because it manages
  the cluster; this one only needs to create and tear down its own namespaces. If
  a future workflow needs more, widen it explicitly rather than inheriting
  everything.
- Capacity: citlali is one node at 3950m CPU / 32Gi with the existing pool at
  `maxRunners: 2`. This adds up to 2 more, so concurrent PR environments will
  queue rather than fan out. Fine at current PR volume.
- The CI litellm virtual key is deliberately not in this PR. It needs a
  `LiteLLMVirtualKey` on main plus a `PushSecret`/`ExternalSecret` hop to reach
  test, and it is only needed once a workflow actually grooms. Separate change.

## Verification
- `kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/test/actions-runner-system` renders all three Kustomizations including the new one.
- `grep -rn runners-misospace kubernetes/apps/main kubernetes/apps/utility` is empty.
- Not applied to any cluster.
