### PR TITLE
fix(llama-nvidia): restore preserve_thinking

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
@@ -95,7 +95,7 @@ spec:
     - "12"
     - --mmap
     - --chat-template-kwargs
-    - '{"reasoning_effort":"medium"}'
+    - '{"reasoning_effort":"medium","preserve_thinking":true}'
     - --n-predict
     - "40960"
   endpoint:


### PR DESCRIPTION
```
'{"reasoning_effort":"medium"}'  ->  '{"reasoning_effort":"medium","preserve_thinking":true}'
```

`a8d8a6634` **replaced** `preserve_thinking` with `reasoning_effort` when it only needed to add it — `--chat-template-kwargs` takes both keys. `llama-strix` has carried `preserve_thinking` throughout, so the asymmetry reads as unintended rather than deliberate.

Qwen3.8's card describes it as how reasoning context from historical messages is retained, which matters for the long multi-turn sessions Miso runs on this model.

## Honest scope

This is **not** established as the cause of the perceived message-repetition. The timeline argues against it being the trigger:

```
preserve_thinking removed:  2026-08-14 20:39
first loop report:          2026-08-25 14:43     <- 11 days later
```

and every loop report falls inside a single ~86-minute window today, not a persistent condition since mid-August.

The likelier proximate cause is compaction — `lossless-claw` runs `contextThreshold: 0.75` with an override dropping it to **0.55 for llama-nvidia specifically**, so a long session compacts early and the model loses sight of what it already handled. Missing `preserve_thinking` would aggravate that by stripping its own reasoning too, but it does not explain the timing on its own.

Worth doing regardless; just should not be read as the fix.