### PR TITLE
fix(flux): default SUBDOMAIN_SUFFIX to empty instead of injecting "" on main

### DIFF
--- a/kubernetes/apps/base/flux-system/addons/httproute.yaml
+++ b/kubernetes/apps/base/flux-system/addons/httproute.yaml
@@ -8,7 +8,7 @@ metadata:
     gatus.home-operations.com/endpoint: |-
       conditions: ["[STATUS] == 404"]
 spec:
-  hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
+  hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev"]
   parentRefs:
     - name: envoy-external
       namespace: network

--- a/kubernetes/apps/base/flux-system/flux-operator/helmrelease.yaml
+++ b/kubernetes/apps/base/flux-system/flux-operator/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
       httpRoute:
         enabled: true
         hostnames:
-          - ${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev
+          - ${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/base/flux-system/headlamp/httproute.yaml
+++ b/kubernetes/apps/base/flux-system/headlamp/httproute.yaml
@@ -5,7 +5,7 @@ kind: HTTPRoute
 metadata:
   name: headlamp
 spec:
-  hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
+  hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev"]
   parentRefs:
     - name: envoy-internal
       namespace: network

--- a/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml
+++ b/kubernetes/apps/base/flux-system/konflate/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
       statusChecks: true
       statusCheckName: "Konflate (${CLUSTER})"
       prComments: ${KONFLATE_PR_COMMENTS:=true}
-      publicUrl: "https://${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"
+      publicUrl: "https://${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev"
       repo: github://joryirving/home-ops
       mcp: true
     persistence:
@@ -33,7 +33,7 @@ spec:
       parentRefs:
         - name: envoy-external
           namespace: network
-      hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
+      hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev"]
     monitoring:
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/base/network/echo/helmrelease.yaml
+++ b/kubernetes/apps/base/network/echo/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
         gatus.home-operations.com/endpoint: |-
           conditions: ["[STATUS] == 200"]
       hostnames:
-        - "${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"
+        - "${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev"
       parentRefs:
         - name: envoy-external
           namespace: network

--- a/kubernetes/apps/base/observability/exporters/blackbox-exporter/httproute.yaml
+++ b/kubernetes/apps/base/observability/exporters/blackbox-exporter/httproute.yaml
@@ -5,7 +5,7 @@ kind: HTTPRoute
 metadata:
   name: blackbox-exporter
 spec:
-  hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
+  hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev"]
   parentRefs:
     - name: envoy-internal
       namespace: network

--- a/kubernetes/apps/base/observability/gatus-sidecar/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/gatus-sidecar/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
     httpRoute:
       enabled: true
       hostnames:
-        - "${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"
+        - "${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev"
       parentRefs:
         - name: envoy-external
           namespace: network

--- a/kubernetes/apps/base/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/base/observability/grafana/instance/grafana.yaml
@@ -43,7 +43,7 @@ spec:
       angular_support_enabled: "true"
     server:
       enable_gzip: "true"
-      root_url: https://${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev
+      root_url: https://${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev
   deployment:
     spec:
       strategy:
@@ -85,7 +85,7 @@ spec:
   httpRoute:
     spec:
       hostnames:
-        - ${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev
+        - ${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev
       parentRefs:
         - name: envoy-external
           namespace: network

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
@@ -103,7 +103,7 @@ spec:
       route:
         main:
           enabled: true
-          hostnames: ["${ALERTMANAGER_SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
+          hostnames: ["${ALERTMANAGER_SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev"]
           parentRefs:
             - name: envoy-internal
               namespace: network
@@ -112,7 +112,7 @@ spec:
           name: alertmanager
           global:
             resolveTimeout: 5m
-        externalUrl: https://${ALERTMANAGER_SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev
+        externalUrl: https://${ALERTMANAGER_SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev
         storage:
           volumeClaimTemplate:
             spec:
@@ -160,14 +160,14 @@ spec:
       route:
         main:
           enabled: true
-          hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
+          hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev"]
           parentRefs:
             - name: envoy-internal
               namespace: network
       prometheusSpec:
         externalLabels:
           cluster: ${CLUSTER}
-        externalUrl: ${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev
+        externalUrl: ${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev
         resources:
           requests:
             cpu: 100m

--- a/kubernetes/apps/base/security/authentik/helmrelease.yaml
+++ b/kubernetes/apps/base/security/authentik/helmrelease.yaml
@@ -51,7 +51,7 @@ spec:
       route:
         main:
           enabled: true
-          hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX}.jory.dev"]
+          hostnames: ["${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev"]
           parentRefs:
             - name: envoy-external
               namespace: network

--- a/kubernetes/clusters/main/apps.yaml
+++ b/kubernetes/clusters/main/apps.yaml
@@ -34,7 +34,6 @@ spec:
               STORAGECLASS: ${STORAGECLASS}
               STORAGE_HR: ${STORAGE_HR}
               STORAGE_NS: ${STORAGE_NS}
-              SUBDOMAIN_SUFFIX: "${SUBDOMAIN_SUFFIX}" # quoted: main sets "", unquoted renders null and fails CRD validation
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/clusters/main/cluster-info.yaml
+++ b/kubernetes/clusters/main/cluster-info.yaml
@@ -13,4 +13,3 @@ data:
   STORAGECLASS: ceph-block
   STORAGE_HR: rook-ceph-cluster
   STORAGE_NS: rook-ceph
-  SUBDOMAIN_SUFFIX: ""

--- a/kubernetes/clusters/test/apps.yaml
+++ b/kubernetes/clusters/test/apps.yaml
@@ -34,7 +34,7 @@ spec:
               STORAGECLASS: ${STORAGECLASS}
               STORAGE_HR: ${STORAGE_HR}
               STORAGE_NS: ${STORAGE_NS}
-              SUBDOMAIN_SUFFIX: "${SUBDOMAIN_SUFFIX}" # quoted: main sets "", unquoted renders null and fails CRD validation
+              SUBDOMAIN_SUFFIX: ${SUBDOMAIN_SUFFIX} # not injected on main: an empty value renders as null and fails admission
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/kubernetes/clusters/utility/apps.yaml
+++ b/kubernetes/clusters/utility/apps.yaml
@@ -34,7 +34,7 @@ spec:
               STORAGECLASS: ${STORAGECLASS}
               STORAGE_HR: ${STORAGE_HR}
               STORAGE_NS: ${STORAGE_NS}
-              SUBDOMAIN_SUFFIX: "${SUBDOMAIN_SUFFIX}" # quoted: main sets "", unquoted renders null and fails CRD validation
+              SUBDOMAIN_SUFFIX: ${SUBDOMAIN_SUFFIX} # not injected on main: an empty value renders as null and fails admission
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
Hotfix for #9462. `cluster-apps` on main is failing admission:

```
Kustomization "actions-runner-controller" is invalid: spec.postBuild.substitute.SUBDOMAIN_SUFFIX: Invalid value: "null": must be of type string
```

No child Kustomization on main has taken the new spec, and because the children pull base from the same Git revision, the 46 apps using the kopiur component fail post-build with `variable not set (strict mode): "STORAGECLASS"`. Nothing is down (last-applied state stands) but main is frozen. test and utility are healthy; their suffix is non-empty.

**Cause:** the patch value `"${SUBDOMAIN_SUFFIX}"` is quoted in `apps.yaml`, but kustomize applies the patch before Flux substitutes, and re-serializes the child as `SUBDOMAIN_SUFFIX: ${SUBDOMAIN_SUFFIX}` (quotes dropped as unnecessary). Substituting `""` then yields `SUBDOMAIN_SUFFIX: ` → null. The quoting check in #9462 was done on the patch text, not on the post-kustomize child, so it proved nothing.

**Fix:** avoid the empty-string value entirely.
- Base hostnames read `${SUBDOMAIN}${SUBDOMAIN_SUFFIX:=}.jory.dev` (15 sites). Under strict mode an unset variable with a `:=` default resolves to the default, verified with `flux envsubst --strict`.
- main's `apps.yaml` and `cluster-info` no longer carry `SUBDOMAIN_SUFFIX`. test and utility keep injecting theirs (`-test`, `-utility`), with a comment on why main differs. The three `apps.yaml` now differ by `spec.path` plus that one line.

Emulated the actual pipeline (substitute cluster-info into `apps.yaml` → kustomize build of the overlay with cluster-apps' patches → envsubst): main children have no `SUBDOMAIN_SUFFIX` key, test/utility children have their suffix as a string. Base dirs `kustomize build`; cluster files pass `kubeconform -strict`.