### PR TITLE
debug(litellm): swap prompt logging for DEBUG log level

### DIFF
--- a/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
+++ b/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
@@ -136,7 +136,6 @@ spec:
   generalSettings:
     health_check_endpoint: /v1/health
     store_model_in_db: false
-    store_prompts_in_spend_logs: true
   extraConfig:
     environment:
     - KIMI_CODE_API_KEY

--- a/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
+++ b/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
@@ -44,7 +44,7 @@ spec:
   - name: GENERIC_USER_ROLE_ATTRIBUTE
     value: litellm_role
   - name: LITELLM_LOG
-    value: INFO
+    value: DEBUG
   - name: LITELLM_MODE
     value: PRODUCTION
   - name: PROXY_BASE_URL


### PR DESCRIPTION
Two changes, one rollout. Removes `store_prompts_in_spend_logs`, which v1.98.0 accepts but which leaves `messages` as `{}` (confirmed with three probes on fully-rolled pods), and raises the existing `LITELLM_LOG` from INFO to DEBUG so the outbound request bodies land in the proxy logs instead.

This is a temporary diagnostic for the GLM cache-miss investigation: `glm-5.3-flash` reads 0.3% cached over 123 requests and `glm-5.3` 0.0% over 40, while the same OpenClaw assembly caches at 69% on `gpt-5.6-luna` and 72% on `llama-nvidia`, and every synthetic reproduction through the proxy caches at 100% from turn 2. DEBUG logs full request bodies for every model on all three replicas, so revert as soon as a pair of consecutive Miso requests is captured.