### PR TITLE
Revert "test(openclaw): suppress memini auto-recall"

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -372,7 +372,7 @@ data:
               skip_system_turns: true,
               fallback_on_error: true,
               timeout_ms: 15000,
-              recall_limit: 0,
+              recall_limit: 3,
               expose_tools: true,
             },
           },


### PR DESCRIPTION
The trial assumed token volume drove the z.ai quota. It does not — Coding Lite Legacy V2 meters prompts, not tokens: measured at ~0.25% of the 5h window per `glm-5.3-flash` request and ~1.03% per `glm-5.3` request, so roughly 395 flash or 97 glm-5.3 prompts per window regardless of how large each prompt is.

Prefix caching therefore has no effect on the quota, and suppressing auto-recall costs all three agents their memory for no saving. The `prependContext` placement is still a genuine defect — it costs prefill latency and would matter on a credit-metered plan — and remains filed upstream.