### PR TITLE
refactor(flux): make cluster-info the single per-cluster knob

### DIFF
--- a/kubernetes/apps/base/downloads/sonarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/sonarr/helmrelease.yaml
@@ -43,7 +43,9 @@ spec:
                     key: password
               SONARR__POSTGRES__PORT: "5432"
               SONARR__POSTGRES__USER: "{{ .Release.Name }}"
+              SONARR__SERVER__ALLOWEDHOSTS: sonarr.jory.dev,sonarr.downloads,sonarr.downloads.svc,sonarr.downloads.svc.cluster.local
               SONARR__SERVER__PORT: &port 80
+              SONARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               SONARR__UPDATE__BRANCH: develop
               TZ: America/Edmonton
             envFrom:
@@ -57,6 +59,9 @@ spec:
                   httpGet:
                     path: /ping
                     port: *port
+                    httpHeaders:
+                      - name: Host
+                        value: localhost
                   initialDelaySeconds: 0
                   periodSeconds: 10
                   timeoutSeconds: 1

--- a/kubernetes/apps/base/flux-system/addons/httproute.yaml
+++ b/kubernetes/apps/base/flux-system/addons/httproute.yaml
@@ -8,7 +8,7 @@ metadata:
     gatus.home-operations.com/endpoint: |-
       conditions: ["[STATUS] == 404"]
 spec:
-  hostnames: ["${SUBDOMAIN}.jory.dev"]
+  hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
   parentRefs:
     - name: envoy-external
       namespace: network

--- a/kubernetes/apps/base/flux-system/flux-operator/helmrelease.yaml
+++ b/kubernetes/apps/base/flux-system/flux-operator/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
       httpRoute:
         enabled: true
         hostnames:
-          - ${SUBDOMAIN}.jory.dev
+          - ${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/base/flux-system/headlamp/httproute.yaml
+++ b/kubernetes/apps/base/flux-system/headlamp/httproute.yaml
@@ -5,7 +5,7 @@ kind: HTTPRoute
 metadata:
   name: headlamp
 spec:
-  hostnames: ["${SUBDOMAIN}.jory.dev"]
+  hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
   parentRefs:
     - name: envoy-internal
       namespace: network

--- a/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml
+++ b/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
       statusChecks: true
       statusCheckName: "Konflate (${CLUSTER})"
       prComments: ${KONFLATE_PR_COMMENTS:=true}
-      publicUrl: "https://${SUBDOMAIN}.jory.dev"
+      publicUrl: "https://${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"
       repo: github://joryirving/home-ops
       mcp: true
     persistence:
@@ -33,7 +33,7 @@ spec:
       parentRefs:
         - name: envoy-external
           namespace: network
-      hostnames: ["${SUBDOMAIN}.jory.dev"]
+      hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
     monitoring:
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/base/network/echo/helmrelease.yaml
+++ b/kubernetes/apps/base/network/echo/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
         gatus.home-operations.com/endpoint: |-
           conditions: ["[STATUS] == 200"]
       hostnames:
-        - "${SUBDOMAIN}.jory.dev"
+        - "${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"
       parentRefs:
         - name: envoy-external
           namespace: network

--- a/kubernetes/apps/base/observability/exporters/blackbox-exporter/httproute.yaml
+++ b/kubernetes/apps/base/observability/exporters/blackbox-exporter/httproute.yaml
@@ -5,7 +5,7 @@ kind: HTTPRoute
 metadata:
   name: blackbox-exporter
 spec:
-  hostnames: ["${SUBDOMAIN}.jory.dev"]
+  hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
   parentRefs:
     - name: envoy-internal
       namespace: network

--- a/kubernetes/apps/base/observability/gatus-sidecar/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/gatus-sidecar/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
     httpRoute:
       enabled: true
       hostnames:
-        - "${SUBDOMAIN}.jory.dev"
+        - "${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"
       parentRefs:
         - name: envoy-external
           namespace: network

--- a/kubernetes/apps/base/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/base/observability/grafana/instance/grafana.yaml
@@ -43,7 +43,7 @@ spec:
       angular_support_enabled: "true"
     server:
       enable_gzip: "true"
-      root_url: https://${SUBDOMAIN}.jory.dev
+      root_url: https://${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev
   deployment:
     spec:
       strategy:
@@ -85,7 +85,7 @@ spec:
   httpRoute:
     spec:
       hostnames:
-        - ${SUBDOMAIN}.jory.dev
+        - ${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev
       parentRefs:
         - name: envoy-external
           namespace: network

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
@@ -103,7 +103,7 @@ spec:
       route:
         main:
           enabled: true
-          hostnames: ["${ALERTMANAGER_SUBDOMAIN}.jory.dev"]
+          hostnames: ["${ALERTMANAGER_SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
           parentRefs:
             - name: envoy-internal
               namespace: network
@@ -112,7 +112,7 @@ spec:
           name: alertmanager
           global:
             resolveTimeout: 5m
-        externalUrl: https://${ALERTMANAGER_SUBDOMAIN}.jory.dev
+        externalUrl: https://${ALERTMANAGER_SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev
         storage:
           volumeClaimTemplate:
             spec:
@@ -160,14 +160,14 @@ spec:
       route:
         main:
           enabled: true
-          hostnames: ["${SUBDOMAIN}.jory.dev"]
+          hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
           parentRefs:
             - name: envoy-internal
               namespace: network
       prometheusSpec:
         externalLabels:
           cluster: ${CLUSTER}
-        externalUrl: ${SUBDOMAIN}.jory.dev
+        externalUrl: ${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev
         resources:
           requests:
             cpu: 100m

--- a/kubernetes/apps/base/security/authentik/helmrelease.yaml
+++ b/kubernetes/apps/base/security/authentik/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
       route:
         main:
           enabled: true
-          hostnames: ["${SUBDOMAIN}.jory.dev"]
+          hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
           parentRefs:
             - name: envoy-external
               namespace: network

--- a/kubernetes/apps/main/observability/kube-prometheus-stack.yaml
+++ b/kubernetes/apps/main/observability/kube-prometheus-stack.yaml
@@ -11,7 +11,6 @@ spec:
     substitute:
       ALERTMANAGER_SUBDOMAIN: alertmanager
       PVC_CAPACITY: "75"
-      STORAGECLASS: ceph-block
       SUBDOMAIN: prometheus
   wait: false
   prune: true

--- a/kubernetes/apps/main/self-hosted/archiveteam.yaml
+++ b/kubernetes/apps/main/self-hosted/archiveteam.yaml
@@ -7,9 +7,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/self-hosted/archiveteam
-  postBuild:
-    substitute:
-      STORAGECLASS: ceph-block
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/test/actions-runner-system/actions-runner-controller.yaml
+++ b/kubernetes/apps/test/actions-runner-system/actions-runner-controller.yaml
@@ -18,6 +18,8 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: actions-runner-controller-runners
+  labels:
+    components.storage/driver: democratic-csi
 spec:
   dependsOn:
     - name: actions-runner-controller

--- a/kubernetes/apps/test/flux-system/addons.yaml
+++ b/kubernetes/apps/test/flux-system/addons.yaml
@@ -9,7 +9,7 @@ spec:
   path: ./kubernetes/apps/base/flux-system/addons
   postBuild:
     substitute:
-      SUBDOMAIN: flux-webhook-${CLUSTER}
+      SUBDOMAIN: flux-webhook
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/test/flux-system/flux-operator.yaml
+++ b/kubernetes/apps/test/flux-system/flux-operator.yaml
@@ -9,7 +9,7 @@ spec:
   path: ./kubernetes/apps/base/flux-system/flux-operator
   postBuild:
     substitute:
-      SUBDOMAIN: flux-${CLUSTER}
+      SUBDOMAIN: flux
   wait: true
   prune: true
   sourceRef:

--- a/kubernetes/apps/test/flux-system/headlamp.yaml
+++ b/kubernetes/apps/test/flux-system/headlamp.yaml
@@ -9,7 +9,7 @@ spec:
   path: ./kubernetes/apps/base/flux-system/headlamp
   postBuild:
     substitute:
-      SUBDOMAIN: headlamp-${CLUSTER}
+      SUBDOMAIN: headlamp
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/test/flux-system/konflate.yaml
+++ b/kubernetes/apps/test/flux-system/konflate.yaml
@@ -9,7 +9,7 @@ spec:
   path: ./kubernetes/apps/base/flux-system/konflate
   postBuild:
     substitute:
-      SUBDOMAIN: konflate-${CLUSTER}
+      SUBDOMAIN: konflate
       KONFLATE_PR_COMMENTS: "false"
   wait: false
   prune: true

--- a/kubernetes/apps/test/network/echo.yaml
+++ b/kubernetes/apps/test/network/echo.yaml
@@ -9,7 +9,7 @@ spec:
   path: ./kubernetes/apps/base/network/echo
   postBuild:
     substitute:
-      SUBDOMAIN: echo-${CLUSTER}
+      SUBDOMAIN: echo
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/test/storage/snapshot-controller.yaml
+++ b/kubernetes/apps/test/storage/snapshot-controller.yaml
@@ -4,6 +4,8 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: snapshot-controller
+  labels:
+    components.storage/driver: democratic-csi
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/storage/snapshot-controller

--- a/kubernetes/apps/utility/actions-runner-system/actions-runner-controller.yaml
+++ b/kubernetes/apps/utility/actions-runner-system/actions-runner-controller.yaml
@@ -18,6 +18,8 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: actions-runner-controller-runners
+  labels:
+    components.storage/driver: democratic-csi
 spec:
   dependsOn:
     - name: actions-runner-controller

--- a/kubernetes/apps/utility/flux-system/addons.yaml
+++ b/kubernetes/apps/utility/flux-system/addons.yaml
@@ -9,7 +9,7 @@ spec:
   path: ./kubernetes/apps/base/flux-system/addons
   postBuild:
     substitute:
-      SUBDOMAIN: flux-webhook-${CLUSTER}
+      SUBDOMAIN: flux-webhook
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/flux-system/flux-operator.yaml
+++ b/kubernetes/apps/utility/flux-system/flux-operator.yaml
@@ -9,7 +9,7 @@ spec:
   path: ./kubernetes/apps/base/flux-system/flux-operator
   postBuild:
     substitute:
-      SUBDOMAIN: flux-${CLUSTER}
+      SUBDOMAIN: flux
   wait: true
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/flux-system/headlamp.yaml
+++ b/kubernetes/apps/utility/flux-system/headlamp.yaml
@@ -9,7 +9,7 @@ spec:
   path: ./kubernetes/apps/base/flux-system/headlamp
   postBuild:
     substitute:
-      SUBDOMAIN: headlamp-${CLUSTER}
+      SUBDOMAIN: headlamp
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/flux-system/konflate.yaml
+++ b/kubernetes/apps/utility/flux-system/konflate.yaml
@@ -9,7 +9,7 @@ spec:
   path: ./kubernetes/apps/base/flux-system/konflate
   postBuild:
     substitute:
-      SUBDOMAIN: konflate-${CLUSTER}
+      SUBDOMAIN: konflate
       KONFLATE_PR_COMMENTS: "false"
   wait: false
   prune: true

--- a/kubernetes/apps/utility/home-automation/home-assistant.yaml
+++ b/kubernetes/apps/utility/home-automation/home-assistant.yaml
@@ -12,10 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: home-assistant
-      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
-      KOPIUR_STORAGECLASS: local-hostpath
-      STORAGE_HR: ${STORAGE_HR}
-      STORAGE_NS: ${STORAGE_NS}
   wait: false
   prune: true
   sourceRef:
@@ -38,10 +34,6 @@ spec:
       APP: trmnl-ha
       KOPIUR_PGID: "0"
       KOPIUR_PUID: "0"
-      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
-      KOPIUR_STORAGECLASS: local-hostpath
-      STORAGE_HR: ${STORAGE_HR}
-      STORAGE_NS: ${STORAGE_NS}
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/utility/home-automation/matter-server.yaml
+++ b/kubernetes/apps/utility/home-automation/matter-server.yaml
@@ -14,10 +14,6 @@ spec:
       APP: matter-server
       KOPIUR_PGID: "1000"
       KOPIUR_PUID: "1000"
-      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
-      KOPIUR_STORAGECLASS: local-hostpath
-      STORAGE_HR: ${STORAGE_HR}
-      STORAGE_NS: ${STORAGE_NS}
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/home-automation/zigbee.yaml
+++ b/kubernetes/apps/utility/home-automation/zigbee.yaml
@@ -13,11 +13,7 @@ spec:
   postBuild:
     substitute:
       APP: zigbee
-      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
-      KOPIUR_STORAGECLASS: local-hostpath
       ZEROSCALER_JOB_NAME: zigbee_probe
-      STORAGE_HR: ${STORAGE_HR}
-      STORAGE_NS: ${STORAGE_NS}
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/network/echo.yaml
+++ b/kubernetes/apps/utility/network/echo.yaml
@@ -9,7 +9,7 @@ spec:
   path: ./kubernetes/apps/base/network/echo
   postBuild:
     substitute:
-      SUBDOMAIN: echo-${CLUSTER}
+      SUBDOMAIN: echo
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/observability/exporters/blackbox-exporter.yaml
+++ b/kubernetes/apps/utility/observability/exporters/blackbox-exporter.yaml
@@ -9,7 +9,7 @@ spec:
   path: ./kubernetes/apps/base/observability/exporters/blackbox-exporter
   postBuild:
     substitute:
-      SUBDOMAIN: blackbox-${CLUSTER}
+      SUBDOMAIN: blackbox
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/observability/gatus.yaml
+++ b/kubernetes/apps/utility/observability/gatus.yaml
@@ -9,7 +9,7 @@ spec:
   path: ./kubernetes/apps/base/observability/gatus-sidecar
   postBuild:
     substitute:
-      SUBDOMAIN: status-${CLUSTER}
+      SUBDOMAIN: status
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/observability/kube-prometheus-stack.yaml
+++ b/kubernetes/apps/utility/observability/kube-prometheus-stack.yaml
@@ -9,11 +9,9 @@ spec:
   path: ./kubernetes/apps/base/observability/kube-prometheus-stack
   postBuild:
     substitute:
-      ALERTMANAGER_SUBDOMAIN: alertmanager-${CLUSTER}
-      CLUSTER: ${CLUSTER}
+      ALERTMANAGER_SUBDOMAIN: alertmanager
       PVC_CAPACITY: "50"
-      STORAGECLASS: local-hostpath
-      SUBDOMAIN: prometheus-${CLUSTER}
+      SUBDOMAIN: prometheus
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/self-hosted/acars.yaml
+++ b/kubernetes/apps/utility/self-hosted/acars.yaml
@@ -12,11 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
-      KOPIUR_STORAGECLASS: local-hostpath
-      STORAGECLASS: local-hostpath
-      STORAGE_HR: ${STORAGE_HR}
-      STORAGE_NS: ${STORAGE_NS}
     substituteFrom:
       - kind: Secret
         name: acarsdrama

--- a/kubernetes/apps/utility/self-hosted/free-game-notifier.yaml
+++ b/kubernetes/apps/utility/self-hosted/free-game-notifier.yaml
@@ -13,11 +13,6 @@ spec:
     substitute:
       APP: *app
       KOPIUR_ON_MISSING_SNAPSHOT: Continue
-      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
-      KOPIUR_STORAGECLASS: local-hostpath
-      STORAGECLASS: local-hostpath
-      STORAGE_HR: ${STORAGE_HR}
-      STORAGE_NS: ${STORAGE_NS}
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/self-hosted/meshcentral.yaml
+++ b/kubernetes/apps/utility/self-hosted/meshcentral.yaml
@@ -12,10 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
-      KOPIUR_STORAGECLASS: local-hostpath
-      STORAGE_HR: ${STORAGE_HR}
-      STORAGE_NS: ${STORAGE_NS}
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/self-hosted/scanservjs.yaml
+++ b/kubernetes/apps/utility/self-hosted/scanservjs.yaml
@@ -12,10 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
-      KOPIUR_STORAGECLASS: local-hostpath
-      STORAGE_HR: ${STORAGE_HR}
-      STORAGE_NS: ${STORAGE_NS}
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/self-hosted/thelounge.yaml
+++ b/kubernetes/apps/utility/self-hosted/thelounge.yaml
@@ -12,10 +12,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      KOPIUR_SNAPSHOTCLASS: csi-local-hostpath
-      KOPIUR_STORAGECLASS: local-hostpath
-      STORAGE_HR: ${STORAGE_HR}
-      STORAGE_NS: ${STORAGE_NS}
   wait: false
   prune: true
   sourceRef:

--- a/kubernetes/apps/utility/storage/snapshot-controller.yaml
+++ b/kubernetes/apps/utility/storage/snapshot-controller.yaml
@@ -4,6 +4,8 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: snapshot-controller
+  labels:
+    components.storage/driver: democratic-csi
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/storage/snapshot-controller

--- a/kubernetes/clusters/main/apps.yaml
+++ b/kubernetes/clusters/main/apps.yaml
@@ -30,6 +30,11 @@ spec:
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}
+              SNAPSHOTCLASS: ${SNAPSHOTCLASS}
+              STORAGECLASS: ${STORAGECLASS}
+              STORAGE_HR: ${STORAGE_HR}
+              STORAGE_NS: ${STORAGE_NS}
+              SUBDOMAIN_SUFFIX: "${SUBDOMAIN_SUFFIX}"
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -110,3 +115,52 @@ spec:
       target:
         kind: Kustomization
         labelSelector: "components.dragonfly/cluster-mode=non-cluster"
+    - # Fix ARC Runner perms for D-CSI
+      patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: not-used
+        spec:
+          patches:
+            - patch: |-
+                apiVersion: helm.toolkit.fluxcd.io/v2
+                kind: HelmRelease
+                metadata:
+                  name: not-used
+                spec:
+                  values:
+                    template:
+                      spec:
+                        securityContext:
+                          fsGroup: 123
+              target:
+                kind: HelmRelease
+      target:
+        kind: Kustomization
+        name: actions-runner-controller-runners
+        labelSelector: "components.storage/driver=democratic-csi"
+    - # Set Snapshot controller value for D-CSI
+      patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: not-used
+        spec:
+          patches:
+            - patch: |-
+                apiVersion: helm.toolkit.fluxcd.io/v2
+                kind: HelmRelease
+                metadata:
+                  name: not-used
+                spec:
+                  values:
+                    controller:
+                      args:
+                        enableDistributedSnapshotting: true
+              target:
+                kind: HelmRelease
+      target:
+        kind: Kustomization
+        name: snapshot-controller
+        labelSelector: "components.storage/driver=democratic-csi"

--- a/kubernetes/clusters/main/apps.yaml
+++ b/kubernetes/clusters/main/apps.yaml
@@ -34,7 +34,7 @@ spec:
               STORAGECLASS: ${STORAGECLASS}
               STORAGE_HR: ${STORAGE_HR}
               STORAGE_NS: ${STORAGE_NS}
-              SUBDOMAIN_SUFFIX: "${SUBDOMAIN_SUFFIX}"
+              SUBDOMAIN_SUFFIX: "${SUBDOMAIN_SUFFIX}" # quoted: main sets "", unquoted renders null and fails CRD validation
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/clusters/main/cluster-info.yaml
+++ b/kubernetes/clusters/main/cluster-info.yaml
@@ -9,3 +9,8 @@ metadata:
     reconcile.fluxcd.io/watch: Enabled
 data:
   CLUSTER: main
+  SNAPSHOTCLASS: csi-ceph-blockpool
+  STORAGECLASS: ceph-block
+  STORAGE_HR: rook-ceph-cluster
+  STORAGE_NS: rook-ceph
+  SUBDOMAIN_SUFFIX: ""

--- a/kubernetes/clusters/test/apps.yaml
+++ b/kubernetes/clusters/test/apps.yaml
@@ -30,8 +30,11 @@ spec:
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}
+              SNAPSHOTCLASS: ${SNAPSHOTCLASS}
+              STORAGECLASS: ${STORAGECLASS}
               STORAGE_HR: ${STORAGE_HR}
               STORAGE_NS: ${STORAGE_NS}
+              SUBDOMAIN_SUFFIX: "${SUBDOMAIN_SUFFIX}"
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -59,6 +62,59 @@ spec:
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization
+    - # Net-new CNPG cluster: plain initdb (no Barman recovery).
+      # Use the `components.postgres/cnpg=init` label on an app's Flux Kustomization
+      # to mark it as a brand-new cluster with no existing data. The component
+      # default is bootstrap.recovery from Barman; this label opts out for net-new
+      # apps that have no backup yet to recover from.
+      # $${...} escape preserves the variable through outer (cluster-apps) substitution
+      # so the inner (app) Kustomization's postBuild can resolve APP/POSTGRES_USERNAME.
+      patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: not-used
+        spec:
+          patches:
+            - target:
+                group: postgresql.cnpg.io
+                version: v1
+                kind: Cluster
+              patch: |-
+                - op: replace
+                  path: /spec/bootstrap
+                  value:
+                    initdb:
+                      database: $${POSTGRES_USERNAME:=$${APP}}
+                      owner: $${POSTGRES_USERNAME:=$${APP}}
+                - op: remove
+                  path: /spec/externalClusters
+      target:
+        kind: Kustomization
+        labelSelector: "components.postgres/cnpg=init"
+    - # Configure Dragonfly for ToolHive's Redis auth-storage Lua scripts.
+      # Replication remains enabled; standalone mode and undeclared-key access
+      # are required by ToolHive's scripts.
+      patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: not-used
+        spec:
+          patches:
+            - target:
+                group: dragonflydb.io
+                version: v1alpha1
+                kind: Dragonfly
+              patch: |-
+                - op: remove
+                  path: /spec/args/2
+                - op: add
+                  path: /spec/args/-
+                  value: --default_lua_flags=allow-undeclared-keys
+      target:
+        kind: Kustomization
+        labelSelector: "components.dragonfly/cluster-mode=non-cluster"
     - # Fix ARC Runner perms for D-CSI
       patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -71,7 +127,7 @@ spec:
                 apiVersion: helm.toolkit.fluxcd.io/v2
                 kind: HelmRelease
                 metadata:
-                  name: home-ops-runner-test
+                  name: not-used
                 spec:
                   values:
                     template:
@@ -83,6 +139,7 @@ spec:
       target:
         kind: Kustomization
         name: actions-runner-controller-runners
+        labelSelector: "components.storage/driver=democratic-csi"
     - # Set Snapshot controller value for D-CSI
       patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -95,7 +152,7 @@ spec:
                 apiVersion: helm.toolkit.fluxcd.io/v2
                 kind: HelmRelease
                 metadata:
-                  name: snapshot-controller
+                  name: not-used
                 spec:
                   values:
                     controller:
@@ -106,3 +163,4 @@ spec:
       target:
         kind: Kustomization
         name: snapshot-controller
+        labelSelector: "components.storage/driver=democratic-csi"

--- a/kubernetes/clusters/test/apps.yaml
+++ b/kubernetes/clusters/test/apps.yaml
@@ -34,7 +34,7 @@ spec:
               STORAGECLASS: ${STORAGECLASS}
               STORAGE_HR: ${STORAGE_HR}
               STORAGE_NS: ${STORAGE_NS}
-              SUBDOMAIN_SUFFIX: "${SUBDOMAIN_SUFFIX}"
+              SUBDOMAIN_SUFFIX: "${SUBDOMAIN_SUFFIX}" # quoted: main sets "", unquoted renders null and fails CRD validation
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/clusters/test/cluster-info.yaml
+++ b/kubernetes/clusters/test/cluster-info.yaml
@@ -9,5 +9,8 @@ metadata:
     reconcile.fluxcd.io/watch: Enabled
 data:
   CLUSTER: test
+  SNAPSHOTCLASS: csi-local-hostpath
+  STORAGECLASS: local-hostpath
   STORAGE_HR: democratic-csi
   STORAGE_NS: storage
+  SUBDOMAIN_SUFFIX: "-test"

--- a/kubernetes/clusters/utility/apps.yaml
+++ b/kubernetes/clusters/utility/apps.yaml
@@ -30,8 +30,11 @@ spec:
           postBuild:
             substitute:
               CLUSTER: ${CLUSTER}
+              SNAPSHOTCLASS: ${SNAPSHOTCLASS}
+              STORAGECLASS: ${STORAGECLASS}
               STORAGE_HR: ${STORAGE_HR}
               STORAGE_NS: ${STORAGE_NS}
+              SUBDOMAIN_SUFFIX: "${SUBDOMAIN_SUFFIX}"
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -59,6 +62,59 @@ spec:
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization
+    - # Net-new CNPG cluster: plain initdb (no Barman recovery).
+      # Use the `components.postgres/cnpg=init` label on an app's Flux Kustomization
+      # to mark it as a brand-new cluster with no existing data. The component
+      # default is bootstrap.recovery from Barman; this label opts out for net-new
+      # apps that have no backup yet to recover from.
+      # $${...} escape preserves the variable through outer (cluster-apps) substitution
+      # so the inner (app) Kustomization's postBuild can resolve APP/POSTGRES_USERNAME.
+      patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: not-used
+        spec:
+          patches:
+            - target:
+                group: postgresql.cnpg.io
+                version: v1
+                kind: Cluster
+              patch: |-
+                - op: replace
+                  path: /spec/bootstrap
+                  value:
+                    initdb:
+                      database: $${POSTGRES_USERNAME:=$${APP}}
+                      owner: $${POSTGRES_USERNAME:=$${APP}}
+                - op: remove
+                  path: /spec/externalClusters
+      target:
+        kind: Kustomization
+        labelSelector: "components.postgres/cnpg=init"
+    - # Configure Dragonfly for ToolHive's Redis auth-storage Lua scripts.
+      # Replication remains enabled; standalone mode and undeclared-key access
+      # are required by ToolHive's scripts.
+      patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: not-used
+        spec:
+          patches:
+            - target:
+                group: dragonflydb.io
+                version: v1alpha1
+                kind: Dragonfly
+              patch: |-
+                - op: remove
+                  path: /spec/args/2
+                - op: add
+                  path: /spec/args/-
+                  value: --default_lua_flags=allow-undeclared-keys
+      target:
+        kind: Kustomization
+        labelSelector: "components.dragonfly/cluster-mode=non-cluster"
     - # Fix ARC Runner perms for D-CSI
       patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -71,7 +127,7 @@ spec:
                 apiVersion: helm.toolkit.fluxcd.io/v2
                 kind: HelmRelease
                 metadata:
-                  name: home-ops-runner-test
+                  name: not-used
                 spec:
                   values:
                     template:
@@ -83,6 +139,7 @@ spec:
       target:
         kind: Kustomization
         name: actions-runner-controller-runners
+        labelSelector: "components.storage/driver=democratic-csi"
     - # Set Snapshot controller value for D-CSI
       patch: |-
         apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -95,7 +152,7 @@ spec:
                 apiVersion: helm.toolkit.fluxcd.io/v2
                 kind: HelmRelease
                 metadata:
-                  name: snapshot-controller
+                  name: not-used
                 spec:
                   values:
                     controller:
@@ -106,3 +163,4 @@ spec:
       target:
         kind: Kustomization
         name: snapshot-controller
+        labelSelector: "components.storage/driver=democratic-csi"

--- a/kubernetes/clusters/utility/apps.yaml
+++ b/kubernetes/clusters/utility/apps.yaml
@@ -34,7 +34,7 @@ spec:
               STORAGECLASS: ${STORAGECLASS}
               STORAGE_HR: ${STORAGE_HR}
               STORAGE_NS: ${STORAGE_NS}
-              SUBDOMAIN_SUFFIX: "${SUBDOMAIN_SUFFIX}"
+              SUBDOMAIN_SUFFIX: "${SUBDOMAIN_SUFFIX}" # quoted: main sets "", unquoted renders null and fails CRD validation
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/clusters/utility/cluster-info.yaml
+++ b/kubernetes/clusters/utility/cluster-info.yaml
@@ -9,5 +9,8 @@ metadata:
     reconcile.fluxcd.io/watch: Enabled
 data:
   CLUSTER: utility
+  SNAPSHOTCLASS: csi-local-hostpath
+  STORAGECLASS: local-hostpath
   STORAGE_HR: democratic-csi
   STORAGE_NS: storage
+  SUBDOMAIN_SUFFIX: "-utility"

--- a/kubernetes/components/kopiur/backup/pvc.yaml
+++ b/kubernetes/components/kopiur/backup/pvc.yaml
@@ -13,4 +13,4 @@ spec:
   resources:
     requests:
       storage: ${KOPIUR_CAPACITY:=5Gi}
-  storageClassName: ${KOPIUR_STORAGECLASS:=ceph-block}
+  storageClassName: ${KOPIUR_STORAGECLASS:=${STORAGECLASS}}

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -26,4 +26,4 @@ spec:
   sources:
     - pvc:
         name: ${APP}
-  volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS:=csi-ceph-blockpool}
+  volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS:=${SNAPSHOTCLASS}}

--- a/kubernetes/components/kopiur/restore/restore.yaml
+++ b/kubernetes/components/kopiur/restore/restore.yaml
@@ -24,4 +24,4 @@ spec:
         - ${KOPIUR_ACCESSMODES:=ReadWriteOnce}
       capacity: ${KOPIUR_CAPACITY:=5Gi}
       name: ${APP}-kopiur-restore
-      storageClassName: ${KOPIUR_STORAGECLASS:=ceph-block}
+      storageClassName: ${KOPIUR_STORAGECLASS:=${STORAGECLASS}}


### PR DESCRIPTION
Step 2 of the multi-cluster dedup. Rendered output is unchanged on every cluster; this is a pure re-plumbing of where per-cluster constants live.

**What moves into `cluster-info`:** `SNAPSHOTCLASS`, `STORAGECLASS`, `STORAGE_HR`, `STORAGE_NS`, `SUBDOMAIN_SUFFIX` (`""` on main, `-test`, `-utility`). The `cluster-apps` defaults patch injects all of them into every child Kustomization, the same way `CLUSTER` already was.

**What that lets us delete:**
- The three `clusters/*/apps.yaml` are now identical except `spec.path`. The two D-CSI patches (runner `fsGroup: 123`, snapshot-controller `enableDistributedSnapshotting`) are gated by a `components.storage/driver=democratic-csi` label on the test/utility Kustomizations instead of only existing in two of the files, so main's behaviour is unchanged. The runner patch also stops claiming to target `home-ops-runner-test` (it always applied to every HelmRelease in that build; the name was ignored because a `target` was set).
- 36 per-app `STORAGE_HR`/`STORAGE_NS`/`KOPIUR_STORAGECLASS`/`KOPIUR_SNAPSHOTCLASS` lines in the utility overlay. `STORAGE_HR/NS` were already being injected by the cluster-apps patch, so re-declaring them per app did nothing. The kopiur component now defaults `KOPIUR_STORAGECLASS:=${STORAGECLASS}` and `KOPIUR_SNAPSHOTCLASS:=${SNAPSHOTCLASS}`; per-app overrides (e.g. litellm's `ceph-filesystem`) still win.
- `STORAGECLASS` and `CLUSTER` lines in kube-prometheus-stack/archiveteam/acars/free-game-notifier overlays.
- Every `SUBDOMAIN: foo-${CLUSTER}` becomes `SUBDOMAIN: foo`. Base hostnames read `${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev` (15 sites, incl. alertmanager), so `status-utility.jory.dev` etc. are unchanged.

**Verification:** rendered every child Kustomization on all three clusters with kustomize + `flux envsubst` (cluster-info vars, the cluster-apps injected vars, and each app's own `substitute`), before and after: 262/262 identical. `kubeconform -strict` passes on the cluster files. `flux envsubst` confirmed the two semantics this relies on: an empty-string var substitutes to `""`, and nested defaults `${A:=${B}}` resolve (already used by `KOPIUR_USERNAME`).

One thing the simulation does not exercise: the label-selected Kustomization patches themselves. Those are unchanged in content; only the selector changed from file placement to a label.