### PR TITLE
fix(test): scope the misospace runner to one namespace, not the cluster

### DIFF
--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/rbac.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/rbac.yaml
@@ -1,40 +1,10 @@
 ---
+# No ClusterRole. This ServiceAccount deliberately has no cluster-wide grants:
+# the misospace repos are public, so anything a job on this runner can reach is
+# reachable from an approved fork PR. Its only permissions come from a
+# namespaced RoleBinding in the misospace-ci namespace (see
+# kubernetes/apps/base/misospace-ci/rbac).
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: misospace-runner-${CLUSTER}
----
-# Scoped deliberately: this runner serves an org whose repos are not this repo,
-# so it gets what an ephemeral PR environment needs and nothing else. The
-# home-ops runner is cluster-admin because it manages the cluster itself; this
-# one only stands up and tears down its own namespaces.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: misospace-runner-${CLUSTER}
-rules:
-  - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["create", "delete", "get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["pods", "pods/log", "pods/exec", "services", "configmaps", "secrets", "persistentvolumeclaims", "serviceaccounts", "events"]
-    verbs: ["*"]
-  - apiGroups: ["apps"]
-    resources: ["deployments", "statefulsets", "replicasets"]
-    verbs: ["*"]
-  - apiGroups: ["batch"]
-    resources: ["jobs", "cronjobs"]
-    verbs: ["*"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: misospace-runner-${CLUSTER}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: misospace-runner-${CLUSTER}
-subjects:
-  - kind: ServiceAccount
-    name: misospace-runner-${CLUSTER}
-    namespace: actions-runner-system

--- a/kubernetes/apps/base/misospace-ci/rbac/kustomization.yaml
+++ b/kubernetes/apps/base/misospace-ci/rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml

--- a/kubernetes/apps/base/misospace-ci/rbac/rbac.yaml
+++ b/kubernetes/apps/base/misospace-ci/rbac/rbac.yaml
@@ -1,0 +1,34 @@
+---
+# Everything the misospace CI runner is allowed to do, scoped to this namespace
+# only. targetNamespace on the parent Flux Kustomization places these here, so
+# they carry no explicit namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: misospace-runner
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/exec", "services", "configmaps", "secrets", "persistentvolumeclaims", "serviceaccounts", "events"]
+    verbs: ["*"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "replicasets"]
+    verbs: ["*"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: misospace-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: misospace-runner
+subjects:
+  # The runner's ServiceAccount lives with the scale set, not here. A subject
+  # namespace is not rewritten by targetNamespace, so this crosses namespaces
+  # deliberately and is the only link between the two.
+  - kind: ServiceAccount
+    name: misospace-runner-${CLUSTER}
+    namespace: actions-runner-system

--- a/kubernetes/apps/test/misospace-ci/kustomization.yaml
+++ b/kubernetes/apps/test/misospace-ci/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: misospace-ci
+components:
+  - ../../../components/namespace
+replacements:
+  - path: ../../../components/replacements/ks.yaml
+resources:
+  - ./rbac.yaml

--- a/kubernetes/apps/test/misospace-ci/rbac.yaml
+++ b/kubernetes/apps/test/misospace-ci/rbac.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: misospace-ci-rbac
+spec:
+  dependsOn:
+    - name: actions-runner-controller-runners-misospace
+      namespace: actions-runner-system
+  interval: 1h
+  path: ./kubernetes/apps/base/misospace-ci/rbac
+  wait: true
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system


### PR DESCRIPTION
## Summary
- Drop the misospace runner's cluster-wide ClusterRole.
- Give it a namespaced `Role` in a new `misospace-ci` namespace instead.

## Why

#9379 gave that ServiceAccount a `ClusterRole` with `secrets: ["*"]` and
`pods/exec: ["*"]`, bound cluster-wide. That was too broad, and on this cluster
it is an escalation path rather than a theoretical one:

```
actions-runner-system/home-ops-runner-test    Talos ServiceAccount, roles: ["os:admin"]
kube-tools/tuppr-talosconfig                  talosconfig
```

A job on the misospace runner could read that secret directly, or `kubectl exec`
into the home-ops runner pod where it is mounted at `/var/run/secrets/talos.dev`,
and get node-level admin on citlali. Every misospace repo is public, so once the
runner group allows public repositories that reach is one approved fork PR away.

Worth being precise about why the workflow-level guard does not help: for
`pull_request` events the workflow file comes from the PR branch, so a fork
controls the `if: head.repo.full_name == github.repository` condition and can
remove it. The brakes are GitHub's first-time-contributor approval and the
absence of workflow secrets, and the second one is irrelevant here because the
runner's cluster access comes from its ServiceAccount, not from secrets.

## How

The ServiceAccount now has no cluster-wide grants at all. `misospace-ci` is a
normal namespace app following the repo convention (`components/namespace` plus
the `ks.yaml` replacement), and the `Role`/`RoleBinding` live in
`apps/base/misospace-ci/rbac` with no explicit namespace, so `targetNamespace`
places them there.

I originally tried a two-namespace pool with explicit `namespace:` fields on the
Roles. That silently does not work: the parent Flux Kustomization inherits
`targetNamespace: actions-runner-system` from the directory convention, which
rewrites `metadata.namespace` on every resource, so both Roles would have landed
in `actions-runner-system` and bound nothing useful. Hence one namespace, created
the way the repo creates namespaces.

## Notes

- **misospace/dispatch#844 needs a matching change.** Its smoke workflow creates
  `dispatch-pr-<n>` namespaces, which this runner can no longer do. It should
  deploy into `misospace-ci` with PR-suffixed resource names and clean up its own
  objects. That PR is not merged, so nothing breaks in the meantime.
- One namespace with `maxRunners: 2` means two concurrent jobs share it. Name
  resources per PR and rely on the workflow's `concurrency` group; if collisions
  turn out to matter, a second namespace is an additive change.
- The RoleBinding crosses namespaces on purpose: the subject's namespace is not
  rewritten by `targetNamespace`, so it is the single explicit link between the
  scale set and its playground.
- Still unaddressed by design: an approved fork PR runs arbitrary code on your
  hardware regardless of RBAC. The pod is the boundary. That is inherent to
  self-hosted runners on public repos and argues for a scoped runner group rather
  than allowing public repositories on `Default`.

## Verification
- `kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/test/misospace-ci` renders the Namespace and a Kustomization with `targetNamespace: misospace-ci`.
- `kubectl kustomize kubernetes/apps/base/misospace-ci/rbac` renders the Role and RoleBinding with no namespace of their own and the subject pointing at `actions-runner-system`.
- `grep -rn misospace-ci kubernetes/apps/main kubernetes/apps/utility` is empty.
- Not applied to any cluster.
