### PR TITLE
fix(llama-vision): disable the prompt cache

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-vision.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-vision.yaml
@@ -64,6 +64,8 @@ spec:
     - --alias
     - llama-vision
     - --cont-batching
+    - --cache-ram
+    - "0"
     # MiniCPM-V 4.5 uses its model-defined 448px slicing and 64-token
     # resampler; --image-min/max-tokens target other vision families.
     - --reasoning


### PR DESCRIPTION
`llama-vision` set neither `--cache-prompt` nor `--cache-ram`, so it inherited llama.cpp's default budget:

```c
// common/common.h:616
int32_t cache_ram_mib = 8192;  // -1 = no limit, 0 - disable, 1 = 1 MiB, etc.
```

`--cache-ram 0` disables it, matching `memini-embed`, `memini-rerank` and `toolhive-embed`, which are already set that way for the same reason.

## Why the cache earns nothing here

Almost every vision request carries a different image, so prompt prefixes do not repeat and hit rate is near zero. The pod agrees — **zero** `making room for prompt cache entry` evictions logged, against llama-strix which was evicting 200-500 MiB entries every couple of seconds.

## Expected saving

Honest answer: **nothing immediately, up to 8 GiB eventually.** `cache-ram` is a ceiling that fills on demand, not a preallocation — llama-vision currently measures 11.33 GiB of GTT against roughly 9 GiB of weights, so the cache has barely grown. This prevents it claiming up to 8 GiB more as traffic arrives, on a box already at 100% GPU with strix and nemotron.

Same class of change as re-capping llama-strix, where the cache had reached about half its 8 GiB budget before being bounded.