### PR TITLE
feat(llm): compaction on nvidia-chat, memini scoring back on strix-chat

### DIFF
--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
               MEMINI_SHORT_TERM_CAP: 300
               MEMINI_ASSESS_BATCH: "5"
               MEMINI_LLM_BASE_URL: http://litellm.llm:4000/v1
-              MEMINI_LLM_MODEL: llama-nvidia-chat
+              MEMINI_LLM_MODEL: llama-strix-chat
               MEMINI_REEMBED_ON_MODEL_CHANGE: true
               MEMINI_RERANK: http://litellm.llm:4000/v1
               MEMINI_RERANK_MODEL: rerank

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -270,8 +270,8 @@ data:
           "admin-http-rpc": { enabled: true },
           "lossless-claw": {
             enabled: true,
-            llm: { allowModelOverride: true, allowedModels: [ "litellm/llama-nvidia" ], },
-            subagent: { allowModelOverride: true, allowedModels: [ "litellm/llama-nvidia" ], },
+            llm: { allowModelOverride: true, allowedModels: [ "litellm/llama-nvidia-chat" ], },
+            subagent: { allowModelOverride: true, allowedModels: [ "litellm/llama-nvidia-chat" ], },
             config: {
               contextThreshold: 0.75,
               contextThresholdOverrides: [
@@ -282,7 +282,7 @@ data:
                 },
               ],
               delegationTimeoutMs: 1000000,
-              expansionModel: "litellm/llama-nvidia",
+              expansionModel: "litellm/llama-nvidia-chat",
               freshTailCount: 64,
               freshTailMaxTokens: 24000,
               ignoreSessionPatterns: [
@@ -298,7 +298,7 @@ data:
               pruneHeartbeatOk: true,
               skipStatelessSessions: true,
               statelessSessionPatterns: [ "agent:*:subagent:**" ],
-              summaryModel: "litellm/llama-nvidia",
+              summaryModel: "litellm/llama-nvidia-chat",
               summaryTimeoutMs: 1000000,
               sweepDeadlineMs: 300000,
               compactUntilUnderDeadlineMs: 600000,


### PR DESCRIPTION
Moves lossless-claw's four **call sites** from `llama-nvidia` to `llama-nvidia-chat`. Same server, same weights, same KV cache — only the sampler differs.

| line | setting | task |
|---|---|---|
| 273 | `llm.allowedModels` | the compaction LLM |
| 274 | `subagent.allowedModels` | delegated compaction |
| 285 | `expansionModel` | re-expanding compacted spans |
| 301 | `summaryModel` | summarising leaf chunks |

## Why

Summarising a `leafChunkTokens: 20000` chunk and re-expanding it are mechanical text transforms — the reasoning is thrown away, only the transformed text is kept. Measured against this exact server:

```
reasoning_effort=low    reasoning_chars=72   completion_tokens=22
reasoning_effort=none   reasoning_chars=0    completion_tokens=2
```

There is a second effect specific to compaction: **thinking tokens come out of the same output allowance the summary needs.** That is presumably why this model already carries a `contextThreshold` override of 0.55 against the 0.75 default — it is short of room. Non-thinking gives the whole budget to actual summary.

## What is deliberately unchanged

```yaml
match: { model: "litellm/llama-nvidia" }   # line 280 — selector, not a call
```

That decides **which sessions** get the 0.55 threshold, and Miso runs on `llama-nvidia`. Changing it would silently revert her to 0.75. Worth remembering the inverse too: if Miso ever moves to `llama-nvidia-chat`, this override stops matching and needs updating.

## memini back to strix

`MEMINI_LLM_MODEL: llama-nvidia-chat -> llama-strix-chat`

memini was moved to nvidia to escape llama-strix'''s 93s p50, which was not merely slow — it was exceeding memini'''s timeout outright (`distill batch ... context deadline exceeded`, no pass completing in 85 minutes).

Most of that latency was reasoning overhead. Measured on that server:

```
llama-strix  reasoning_effort=low    reasoning_chars=564   completion_tokens=157
llama-strix  reasoning_effort=none   reasoning_chars=0     completion_tokens=2
```

So `llama-strix-chat` should be viable where plain `llama-strix` was not — and it hands the 3090 back to Miso and to lossless-claw'''s compaction, which moves onto `nvidia-chat` in this same change. The two halves are complementary rather than coincidental.

`llama-strix-chat` is already in memini'''s virtual-key scope.

**To verify after rollout:** the pass logs `"assessed memory importance","assessed":200`. Time from the burst starting to that line is the pass duration — on nvidia-chat it was about 3 minutes.