### PR TITLE
feat(llm): Flash-Next on the Vulkan fork with native MTP speculative decoding

### DIFF
--- a/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   values:
     controllers:
       comfyui:
-        replicas: 1
+        replicas: 0
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/base/llm/litellm/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/kustomization.yaml
@@ -9,12 +9,12 @@ resources:
   - ./virtualkeys
   - ./llama-nvidia.yaml
   # - ./llama-nvidia-muse.yaml
-  # - ./llama-flash-next.yaml
-  - ./llama-strix.yaml
+  - ./llama-flash-next.yaml
+  # - ./llama-strix.yaml
   # - ./llama-strix-dsv4f.yaml
   # - ./llama-strix-fp8.yaml
-  - ./llama-reviewer.yaml
-  - ./llama-vision.yaml
+  # - ./llama-reviewer.yaml
+  # - ./llama-vision.yaml
   - ./prometheusrule.yaml
   - ./llmkube-skirk-cache.yaml
   - ./servicemonitor.yaml

--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -12,10 +12,11 @@ spec:
   format: gguf
   quantization: UD-Q3_K_XL
   hardware:
-    accelerator: rocm
+    accelerator: vulkan
     gpu:
       enabled: true
       vendor: amd
+      runtime: vulkan
       layers: 99
       resourceClaims:
         - name: gpu
@@ -32,10 +33,11 @@ spec:
   format: gguf
   quantization: Q8_0
   hardware:
-    accelerator: rocm
+    accelerator: vulkan
     gpu:
       enabled: true
       vendor: amd
+      runtime: vulkan
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
@@ -48,7 +50,7 @@ spec:
   modelCache:
     claimName: llmkube-skirk-cache
   runtime: llamacpp
-  image: docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:1c655ca0443655f2e7603d054770b07cd8c79267145728b3261295f005053947
+  image: ghcr.io/joryirving/llama-qwen4exp:0.1.0@sha256:2f83a3eb050207bc2776e180edd4d99ee8390fc13245bfeb27e1b6fae9a28ae3
   rolloutPolicy:
     waitForIdle: false
     idleTimeoutSeconds: 86400
@@ -63,18 +65,20 @@ spec:
       operator: Exists
       effect: NoSchedule
   contextSize: 262144
-  parallelSlots: 2
+  parallelSlots: 1
   flashAttention: true
   jinja: true
-  cacheTypeK: f16
-  cacheTypeV: f16
+  speculativeDecoding:
+    type: draft-mtp
+    draftModelRef: llama-strix-mtp
+    nDraftMax: 6
+    pMin: 0.75
+  cacheTypeK: q8_0
+  cacheTypeV: q8_0
   reasoningBudget: 16384
   reasoningBudgetMessage: "Stop reasoning and produce the implementation, tool call, or final answer."
   batchSize: 6144
   uBatchSize: 2048
-  env:
-    - name: ROCBLAS_USE_HIPBLASLT
-      value: "1"
   resources:
     cpu: "500m"
     memory: 16Gi
@@ -105,12 +109,7 @@ spec:
     - "8"
     - --threads-batch
     - "16"
-    - --tensor-read-lazy
-    - "on"
-    - -lv
-    - "4"
-    - --load-mode
-    - none
+    - --no-mmap
     - --chat-template-kwargs
     - '{"preserve_thinking":true}'
   probeOverrides:

--- a/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
@@ -18,7 +18,7 @@ resources:
   - ./kimi-k2.7-1.yaml
   - ./kimi-k3-1.yaml
   - ./llama-nvidia-chat.yaml
-  - ./llama-reviewer-chat.yaml
+  # - ./llama-reviewer-chat.yaml
   - ./llama-strix-chat.yaml
   - ./minimax-m2.7.yaml
   - ./minimax-m3-chat.yaml


### PR DESCRIPTION
Moves llama-strix onto a build of `apepojken/llama.cpp` `qwen4exp-spec-mtp`, which sits on top of the upstream qwen4_exp work merged to llama.cpp mainline on 2026-08-27 and adds fixes for seven stacked speculative-decoding bugs plus a native implementation of the model's 4B MTP head that public GGUFs strip — the 3.85GiB `llama-strix-mtp` sidecar has been defined but unwired until now, and becomes the draft model. Vulkan/RADV measures faster than ROCm at every depth on this architecture so both Models move to the vulkan accelerator/runtime (dropping the ROCm-only `ROCBLAS_USE_HIPBLASLT`, and the `--no-mmap` in the image CMD retires the `--tensor-read-lazy`/`--load-mode none` UMA workaround), `--spec-draft-n-max` is pinned at 6 because the Vulkan mat-vec shaders batch at most 8 columns against verify batches of n-max+1, and the fork serves a single slot only. Q3_K_XL wants the whole box, so comfyui scales to zero and llama-strix (Ornith), llama-reviewer and llama-vision drop out of the kustomization along with the now-dangling llama-reviewer-chat entry.