### PR TITLE
fix(test): set fsGroup on the misospace runner so it can write its work dir

### DIFF
--- a/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/helmrelease.yaml
+++ b/kubernetes/apps/base/actions-runner-system/actions-runner-controller/runners-misospace/helmrelease.yaml
@@ -29,6 +29,13 @@ spec:
     minRunners: ${misospaceMinRunners:=0}
     template:
       spec:
+        # Required for containerMode: kubernetes. The kubelet chowns the work
+        # volume to this group, and without it the PVC stays root-owned and the
+        # runner (uid 1001) dies with "Fail to create and validate runner's work
+        # directory '/home/runner/_work'". The home-ops scale set gets this from
+        # the chart default; supplying our own template.spec suppressed it.
+        securityContext:
+          fsGroup: 123
         containers:
           - name: runner
             image: ghcr.io/joryirving/actions-runner:2.336.0@sha256:1495127fbb7e148fb288587d96f07305c7cc93f15b2dc43187cfe13f1a875eeb


### PR DESCRIPTION
## Summary
- Set `template.spec.securityContext.fsGroup: 123` on the misospace runner scale set.

## Why

With the runner group now allowing public repositories, GitHub started assigning
jobs and runner pods finally spawned. They immediately die:

```
System.IO.IOException: Permission denied
WRITE ERROR: Fail to create and validate runner's work directory '/home/runner/_work'.
Runner listener exit with terminated error, stop the service, no retry needed.
```

`containerMode: kubernetes` mounts a PVC at the runner's work directory. Without
`fsGroup` the kubelet does not chown it, so the volume stays root-owned and the
runner process (uid 1001) cannot write to it. ARC documents `fsGroup: 123` as
required for Kubernetes container mode.

The working `home-ops-runner-test` pod has `podSecurityContext: {"fsGroup": 123}`;
the misospace pods had `{}`. Neither HelmRelease sets it, so the chart supplies it
by default for Kubernetes mode and supplying our own `template.spec` suppressed
that default. Setting it explicitly is both the fix and the clearer statement of
intent, since the next person reading this file should not have to know about a
conditional chart default.

Not a Pod Security consequence, despite the timing: runner pods live in
`actions-runner-system`, which carries no PSA labels. Only `misospace-ci` was
labelled in #9384.

## Verification
- `kubectl kustomize` on the directory renders `securityContext: {fsGroup: 123}` in the runner pod template.
- After reconcile, a runner pod should reach `Running` instead of erroring, and the queued `PR Smoke` job on misospace/dispatch#844 should be picked up.
- Not applied to any cluster.
