### PR TITLE
fix(test): authenticate the misospace runner with the its-miso app

### DIFF
--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/externalsecret.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/externalsecret.yaml
@@ -12,7 +12,9 @@ spec:
     name: *name
     template:
       data:
-        github_token: "{{ .GITHUB_TOKEN }}"
+        github_app_id: "{{ .BOT_APP_ID }}"
+        github_app_installation_id: "{{ .BOT_MISOSPACE_INSTALL_ID }}"
+        github_app_private_key: "{{ .BOT_APP_PRIVATE_KEY }}"
   dataFrom:
     - extract:
         key: github-miso


### PR DESCRIPTION
## Summary
- Switch the misospace runner's `githubConfigSecret` from a PAT to the `its-miso` GitHub App.

## Why

The scale set installed cleanly in #9379 but never registered, so no listener and
no runners. The controller loops on:

```
POST https://api.github.com/orgs/misospace/actions/runners/registration-token
403 Forbidden: You must be an org admin or have the runners and runner groups
fine-grained permission.
```

`GITHUB_TOKEN` in `github-miso` is a fine-grained PAT without org runner
administration. Rather than widen it, this moves to the app: that token is shared
by dispatch, foreman and openclaw, none of which should gain the ability to
administer org runners.

Uses `BOT_APP_ID` (2781079, matches the `its-miso` app), `BOT_APP_PRIVATE_KEY`,
and `BOT_MISOSPACE_INSTALL_ID` (installation 124547748 on the misospace org).

## Notes

**This alone does not fix the 403.** The app also needs
**Organization permissions → Self-hosted runners: Read and write**. As of writing
the installation has `organization_runner_custom_images: write` and
`organization_administration: read`, neither of which mints a registration token,
so the same 403 will continue until that grant lands and is approved. Merge order
does not matter; ARC retries every few minutes and will self-heal once both are
in place.

Verify after merge with the installation permissions rather than the pod list,
since a missing grant looks identical to a slow reconcile:

```
gh api /orgs/misospace/installations \
  --jq '.installations[] | select(.app_slug=="its-miso") | .permissions'
```

Then `kubectl get autoscalingrunnerset -n actions-runner-system misospace-test`
should leave `CURRENT RUNNERS` blank no longer, and a `misospace-test-*-listener`
pod should appear.

## Verification
- `kubectl kustomize` on the directory renders the ExternalSecret with all three app fields.
- 1Password `github-miso` confirmed to carry `BOT_APP_ID`, `BOT_APP_PRIVATE_KEY`, `BOT_MISOSPACE_INSTALL_ID`.
- Not applied to any cluster.
