### PR TITLE
feat(llama-strix): move to the unsloth UD-Q4_K_XL build and re-cap the prompt cache

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-strix.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-strix.yaml
@@ -4,13 +4,13 @@ kind: Model
 metadata:
   name: llama-strix
 spec:
-  source: hf://SC117/Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-APEX-GGUF
+  source: hf://unsloth/Qwen3.6-35B-A3B-MTP-GGUF
   files:
-    - Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-APEX-I-Balanced.gguf
-    - mmproj-Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-APEX-F16.gguf
-  mmproj: mmproj-Qwen3.6-35B-A3B-uncensored-heretic-Native-MTP-Preserved-APEX-F16.gguf
+    - Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf
+    - mmproj-F16.gguf
+  mmproj: mmproj-F16.gguf
   format: gguf
-  quantization: I-Balanced
+  quantization: UD-Q4_K_XL
   hardware:
     accelerator: rocm
     gpu:
@@ -79,6 +79,8 @@ spec:
     - --spec-draft-type-v
     - q8_0
     - --cache-prompt
+    - --cache-ram
+    - "4096"
     - --kv-unified
     - --checkpoint-min-step
     - "32768"


### PR DESCRIPTION
The abliterated heretic build is no longer needed, so this moves llama-strix to unsloth's imatrix-calibrated UD quant and puts a bound back on the prompt cache.

## Weights

| | current | new |
|---|---:|---:|
| `...heretic-...-APEX-I-Balanced.gguf` | 24.18 GiB | — |
| `Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf` | — | 21.28 GiB |

**2.90 GiB saved**, measured from the files rather than estimated, and UD is imatrix-calibrated where I-Balanced is not.

## It has to be the MTP repo

unsloth publishes two separate repos, and only one keeps the speculative-decoding head. Verified by reading the GGUF tensor tables:

| repo | tensors | blocks | `nextn` |
|---|---:|---:|---:|
| `Qwen3.6-35B-A3B-MTP-GGUF` | 753 | 41 | **4** |
| `Qwen3.6-35B-A3B-GGUF` | 733 | 40 | 0 |

Using the plain repo would leave `--spec-type draft-mtp` silently inert — no error, just no speculation.

`mmproj-F16.gguf` (0.84 GiB, same as the current projector) is listed in `files:` **and** `mmproj:`. Naming it only in `mmproj:` never downloads it and kills vision silently, which matters here because llama-strix is Openclaw's image primary.

## Prompt cache

Dropping `--cache-ram` put llama-strix on llama.cpp's 8192 MiB default. Measured against `/proc/1/fdinfo`, the pod sits at 31.88 GiB total — 24.18 weights + 0.84 mmproj + ~2.66 KV leaves ~4.2 GiB of cache and compute buffers, i.e. the cache was about half way into a budget it would have kept filling. Restoring `4096` bounds that.

## Context left alone

I had suggested cutting `contextSize`, on arithmetic that assumed 40 attention layers. Qwen3.6-35B-A3B is a hybrid — `full_attention_interval: 4`, so only 10 layers carry KV, and the metadata also exposes `ssm.*` keys. Actual KV at 262 k is ~2.66 GiB, not the ~10.6 I estimated, so cutting to 164 k would have saved about 1 GiB for 98 k of lost headroom. Not worth it; `contextSize` stays at 262144.