### PR TITLE
fix(foreman): point coder-frontier back at MiniMax for quota headroom

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -8,7 +8,7 @@ spec:
   provider: cloud-proxy
   providerConfig:
     baseURL: http://litellm.llm:4000/v1
-    model: reasoning-pool
+    model: MiniMax-M3-chat
     apiKeySecretRef:
       name: foreman-agent
       key: LITELLM_API_KEY


### PR DESCRIPTION
## Summary
- Point `coder-frontier` back at `MiniMax-M3-chat`, reverting the model half of #9303.

## Why

Quota. `reasoning-pool` fans out across four paid providers with real limits;
MiniMax is effectively unlimited on our plan. `coder-frontier` is the escalation
tier, so it is exactly the agent most likely to exhaust a quota, and an exhausted
pool takes the frontier lane down entirely.

#9303 moved it off the shim to stop a reasoning leak: `MiniMax-M3-chat` returns
its reasoning inline as `<think>…</think>` in `content`, and LiteLLM strips the
balanced pair only on non-streaming responses while the foreman agent is
SSE-only (`pkg/foreman/agent/oai/types.go:199`, `client.go:53`). That leak is
real and this reinstates it.

Trading it back deliberately: the leak is a degradation that ran unnoticed for
weeks, quota exhaustion is an outage. Availability wins.

## Notes

- The key scope keeps `reasoning-pool`. It is harmless, `alert-triage` also holds
  it, and leaving it means switching back is a one-line change rather than a
  scope edit plus a reconcile.
- This restores the state `coder-revision` has been in all along, so the leak is
  now consistent across both rather than fixed on one agent and not the other.
- The durable fix is upstream, not here. Either LiteLLM parses `<think>` blocks
  out of streaming deltas the way it already does for non-streaming, or the
  foreman agent tolerates them in its SSE handling. Worth filing against LLMKube
  alongside the existing Anthropic-endpoint request (#1627), since a native
  Anthropic client would sidestep the shim entirely.
- The MiniMax Anthropic surface remains unusable: a streaming tool-calling
  request through litellm returns HTTP 500 with zero SSE chunks, tested during
  #9303.

## Verification
- Values-only change. After reconcile, confirm `kubectl get agent -n llm coder-frontier -o jsonpath='{.spec.providerConfig.model}'` reads `MiniMax-M3-chat`.
- `MiniMax-M3-chat` is already in the `foreman` key scope (`coder-revision` uses it), so no key update is needed this time.
