### PR TITLE
feat(llm): serve Flash-Next on Vulkan with the engram streamed from NVMe

### DIFF
--- a/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   values:
     controllers:
       comfyui:
-        replicas: 1
+        replicas: 0
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
@@ -12,7 +12,7 @@ spec:
   provider: cloud-proxy
   providerConfig:
     baseURL: http://litellm.llm:4000/v1
-    model: llama-reviewer
+    model: llama-strix
     apiKeySecretRef:
       name: foreman-agent
       key: LITELLM_API_KEY

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -8,7 +8,7 @@ spec:
   provider: cloud-proxy
   providerConfig:
     baseURL: http://litellm.llm:4000/v1
-    model: llama-reviewer
+    model: llama-strix
     apiKeySecretRef:
       name: foreman-agent
       key: LITELLM_API_KEY

--- a/kubernetes/apps/base/llm/litellm/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/kustomization.yaml
@@ -9,11 +9,11 @@ resources:
   - ./virtualkeys
   - ./llama-nvidia.yaml
   # - ./llama-nvidia-muse.yaml
-  # - ./llama-flash-next.yaml
-  - ./llama-strix.yaml
+  - ./llama-flash-next.yaml
+  # - ./llama-strix.yaml
   # - ./llama-strix-dsv4f.yaml
   # - ./llama-strix-fp8.yaml
-  - ./llama-reviewer.yaml
+  # - ./llama-reviewer.yaml
   - ./llama-vision.yaml
   - ./prometheusrule.yaml
   - ./llmkube-skirk-cache.yaml

--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -32,7 +32,7 @@ spec:
   modelCache:
     claimName: llmkube-skirk-cache
   runtime: llamacpp
-  image: docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.14-qwen-3.8-flash-next@sha256:88fb04a0d5d4d9b10f1d334e310f3fd109f70742cb3138161e53f3856d4131fa
+  image: docker.io/kyuz0/amd-strix-halo-toolboxes:vulkan-radv@sha256:3048ccb03134311307db7eac895ba329f0fd0ba2e0d3a65e923dfbd2b5d9ec3d
   rolloutPolicy:
     waitForIdle: true
     idleTimeoutSeconds: 86400
@@ -86,6 +86,8 @@ spec:
     - "8"
     - --threads-batch
     - "16"
+    - --tensor-read-lazy
+    - "on"
     - --load-mode
     - none
     - --chat-template-kwargs


### PR DESCRIPTION
Both upstream gates landed today: qwen4exp merged at 20:42Z, and TENSOR_READ_LAZY merged at 13:14Z with `qwen4exp.cpp` already flagging its engram tensor, so the 26.82 GiB n-gram table streams from NVMe instead of sitting resident and Flash-Next should drop from 101.3 GiB to roughly 74. kyuz0's `vulkan-radv` rebuilt at 22:15Z from commit `e70802a01` — verified rather than assumed, in that `src/models/qwen4exp.cpp` exists at that commit and carries the flag, and the shipped binary lists `--tensor-read-lazy` in its own help. Vulkan-RADV is the reason for the swap since it beats ROCm by roughly 50% on decode at depth on Strix Halo, and the flag is set to `"on"` rather than left at the `auto` default which only goes lazy above 4 GiB; the serving config is otherwise untouched (same three UD-Q3_K_XL shards, 262144 across 2 slots, f16 KV, `--load-mode none`). Strix cannot hold this and the reviewer, so `llama-strix` and `llama-reviewer` leave the kustomization, comfyui scales to zero and Foreman's two review lanes fall back to `llama-strix`. Two things to check after rollout rather than trust: whether lazy reads hold up over the Ceph-backed model cache, since that is the same random-read pattern that cold-faulted at 0.27 tok/s under `--mmap`, and whether decode actually improves — ngxson measured -8% TG from lazy reads on gemma, so this change buys memory and Vulkan has to buy the speed.