### PR TITLE
refactor(talos): derive the 1Password item from CLUSTER

### DIFF
--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -55,6 +55,7 @@ tasks:
       SCHEMATIC:
         sh: task --silent talos:generate-schematic CLUSTER={{.CLUSTER}} NODE={{.NODE}} EGPU={{.EGPU_EFFECTIVE}}
     env:
+      CLUSTER: "{{.CLUSTER}}"
       MACHINE_TYPE: "{{.MACHINE_TYPE}}"
       SCHEMATIC: "{{.SCHEMATIC}}"
     requires:
@@ -71,7 +72,7 @@ tasks:
     desc: Verify rendered node config uses the live cluster machine CA [CLUSTER=main] [NODE=required]
     cmd: |-
       rendered_ca="$(
-        MACHINE_TYPE={{.MACHINE_TYPE}} SCHEMATIC={{.SCHEMATIC}} minijinja-cli {{.TALOS_DIR}}/machineconfig.yaml.j2 \
+        CLUSTER={{.CLUSTER}} MACHINE_TYPE={{.MACHINE_TYPE}} SCHEMATIC={{.SCHEMATIC}} minijinja-cli {{.TALOS_DIR}}/machineconfig.yaml.j2 \
           | op inject \
           | yq --exit-status --no-doc '.machine.ca.crt'
       )"
@@ -146,7 +147,7 @@ tasks:
         exit 1
       fi
 
-      env MACHINE_TYPE=controlplane SCHEMATIC="" minijinja-cli {{.TALOS_DIR}}/machineconfig.yaml.j2 \
+      env CLUSTER={{.CLUSTER}} MACHINE_TYPE=controlplane SCHEMATIC="" minijinja-cli {{.TALOS_DIR}}/machineconfig.yaml.j2 \
         | op inject > "$tmp_dir/controlplane.yaml"
       talosctl gen secrets \
         --from-controlplane-config "$tmp_dir/controlplane.yaml" \

--- a/talos/main/machineconfig.yaml.j2
+++ b/talos/main/machineconfig.yaml.j2
@@ -3,9 +3,9 @@
 version: v1alpha1
 machine:
   ca:
-    crt: op://Kubernetes/talos-main/MACHINE_CA_CRT
+    crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/MACHINE_CA_CRT
     {% if ENV.MACHINE_TYPE == 'controlplane' %}
-    key: op://Kubernetes/talos-main/MACHINE_CA_KEY
+    key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/MACHINE_CA_KEY
     {% endif %}
   features:
     diskQuotaSupport: true
@@ -112,16 +112,16 @@ machine:
     vm.dirty_bytes: "536870912"                # 512MiB | Cap dirty buildup (ratio 5%/20% on 134GB RAM allowed multi-GB flush storms)
     vm.dirty_expire_centisecs: "3000"         # Expire dirty data after 30s
     vm.dirty_writeback_centisecs: "500"       # Flush dirty pages every 5s
-  token: op://Kubernetes/talos-main/MACHINE_TOKEN
+  token: op://Kubernetes/talos-{{ ENV.CLUSTER }}/MACHINE_TOKEN
   type: {{ ENV.MACHINE_TYPE }}
   time:
     disabled: false
     servers: ["time.cloudflare.com"]
 cluster:
   ca:
-    crt: op://Kubernetes/talos-main/CLUSTER_CA_CRT
+    crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_CA_CRT
     {% if ENV.MACHINE_TYPE == 'controlplane' %}
-    key: op://Kubernetes/talos-main/CLUSTER_CA_KEY
+    key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_CA_KEY
     {% endif %}
   clusterName: main
   controlPlane:
@@ -133,19 +133,19 @@ cluster:
         disabled: true
       service:
         disabled: false
-  id: op://Kubernetes/talos-main/CLUSTER_ID
+  id: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ID
   network:
     cni:
       name: none
     dnsDomain: cluster.local
     podSubnets: ["10.42.0.0/16"]
     serviceSubnets: ["10.43.0.0/16"]
-  secret: op://Kubernetes/talos-main/CLUSTER_SECRET
-  token: op://Kubernetes/talos-main/CLUSTER_TOKEN
+  secret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRET
+  token: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_TOKEN
   {% if ENV.MACHINE_TYPE == 'controlplane' %}
   aggregatorCA:
-    crt: op://Kubernetes/talos-main/CLUSTER_AGGREGATORCA_CRT
-    key: op://Kubernetes/talos-main/CLUSTER_AGGREGATORCA_KEY
+    crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_AGGREGATORCA_CRT
+    key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_AGGREGATORCA_KEY
   allowSchedulingOnControlPlanes: true
   apiServer:
     certSANs: ["k8s.main.internal", "127.0.0.1"]
@@ -162,14 +162,14 @@ cluster:
   etcd:
     advertisedSubnets: ["10.69.1.0/24"]
     ca:
-      crt: op://Kubernetes/talos-main/CLUSTER_ETCD_CA_CRT
-      key: op://Kubernetes/talos-main/CLUSTER_ETCD_CA_KEY
+      crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ETCD_CA_CRT
+      key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ETCD_CA_KEY
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
   proxy:
     disabled: true
     image: registry.k8s.io/kube-proxy:v1.36.2
-  secretboxEncryptionSecret: op://Kubernetes/talos-main/CLUSTER_SECRETBOXENCRYPTIONSECRET
+  secretboxEncryptionSecret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRETBOXENCRYPTIONSECRET
   scheduler:
     config:
       apiVersion: kubescheduler.config.k8s.io/v1
@@ -192,5 +192,5 @@ cluster:
     extraArgs:
       bind-address: 0.0.0.0
   serviceAccount:
-    key: op://Kubernetes/talos-main/CLUSTER_SERVICEACCOUNT_KEY
+    key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SERVICEACCOUNT_KEY
   {% endif %}

--- a/talos/test/machineconfig.yaml.j2
+++ b/talos/test/machineconfig.yaml.j2
@@ -3,9 +3,9 @@
 version: v1alpha1
 machine:
   ca:
-    crt: op://Kubernetes/talos-test/MACHINE_CA_CRT
+    crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/MACHINE_CA_CRT
     {% if ENV.MACHINE_TYPE == 'controlplane' %}
-    key: op://Kubernetes/talos-test/MACHINE_CA_KEY
+    key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/MACHINE_CA_KEY
     {% endif %}
   features:
     diskQuotaSupport: true
@@ -89,13 +89,13 @@ machine:
     vm.dirty_ratio: "20"                      # Cap dirty page buildup
     vm.dirty_expire_centisecs: "3000"         # Expire dirty data after 30s
     vm.dirty_writeback_centisecs: "500"       # Flush dirty pages every 5s
-  token: op://Kubernetes/talos-test/MACHINE_TOKEN
+  token: op://Kubernetes/talos-{{ ENV.CLUSTER }}/MACHINE_TOKEN
   type: {{ ENV.MACHINE_TYPE }}
 cluster:
   ca:
-    crt: op://Kubernetes/talos-test/CLUSTER_CA_CRT
+    crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_CA_CRT
     {% if ENV.MACHINE_TYPE == 'controlplane' %}
-    key: op://Kubernetes/talos-test/CLUSTER_CA_KEY
+    key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_CA_KEY
     {% endif %}
   clusterName: test
   controlPlane:
@@ -107,19 +107,19 @@ cluster:
         disabled: true
       service:
         disabled: false
-  id: op://Kubernetes/talos-test/CLUSTER_ID
+  id: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ID
   network:
     cni:
       name: none
     dnsDomain: cluster.local
     podSubnets: ["10.42.0.0/16"]
     serviceSubnets: ["10.43.0.0/16"]
-  secret: op://Kubernetes/talos-test/CLUSTER_SECRET
-  token: op://Kubernetes/talos-test/CLUSTER_TOKEN
+  secret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRET
+  token: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_TOKEN
   {% if ENV.MACHINE_TYPE == 'controlplane' %}
   aggregatorCA:
-    crt: op://Kubernetes/talos-test/CLUSTER_AGGREGATORCA_CRT
-    key: op://Kubernetes/talos-test/CLUSTER_AGGREGATORCA_KEY
+    crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_AGGREGATORCA_CRT
+    key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_AGGREGATORCA_KEY
   allowSchedulingOnControlPlanes: true
   apiServer:
     certSANs: ["k8s.test.internal", "127.0.0.1"]
@@ -136,14 +136,14 @@ cluster:
   etcd:
     advertisedSubnets: ["10.69.1.0/24"]
     ca:
-      crt: op://Kubernetes/talos-test/CLUSTER_ETCD_CA_CRT
-      key: op://Kubernetes/talos-test/CLUSTER_ETCD_CA_KEY
+      crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ETCD_CA_CRT
+      key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ETCD_CA_KEY
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
   proxy:
     disabled: true
     image: registry.k8s.io/kube-proxy:v1.36.2
-  secretboxEncryptionSecret: op://Kubernetes/talos-test/CLUSTER_SECRETBOXENCRYPTIONSECRET
+  secretboxEncryptionSecret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRETBOXENCRYPTIONSECRET
   scheduler:
     config:
       apiVersion: kubescheduler.config.k8s.io/v1
@@ -166,7 +166,7 @@ cluster:
     extraArgs:
       bind-address: 0.0.0.0
   serviceAccount:
-    key: op://Kubernetes/talos-test/CLUSTER_SERVICEACCOUNT_KEY
+    key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SERVICEACCOUNT_KEY
   {% endif %}
 
 ---

--- a/talos/utility/machineconfig.yaml.j2
+++ b/talos/utility/machineconfig.yaml.j2
@@ -3,9 +3,9 @@
 version: v1alpha1
 machine:
   ca:
-    crt: op://Kubernetes/talos-utility/MACHINE_CA_CRT
+    crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/MACHINE_CA_CRT
     {% if ENV.MACHINE_TYPE == 'controlplane' %}
-    key: op://Kubernetes/talos-utility/MACHINE_CA_KEY
+    key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/MACHINE_CA_KEY
     {% endif %}
   features:
     diskQuotaSupport: true
@@ -88,7 +88,7 @@ machine:
     vm.dirty_ratio: "20"                      # Cap dirty page buildup
     vm.dirty_expire_centisecs: "3000"         # Expire dirty data after 30s
     vm.dirty_writeback_centisecs: "500"       # Flush dirty pages every 5s
-  token: op://Kubernetes/talos-utility/MACHINE_TOKEN
+  token: op://Kubernetes/talos-{{ ENV.CLUSTER }}/MACHINE_TOKEN
   type: {{ ENV.MACHINE_TYPE }}
   sysfs:
     devices.system.cpu.cpufreq.policy0.scaling_governor: powersave
@@ -98,9 +98,9 @@ machine:
     servers: ["time.cloudflare.com"]
 cluster:
   ca:
-    crt: op://Kubernetes/talos-utility/CLUSTER_CA_CRT
+    crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_CA_CRT
     {% if ENV.MACHINE_TYPE == 'controlplane' %}
-    key: op://Kubernetes/talos-utility/CLUSTER_CA_KEY
+    key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_CA_KEY
     {% endif %}
   clusterName: utility
   controlPlane:
@@ -112,19 +112,19 @@ cluster:
         disabled: true
       service:
         disabled: false
-  id: op://Kubernetes/talos-utility/CLUSTER_ID
+  id: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ID
   network:
     cni:
       name: none
     dnsDomain: cluster.local
     podSubnets: ["10.42.0.0/16"]
     serviceSubnets: ["10.43.0.0/16"]
-  secret: op://Kubernetes/talos-utility/CLUSTER_SECRET
-  token: op://Kubernetes/talos-utility/CLUSTER_TOKEN
+  secret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRET
+  token: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_TOKEN
   {% if ENV.MACHINE_TYPE == 'controlplane' %}
   aggregatorCA:
-    crt: op://Kubernetes/talos-utility/CLUSTER_AGGREGATORCA_CRT
-    key: op://Kubernetes/talos-utility/CLUSTER_AGGREGATORCA_KEY
+    crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_AGGREGATORCA_CRT
+    key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_AGGREGATORCA_KEY
   allowSchedulingOnControlPlanes: true
   apiServer:
     certSANs: ["k8s.utility.internal", "127.0.0.1"]
@@ -141,14 +141,14 @@ cluster:
   etcd:
     advertisedSubnets: ["10.69.1.0/24"]
     ca:
-      crt: op://Kubernetes/talos-utility/CLUSTER_ETCD_CA_CRT
-      key: op://Kubernetes/talos-utility/CLUSTER_ETCD_CA_KEY
+      crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ETCD_CA_CRT
+      key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ETCD_CA_KEY
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
   proxy:
     disabled: true
     image: registry.k8s.io/kube-proxy:v1.36.2
-  secretboxEncryptionSecret: op://Kubernetes/talos-utility/CLUSTER_SECRETBOXENCRYPTIONSECRET
+  secretboxEncryptionSecret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRETBOXENCRYPTIONSECRET
   scheduler:
     config:
       apiVersion: kubescheduler.config.k8s.io/v1
@@ -171,7 +171,7 @@ cluster:
     extraArgs:
       bind-address: 0.0.0.0
   serviceAccount:
-    key: op://Kubernetes/talos-utility/CLUSTER_SERVICEACCOUNT_KEY
+    key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SERVICEACCOUNT_KEY
   {% endif %}
 ---
 apiVersion: v1alpha1


### PR DESCRIPTION
Step 4 of the multi-cluster dedup.

Each `talos/<cluster>/machineconfig.yaml.j2` spelled out `op://Kubernetes/talos-<cluster>/…` 14 times. Those lines were the bulk of the diff between the three templates and are now `talos-{{ ENV.CLUSTER }}`, with `CLUSTER` passed to `minijinja-cli` by `talos:apply-node` (env block), `talos:verify-machine-ca`, and `talos:rotate-talosconfig` next to `MACHINE_TYPE`/`SCHEMATIC`. All three tasks already `requires` `CLUSTER`.

Verified by rendering every template for both machine types with `CLUSTER`/`MACHINE_TYPE`/`SCHEMATIC` set, before and after: 6/6 identical.

What is left differing between the templates is real hardware/topology config (thunderbolt and kubelet reservations on main; bond/VLAN/UserVolume trailers and the byte- vs ratio-based dirty limits), which reads better per cluster than behind `{% if %}` blocks. Not folding those.

Unrelated observation while in here: `bootstrap:nodes` runs `talosctl apply-config --insecure` with no `--file`, so it cannot be applying anything; `bootstrap:cluster` presumably relies on nodes already having been configured via `talos:apply-node`. Left alone.