### PR TITLE
test(openclaw): suppress memini auto-recall to measure the cache cost

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -372,7 +372,7 @@ data:
               skip_system_turns: true,
               fallback_on_error: true,
               timeout_ms: 15000,
-              recall_limit: 3,
+              recall_limit: 0,
               expose_tools: true,
             },
           },


### PR DESCRIPTION
Measurement, not a destination — revert once we have the number.

The memini plugin returns recall as `prependContext`, which OpenClaw places at the head of the conversation, so the block sits in front of the *oldest* user message and is rebuilt every turn. Captured outbound payloads diverge from one another at char ~46k, exactly the injection point, and the same historical user message appears with the block in one request and without it in the next — history is rewritten, not appended. The provider reports 0.3% cached across 123 requests and 15.3M prompt tokens, and those hits were three synthetic controls I sent by hand, not agent traffic. A synthetic conversation of the same shape through the same proxy caches at 100% from turn 2, so the transport and provider are fine.

`recall_limit: 0` makes the handler return before producing any `prependContext`, leaving on-demand `memory_recall` as the only path. If the cache column moves off zero, the injection point is confirmed as the dominant cause.

Two caveats. This dial is global to the plugin, so it suppresses automatic recall for every agent, not only the one being measured. And giving up auto-recall is most of the value of the plugin, so the real fix is upstream — filed as an option to attach the block at the tail instead of the head.