### PR TITLE
fix(dispatch-mcp): give it a writable /tmp

### DIFF
--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/dispatch-mcp/mcpserver.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/dispatch-mcp/mcpserver.yaml
@@ -22,5 +22,15 @@ spec:
       memory: 128Mi
     limits:
       memory: 512Mi
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
   groupRef:
     name: mcp-tools


### PR DESCRIPTION
Follow-on from #9429. With the MCPServer name collision resolved, the server reconciles and starts for the first time — and immediately hits the next problem:

```
ENOENT, syscall: 'mkdir', path: '/tmp/tsx-1000'
Node.js v24.19.0
```

toolhive runs MCP servers with `readOnlyRootFilesystem: true`, and this image is Node running `tsx`, which needs to create a scratch dir under `/tmp`. The Go-based servers (talos-mcp, flux-mcp) never noticed.

**`arr-mcp` already carries this exact pattern** for the same reason — it runs node via `npx` — so this copies it rather than inventing anything:

```yaml
podTemplateSpec:
  spec:
    containers:
      - name: mcp
        volumeMounts:
          - name: tmp
            mountPath: /tmp
    volumes:
      - name: tmp
        emptyDir: {}
```

This bug was always there; it was simply unreachable while the operator was failing earlier in reconcile. `spec.volumes` on the CRD only supports hostPath, so `podTemplateSpec` is the right place for an emptyDir.