### PR TITLE
debug(litellm): log prompts to spend logs, temporarily

### DIFF
--- a/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
+++ b/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
@@ -136,6 +136,7 @@ spec:
   generalSettings:
     health_check_endpoint: /v1/health
     store_model_in_db: false
+    store_prompts_in_spend_logs: true
   extraConfig:
     environment:
     - KIMI_CODE_API_KEY


### PR DESCRIPTION
Temporary diagnostic. Miso gets 0 cache hits across 120 requests on `glm-5.3-flash`, while the same OpenClaw prompt assembly caches at 69% on `gpt-5.6-luna` and 72% on `llama-nvidia`, and synthetic requests through the proxy cache at 100% from turn 2 even with 60 tools and a 90k prefix — so the volatile element is in her real payload, which `LiteLLM_SpendLogs.messages` redacts by default. This flips `store_prompts_in_spend_logs` on so two consecutive requests can be diffed, and should be reverted immediately after. While it is on, prompts and responses for every model land in the spend DB.