### PR TITLE
fix(nemotron): drop context to 200k

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-strix-nemotron.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-strix-nemotron.yaml
@@ -43,7 +43,7 @@ spec:
     - key: llm-workload
       operator: Exists
       effect: NoSchedule
-  contextSize: 262144
+  contextSize: 200000
   parallelSlots: 2
   flashAttention: true
   jinja: true

--- a/kubernetes/apps/base/llm/opencode/configmap.yaml
+++ b/kubernetes/apps/base/llm/opencode/configmap.yaml
@@ -101,7 +101,7 @@ data:
           "models": {
             "llama-strix": { "name": "Qwen3.6-35B-A3B heretic (Strix)", "limit": { "context": 262144, "output": 20480 } },
             "llama-nvidia": { "name": "Qwen3.8-27B (3090)", "limit": { "context": 140000, "output": 40960 } },
-            "llama-strix-nemotron": { "name": "Nemotron 3.5 Lightning 30B-A3B (Strix)", "limit": { "context": 262144, "output": 20480 } },
+            "llama-strix-nemotron": { "name": "Nemotron 3.5 Lightning 30B-A3B (Strix)", "limit": { "context": 200000, "output": 20480 } },
             "kimi-k2.7": { "name": "Kimi K2.7 Code", "limit": { "context": 262144, "output": 32768 } },
             "kimi-k3": { "name": "Kimi K3", "limit": { "context": 1048576, "output": 131072 } },
             "dsv4f": { "name": "DeepSeek V4 Flash", "limit": { "context": 1000000, "output": 16384 } },


### PR DESCRIPTION
`contextSize: 262144 -> 200000` on the InferenceService, and the matching `context` in the cluster opencode catalog.

Sized from what it actually serves — across 5,741 accounted requests in the litellm spend logs:

| p50 | p95 | p99 | max |
|---:|---:|---:|---:|
| 8,363 | 19,729 | 37,875 | **80,013** |

200k leaves 2.5x headroom over the all-time maximum.

The service runs `--kv-unified`, so total KV is `n_ctx` regardless of slot count — this takes it from roughly **0.80 GiB to 0.61 GiB**. Small, as discussed, but skirk is tight enough that it is being taken deliberately.

Client-side catalogs follow in dotfiles.