### PR TITLE
Revert "debug(litellm): raise log level to DEBUG"

### DIFF
--- a/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
+++ b/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
@@ -44,7 +44,7 @@ spec:
   - name: GENERIC_USER_ROLE_ATTRIBUTE
     value: litellm_role
   - name: LITELLM_LOG
-    value: DEBUG
+    value: INFO
   - name: LITELLM_MODE
     value: PRODUCTION
   - name: PROXY_BASE_URL


### PR DESCRIPTION
Capture complete, so drop the log level back to INFO. Findings: Miso's outbound payloads diverge from one another at char ~46k, immediately after the system prompt, where a live timestamp and the memini recall block are prepended to the first user message and rewritten every turn — so no reused prefix can extend past the system prompt. A second divergence at char ~6k shows the tool list inside the system prompt is not stably ordered, which independently zeroes the cache on the turns it fires.