### PR TITLE
fix(llm): namespace audit findings

### DIFF
--- a/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
               HIP_VISIBLE_DEVICES: "0"
               ROCR_VISIBLE_DEVICES: "0"
               PYTORCH_HIP_ALLOC_CONF: "max_split_size_mb:256,garbage_collection_threshold:0.6"
-              CLI_ARGS: "--listen 0.0.0.0 --port 8188 --use-pytorch-cross-attention --disable-mmap --reserve-vram 90"
+              CLI_ARGS: "--listen 0.0.0.0 --port 8188 --use-pytorch-cross-attention --disable-mmap --reserve-vram 90 --highvram"
             # No resources block on purpose: BestEffort QoS makes comfyui the
             # first pod the Talos OOM manager kills (ranking weight 1.0) and the
             # first kubelet evicts under MemoryPressure on the shared UMA node.

--- a/kubernetes/apps/base/llm/litellm/llama-reviewer.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-reviewer.yaml
@@ -73,7 +73,7 @@ spec:
     - --cont-batching
     - --cache-prompt
     - --cache-ram
-    - "4096"
+    - "0"
     - --kv-unified
     - --checkpoint-min-step
     - "32768"

--- a/kubernetes/apps/base/llm/litellm/llama-reviewer.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-reviewer.yaml
@@ -73,7 +73,7 @@ spec:
     - --cont-batching
     - --cache-prompt
     - --cache-ram
-    - "0"
+    - "4096"
     - --kv-unified
     - --checkpoint-min-step
     - "32768"

--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/dispatch-mcp/mcpserver.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/dispatch-mcp/mcpserver.yaml
@@ -3,7 +3,7 @@
 apiVersion: toolhive.stacklok.dev/v1alpha1
 kind: MCPServer
 metadata:
-  name: dispatch
+  name: dispatch-mcp
 spec:
   image: ghcr.io/misospace/dispatch-mcp:sha-e4eaba8@sha256:11fee95712142758e1ff4c608ff0c7104ab391926fec5f96e8ea6ec63a8b1bed
   transport: stdio

--- a/kubernetes/apps/base/observability/prometheus-adapter/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/prometheus-adapter/helmrelease.yaml
@@ -9,6 +9,8 @@ spec:
     kind: OCIRepository
     name: prometheus-adapter
   interval: 1h
+  driftDetection:
+    mode: enabled
   values:
     prometheus:
       url: http://prometheus-operated.observability.svc.cluster.local


### PR DESCRIPTION
Two config fixes from a namespace audit. Both are long-standing and unrelated to this week's model work.

## 1. `MCPServer/dispatch` has never started (Pending since 2026-08-21)

toolhive derives its Deployment name from the MCPServer name, so an MCPServer called `dispatch` tries to own a Deployment called `dispatch` — which already exists as the Helm-managed dispatch app. Selectors differ, `spec.selector` is immutable, and the operator has failed the same reconcile every ~17 minutes since:

```
Deployment.apps "dispatch" is invalid: spec.selector: Invalid value:
{"matchLabels":{"app":"mcpserver",...,"toolhive-name":"dispatch"}}: field is immutable
```

Renamed to `dispatch-mcp`, matching its directory and the other servers (`ha-mcp`, `seerr-mcp`, `talos-mcp`).

**Verified safe before changing:** the app Deployment carries **no ownerReferences** — toolhive never adopted it, because reconcile always failed first — so removing the old MCPServer cannot cascade into the running app. The old MCPServer owns only `Service/mcp-dispatch-proxy`, recreated under the new name, and nothing references it: vmcp discovers backends via `groupRef: mcp-tools`.

Downstream, this also silences ~720 lines per 6h of `backend remains unhealthy: dispatch` in vmcp.

## 2. Four HPAs cluster-wide are inert — the external metrics APIService is missing

`APIService/v1beta1.external.metrics.k8s.io` does not exist, so no external metric resolves and every HPA targeting one has been logging `FailedGetExternalMetric` every 15 seconds:

```
llm/miso-gallery        downloads/bazarr
downloads/brrpolice     downloads/metube
```

This is **not** a missing component. prometheus-adapter is deployed and Ready, its `rules.external` block is correct, the metric exists (`probe_success{job="nfs_probe"}` = 1), and rendering chart 5.3.0 with the deployed values produces the APIService. Helm's stored release still contains it — the object was installed and later deleted, and nothing put it back because the HelmRelease has no drift detection and only reconciles hourly against its source.

`driftDetection.mode: enabled` lets Flux notice the missing resource and restore it.

## Audit findings deliberately not actioned here

- **vmcp panics on empty embedding vectors** (`cosine.go:17`, index out of range) — already fixed upstream in `fe39aecfa`, unreleased. We run v0.44.0, cut one day before the fix. Awaiting a release rather than mitigating locally; the only local option was a second `toolhive-embed` replica, which is GPU-pinned to skirk and would cost ~1.9 GiB on the most contended node.
- **litellm `_pre_call_checks: failed to count tokens`** (~450 in 2h) — known upstream bug [BerriAI/litellm#35626](https://github.com/BerriAI/litellm/issues/35626), open, present in v1.98.0. Correlates one-for-one with embedding requests. Benign here: the request still succeeds and only context-window filtering is skipped, and every deployment in both multi-deployment pools has ~1M context.
- **memini plugin command registration** — `memini:status` and `memini:namespace` are rejected by openclaw's name validator (colon). Reported as [eleboucher/memini#82](https://github.com/eleboucher/memini/issues/82). No functional impact; the `memory_*` tools are unaffected.