### PR TITLE
fix(llama-strix): call llama-server by absolute path

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -55,7 +55,7 @@ spec:
     waitForIdle: false
     idleTimeoutSeconds: 86400
   command:
-    - llama-server
+    - /app/llama-server
   replicas: 1
   priority: high
   nodeSelector:


### PR DESCRIPTION
llama-strix is in CrashLoopBackOff with empty logs — the container fails at init, before llama.cpp writes anything, with `exec: "llama-server": executable file not found in $PATH`. The fork image copies its binaries to `/app` and points ENTRYPOINT at `/app/llama-server`, without the `/usr/bin/llama-server` symlink the kyuz0 toolbox ships and without `/app` on PATH, so the bare command name we carried over no longer resolves.