### PR TITLE
fix(test): enforce pod security on misospace-ci and drop its Flux token

### DIFF
--- a/kubernetes/apps/test/misospace-ci/kustomization.yaml
+++ b/kubernetes/apps/test/misospace-ci/kustomization.yaml
@@ -9,3 +9,64 @@ replacements:
   - path: ../../../components/replacements/ks.yaml
 resources:
   - ./rbac.yaml
+patches:
+  # Enforce Pod Security. Without this the runner's namespaced pods:["*"] is a
+  # node escape rather than a sandbox: a job can create a privileged pod with
+  # hostPath:/ and read every secret on the node off /var/lib/kubelet, which on
+  # this single-node cluster includes the home-ops runner's cluster-admin token
+  # and its Talos os:admin cert. Verified before this change with
+  # `kubectl apply --dry-run=server --as=…:misospace-runner-test`: the API
+  # server admitted exactly that pod.
+  #
+  # baseline (not restricted) is what gets enforced, because it rejects
+  # privileged/hostPath/hostPID/hostNetwork without requiring every CI manifest
+  # to carry a securityContext. warn+audit are set to restricted so the gap to
+  # the stricter level is visible before anyone tries to close it.
+  - target:
+      kind: Namespace
+    patch: |-
+      - op: add
+        path: /metadata/labels/pod-security.kubernetes.io~1enforce
+        value: baseline
+      - op: add
+        path: /metadata/labels/pod-security.kubernetes.io~1enforce-version
+        value: latest
+      - op: add
+        path: /metadata/labels/pod-security.kubernetes.io~1warn
+        value: restricted
+      - op: add
+        path: /metadata/labels/pod-security.kubernetes.io~1audit
+        value: restricted
+  # The shared namespace component ships a Flux github-status alert, which
+  # creates a GitHub token secret in every namespace that uses it. This
+  # namespace exists to run code from public repositories, and the runner has
+  # secrets:["*"] here, so that token would be readable by any CI job with no
+  # escape required. Drop the three resources rather than the whole component,
+  # which also supplies the namespace itself and the alertmanager alert.
+  - target:
+      kind: ExternalSecret
+      name: github-status-token
+    patch: |-
+      $patch: delete
+      apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      metadata:
+        name: github-status-token
+  - target:
+      kind: Provider
+      name: github-status
+    patch: |-
+      $patch: delete
+      apiVersion: notification.toolkit.fluxcd.io/v1beta3
+      kind: Provider
+      metadata:
+        name: github-status
+  - target:
+      kind: Alert
+      name: github-status
+    patch: |-
+      $patch: delete
+      apiVersion: notification.toolkit.fluxcd.io/v1beta3
+      kind: Alert
+      metadata:
+        name: github-status


### PR DESCRIPTION
## Summary
- Enforce Pod Security (`baseline`) on `misospace-ci`.
- Stop the shared namespace component creating a Flux GitHub token in that namespace.

## Why

#9383 scoped the misospace runner from a cluster-wide ClusterRole down to a
namespaced Role, and I treated that as sufficient. It is not. A security review
of the full blast radius found that namespace-scoped `pods: ["*"]` plus no
admission control is a node escape, not a sandbox.

Verified against the live cluster before this change, with a server-side dry run
as the runner's own ServiceAccount:

```
kubectl apply --dry-run=server -f privileged-hostpath-pod.yaml \
  --as=system:serviceaccount:actions-runner-system:misospace-runner-test
→ pod/escape-check created (server dry run)
```

That pod requested `privileged: true`, `hostPID: true`, `hostNetwork: true` and
`hostPath: /`. `misospace-ci` carried no `pod-security.kubernetes.io/*` labels,
there is no Kyverno/Gatekeeper/Kubewarden on the cluster, and no relevant
ValidatingAdmissionPolicy, so nothing rejected it.

citlali is a single control-plane node, so host filesystem access there means
reading every pod's secrets from `/var/lib/kubelet`. On that same node sit the
`home-ops-runner-test` ServiceAccount token (bound to `cluster-admin`) and its
Talos secret with `roles: ["os:admin"]`, plus the `its-miso` GitHub App private
key in `actions-runner-system`. That app has org-wide `contents: write`,
`workflows: write` and `organization_self_hosted_runners: write` across every
misospace repo.

None of that is reachable by RBAC — `can-i get secrets -n actions-runner-system`
is correctly `no`. It is reachable by bypassing the API entirely, which is what
a privileged hostPath pod does.

Second issue, unrelated to admission: `misospace-ci` contained
`github-status-token`, a Flux GitHub token, directly readable by the runner SA
with no escape needed. It arrived because I included the shared
`components/namespace`, which bundles the github-status alert. A namespace whose
purpose is running code from public repositories should not carry one.

## How

`enforce: baseline` rather than `restricted`, deliberately: baseline rejects
privileged, hostPath, hostPID and hostNetwork, which is what closes the escape,
without requiring every CI manifest to carry a full securityContext. `warn` and
`audit` are set to `restricted` so the distance to the stricter level stays
visible rather than being forgotten.

The three github-status resources are removed with targeted `$patch: delete`
rather than dropping the component, which also supplies the namespace itself and
the alertmanager alert. The shared component is untouched, so no other namespace
on any cluster changes.

## Notes

- **This is what actually gates allowing public repositories on the runner**, not
  the runner-group question. With it, a hostile job gets full control of one
  disposable namespace. Without it, it gets the node.
- Still true after this change, and not addressed here: no NetworkPolicy exists
  anywhere on the cluster, so a job pod has unrestricted egress to the flat
  `10.69.1.0/24` that also carries the production nodes, and to the internet.
  Production services are ClusterIP and not cross-cluster routable, so that is
  reconnaissance and exfiltration reach rather than automatic production
  compromise, but it is worth its own change.
- Also not addressed: no ResourceQuota or LimitRange on `misospace-ci`, so
  nothing stops a job exhausting the node it shares with the control plane.
- Structural, not fixable by config: a `cluster-admin` runner and public CI share
  one kernel on a single-node cluster. Pod Security contains the API-level
  escape; it does not separate the tenants.

## Verification
- `kubectl kustomize --load-restrictor=LoadRestrictionsNone kubernetes/apps/test/misospace-ci` renders the Namespace with all four PSA labels, keeps the alertmanager Alert and Provider, and no longer emits the github-status Alert, Provider or ExternalSecret.
- `git diff kubernetes/components/` is empty; only `apps/test/misospace-ci/kustomization.yaml` changed.
- Not applied to any cluster. **After merge, re-run the dry run above and confirm it is now denied** — that is the check that proves this worked, and a rendered label is not the same thing.
