### PR TITLE
fix(bootstrap): point helmfile hooks at the cluster overlay and base paths

### DIFF
--- a/bootstrap/helmfile/apps.yaml
+++ b/bootstrap/helmfile/apps.yaml
@@ -43,7 +43,7 @@ releases:
           - --namespace={{ .Release.Namespace }}
           - --server-side
           - --force-conflicts
-          - --filename=../../kubernetes/apps/{{ .Release.Namespace }}/{{ .Release.Name }}/networking.yaml
+          - --filename=../../kubernetes/apps/{{ requiredEnv "CLUSTER" }}/{{ .Release.Namespace }}/{{ .Release.Name }}/networking.yaml
         events:
           - postsync
         showlogs: true
@@ -82,7 +82,7 @@ releases:
           - apply
           - --server-side
           - --force-conflicts
-          - --filename=../../kubernetes/apps/{{ .Release.Namespace }}/{{ .Release.Name }}/clustersecretstore.yaml
+          - --filename=../../kubernetes/apps/base/{{ .Release.Namespace }}/{{ .Release.Name }}/clustersecretstore.yaml
         events:
           - postsync
         showlogs: true

--- a/talos/test/machineconfig.yaml.j2
+++ b/talos/test/machineconfig.yaml.j2
@@ -60,7 +60,7 @@ machine:
     topology.kubernetes.io/zone: {{ 'm' if ENV.MACHINE_TYPE == 'controlplane' else 'w' }}
   sysfs:
     devices.system.cpu.cpufreq.policy0.scaling_governor: powersave
-    devices.system.cpu.cpufreq.policy0.energy_performance_preference: balancer_power
+    devices.system.cpu.cpufreq.policy0.energy_performance_preference: balance_power
   sysctls:
     fs.inotify.max_user_watches: "1048576"     # Watchdog
     fs.inotify.max_user_instances: "8192"      # Watchdog

--- a/talos/utility/machineconfig.yaml.j2
+++ b/talos/utility/machineconfig.yaml.j2
@@ -92,7 +92,7 @@ machine:
   type: {{ ENV.MACHINE_TYPE }}
   sysfs:
     devices.system.cpu.cpufreq.policy0.scaling_governor: powersave
-    devices.system.cpu.cpufreq.policy0.energy_performance_preference: balancer_power
+    devices.system.cpu.cpufreq.policy0.energy_performance_preference: balance_power
   time:
     disabled: false
     servers: ["time.cloudflare.com"]


### PR DESCRIPTION
Two drift bugs surfaced by a three-way diff of the cluster overlays.

**Bootstrap hooks reference paths that do not exist.** `bootstrap/helmfile/apps.yaml` applies `../../kubernetes/apps/kube-system/cilium/networking.yaml` and `.../external-secrets/onepassword-connect/clustersecretstore.yaml`. Neither path exists; the real ones are `kubernetes/apps/<cluster>/kube-system/cilium/networking.yaml` and `kubernetes/apps/base/external-secrets/onepassword-connect/clustersecretstore.yaml`. Broken since #8641; no cluster has been bootstrapped since, so it never fired. The cilium hook now resolves the overlay via `requiredEnv "CLUSTER"` (already exported by the bootstrap taskfile); the onepassword hook points at base.

**Talos EPP typo.** `talos/{test,utility}/machineconfig.yaml.j2` set `energy_performance_preference: balancer_power`. The valid value (and what main uses) is `balance_power`, so the sysfs write was being rejected and those nodes were not on the intended power profile. Takes effect on the next `task talos:apply-node` for celestia/citlali.

Not runtime-affecting for Flux; nothing to reconcile.