### PR TITLE
fix(memini): unstick importance scoring and widen dedup

### DIFF
--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -30,12 +30,12 @@ spec:
               MEMINI_RECALL_EMBED_TIMEOUT: 5s
               MEMINI_WRITE_DEDUP_SCORE: "0.80"
               MEMINI_WRITE_DEDUP_ACTION: coalesce
-              MEMINI_DEDUP_TIERS: episodic
+              MEMINI_DEDUP_TIERS: episodic,semantic,procedural
               MEMINI_DEDUP_SIMILARITY: 0.80
               MEMINI_SHORT_TERM_CAP: 300
-              MEMINI_ASSESS_BATCH: "5"
+              MEMINI_ASSESS_BATCH: "1"
               MEMINI_LLM_BASE_URL: http://litellm.llm:4000/v1
-              MEMINI_LLM_MODEL: memini-summary
+              MEMINI_LLM_MODEL: llama-strix
               MEMINI_REEMBED_ON_MODEL_CHANGE: true
               MEMINI_RERANK: http://litellm.llm:4000/v1
               MEMINI_RERANK_MODEL: rerank

--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
               MEMINI_DEDUP_TIERS: episodic,semantic,procedural
               MEMINI_DEDUP_SIMILARITY: 0.80
               MEMINI_SHORT_TERM_CAP: 300
-              MEMINI_ASSESS_BATCH: "1"
+              MEMINI_ASSESS_BATCH: "3"
               MEMINI_LLM_BASE_URL: http://litellm.llm:4000/v1
               MEMINI_LLM_MODEL: llama-strix
               MEMINI_REEMBED_ON_MODEL_CHANGE: true


### PR DESCRIPTION
## Importance scoring is stuck

The hourly pass fails every run with the identical error:

```
importance assessment: LLM unavailable, deferring
  error: llm: got 4 importance scores for 5 memories
```

21 occurrences in 24h, same mismatch each time. memini rejects the whole batch rather than applying the 4 scores it got, so those memories are never scored. The backlog is visible in the data — unscored memories per day in `openclaw/main`:

```
08-22    2 of 133
08-23   41 of 150
08-24   34 of 182
08-25   58 of 167
```

**522 of 1434** memories in that namespace have no `assessed_importance`, which degrades retrieval ranking as the fraction climbs.

`MEMINI_ASSESS_BATCH: 5 -> 3` — small enough that miscounting is unlikely, and a third of the calls a batch of 1 would cost.
`MEMINI_LLM_MODEL: memini-summary -> llama-strix` — memini-summary is Qwen3.5-4B at Q4, and emitting exactly N scores for N items is the kind of counting task a 4B fails.

**Stays local.** memini holds conversation memory; none of it should reach a cloud provider. `llama-strix` is already in memini's virtual-key scope, so no key change is needed.

## Dedup was scoped to one tier

`MEMINI_DEDUP_TIERS: episodic` only. But the growth is in `semantic/deduced` (374 rows since 08-21) and `procedural/deduced` (163), neither of which was deduped — which is why nine duplicate fingerprint groups survived in `openclaw/main`.

Now `episodic,semantic,procedural`.

## What this does not fix

The root cause of the volume is a **message refire loop in openclaw**, not memini. `openclaw/main` went from ~1-9 memories/day to ~170/day on 08-21, and the memories narrate it themselves — *"your message looped twice"*, *"seventh in a row"*, *"that message looped ~15 times — executed exactly once"*. Messages queue from two sources (`source=dispatch` and `source=replyResolver`) into the same session lane, and sessions transition `prev=processing new=processing reason="run_started"`. That needs tracing separately.

## Run-time cost

The scoring model answers slowly, so batch size drives how long each hourly pass occupies it:

| model | p50 | calls/run | time per run |
|---|---:|---:|---:|
| `llama-strix` | 45.5s | 67 | **~51 min** |
| `llama-strix-nemotron` | 6.8s | 67 | ~8 min |

At `max_per_run: 200` the 1,651-memory backlog clears in about 8 hourly runs either way — but on llama-strix that means roughly **51 minutes of near-continuous load per hour** on the busiest local model, which also has `waitForIdle: true` and a rollout (#9398) currently deferred waiting for its slots to idle.