### PR TITLE
feat(llama-strix): EngramHalo build with the MTP draft head

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -22,6 +22,22 @@ spec:
           resourceClaimTemplateName: llama-strix-gpu
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: llama-strix-mtp
+spec:
+  source: hf://EasiiX/Qwen3.8-Flash-Next-MTP-Strix-Halo-GGUF
+  files:
+    - mtp-Qwen3.8-Flash-Next-Q8_0.gguf
+  format: gguf
+  quantization: Q8_0
+  hardware:
+    accelerator: rocm
+    gpu:
+      enabled: true
+      vendor: amd
+---
+apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
 metadata:
   name: llama-strix
@@ -29,10 +45,15 @@ metadata:
     krr/ignore: "true"
 spec:
   modelRef: llama-strix
+  speculativeDecoding:
+    type: draft-mtp
+    draftModelRef: llama-strix-mtp
+    nDraftMax: 4
+    pMin: 0.75
   modelCache:
     claimName: llmkube-skirk-cache
   runtime: llamacpp
-  image: docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:1c655ca0443655f2e7603d054770b07cd8c79267145728b3261295f005053947
+  image: ghcr.io/joryirving/engramhalo:rocm-gfx1151@sha256:35621b72a8b37ab4a6aae77a28baf3ec7d92ec0688cb604b1df4ecf952e72ac5
   rolloutPolicy:
     waitForIdle: false
     idleTimeoutSeconds: 86400


### PR DESCRIPTION
Custom ROCm image built from `Aristo94/EngramHalo.cpp` at `b08a77760` (branch `strix-halo-qwen4exp`, gfx1151 only), pushed to `ghcr.io/joryirving/engramhalo:rocm-gfx1151` and public. That fork carries three things stock master does not: the qwen4exp MTP draft head (`#27739` closed unmerged when `#27742` superseded it, and `qwen4exp.cpp` on master still has zero MTP references), two ROCm kernel fixes — the sparse-attention indexer's `top_k` ran on CPU 12x per token, and sparse attention ran dense with a mask instead of gathering the 2048 selected KV rows — and `877d1046b`, which drops page cache behind uploaded tensors during load. That last one is the fix for the load deadlock we hit, where file pages and the device buffer both come out of the same UMA pool and the server never finishes init.

The draft weights need their own Model CR because `files:` entries are repo-relative to a single `Source` and the sidecar lives in a different HF repo; `speculativeDecoding.draftModelRef` resolves the staged path itself so the manifest never names a content-hash cache directory. `--load-mode` stays `none` on purpose — lazy read is inert and the engram stays resident at 27.5 GiB, because this change tests MTP alone and mmap is a separate step. Upstream reports 34.6 t/s decode on code against a 23.5 stock baseline at 85% acceptance on an IQ3_XXS target; ours measures 14.0 on Q3_K_XL at 2 slots x 262144, so expect the shape of the gain rather than the number.