### PR TITLE
feat(forgejo): add internal code hosting

### DIFF
--- a/kubernetes/apps/base/self-hosted/forgejo/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/forgejo/helmrelease.yaml
@@ -1,0 +1,68 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: forgejo
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: forgejo
+  interval: 30m
+  dependsOn: []
+  values:
+    gitea:
+      admin:
+        passwordMode: initialOnlyRequireReset
+        username: forgejo_admin
+      config:
+        indexer:
+          REPO_INDEXER_ENABLED: true
+        mailer:
+          ENABLED: false
+        openid:
+          ENABLE_OPENID_SIGNIN: false
+          ENABLE_OPENID_SIGNUP: false
+        repository:
+          DEFAULT_REPO_UNITS: repo.code,repo.releases,repo.issues,repo.pulls
+          DISABLED_REPO_UNITS: repo.ext_wiki,repo.ext_issues
+          ROOT: /data/git/repositories
+        security:
+          REVERSE_PROXY_TRUSTED_PROXIES: 10.42.0.0/16
+        server:
+          DOMAIN: forgejo.jory.dev
+          PROTOCOL: http
+          ROOT_URL: https://forgejo.jory.dev
+          SSH_DOMAIN: forgejo-ssh.self-hosted.svc.cluster.local
+          SSH_LISTEN_PORT: 2222
+          SSH_PORT: 22
+          START_SSH_SERVER: true
+        service:
+          DEFAULT_ENABLE_TIMETRACKING: false
+          DISABLE_REGISTRATION: true
+          ENABLE_NOTIFY_MAIL: false
+          REQUIRE_SIGNIN_VIEW: true
+          SHOW_REGISTRATION_BUTTON: false
+    httpRoute:
+      enabled: false
+    image:
+      digest: sha256:1131f4c646d6115577b7cb9ccfe8cd2c289bb54a1e1ed42400be0e22916af924
+      registry: code.forgejo.org
+      repository: forgejo/forgejo
+      rootless: true
+      tag: 15.0.7-rootless
+    persistence:
+      claimName: forgejo
+      create: false
+      enabled: true
+    resources:
+      limits:
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    service:
+      ssh:
+        port: 22
+    tcpRoute:
+      enabled: false

--- a/kubernetes/apps/base/self-hosted/forgejo/httproute.yaml
+++ b/kubernetes/apps/base/self-hosted/forgejo/httproute.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: forgejo
+spec:
+  hostnames:
+    - forgejo.jory.dev
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: forgejo-http
+          port: 3000
+      timeouts:
+        request: 300s

--- a/kubernetes/apps/base/self-hosted/forgejo/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/forgejo/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/self-hosted/forgejo/kustomization.yaml
+++ b/kubernetes/apps/base/self-hosted/forgejo/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./helmrelease.yaml
   - ./httproute.yaml
   - ./ocirepository.yaml
+  - ./pushsecret.yaml

--- a/kubernetes/apps/base/self-hosted/forgejo/ocirepository.yaml
+++ b/kubernetes/apps/base/self-hosted/forgejo/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: forgejo
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 17.1.5
+  url: oci://code.forgejo.org/forgejo-helm/forgejo

--- a/kubernetes/apps/base/self-hosted/forgejo/pushsecret.yaml
+++ b/kubernetes/apps/base/self-hosted/forgejo/pushsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/pushsecret_v1alpha1.json
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: forgejo-admin
+spec:
+  data:
+    - match:
+        secretKey: username
+        remoteRef:
+          remoteKey: forgejo
+          property: username
+    - match:
+        secretKey: password
+        remoteRef:
+          remoteKey: forgejo
+          property: password
+  refreshInterval: 1h
+  secretStoreRefs:
+    - kind: ClusterSecretStore
+      name: onepassword
+  selector:
+    secret:
+      name: forgejo-admin

--- a/kubernetes/apps/main/self-hosted/forgejo.yaml
+++ b/kubernetes/apps/main/self-hosted/forgejo.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app forgejo
+spec:
+  components:
+    - ../../../../components/kopiur/backup
+  interval: 1h
+  path: ./kubernetes/apps/base/self-hosted/forgejo
+  postBuild:
+    substitute:
+      APP: *app
+      KOPIUR_CAPACITY: 50Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/main/self-hosted/kustomization.yaml
+++ b/kubernetes/apps/main/self-hosted/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./archiveteam.yaml
   - ./atuin.yaml
   - ./bentopdf.yaml
+  - ./forgejo.yaml
   - ./manyfold.yaml
   - ./paperless.yaml
   - ./picoshare.yaml


### PR DESCRIPTION
Adds a private Forgejo instance in the main cluster's self-hosted namespace, reachable only through envoy-internal and the in-cluster SSH service. Its 50Gi Ceph-backed PVC is covered by the existing Kopiur snapshot/restore flow to the NFS-backed volsync repository.