### PR TITLE
feat(litellm): force effort max on gpt-5.6-luna

### DIFF
--- a/kubernetes/apps/base/llm/litellm/models/chatgpt-gpt-5.6-luna.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/chatgpt-gpt-5.6-luna.yaml
@@ -11,6 +11,9 @@ spec:
     additional:
       additional_drop_params:
       - temperature
+      extra_body:
+        reasoning:
+          effort: max
   info:
     mode: responses
     maxInputTokens: 1050000


### PR DESCRIPTION
`reasoning-pool-1` already pins `effort: max`, but a direct call to `chatgpt/gpt-5.6-luna` inherited whatever the client sent — so the same model behaved differently depending on which name was used. Benching the bare model scored it at medium effort, which nothing in the stack actually runs. This makes the two paths agree.

Note it also raises effort for the direct consumers of that name: the zed favourite, the `gpt-cheap` alias in the OpenClaw catalogue, and the opencode model list.