### PR TITLE
fix(llama-strix): use the MTP sidecar the Vulkan fork expects

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -27,9 +27,9 @@ kind: Model
 metadata:
   name: llama-strix-mtp
 spec:
-  source: hf://EasiiX/Qwen3.8-Flash-Next-MTP-Strix-Halo-GGUF
+  source: hf://jockevaupptaget/Qwen3.8-Flash-Next-MTP-GGUF
   files:
-    - mtp-Qwen3.8-Flash-Next-Q8_0.gguf
+    - mtp-Qwen-Qwen3.8-Flash-Next-Q8_0.gguf
   format: gguf
   quantization: Q8_0
   hardware:


### PR DESCRIPTION
llama-strix fails to load with `check_tensor_dims: tensor 'blk.48.nextn.fc_embd.weight' not found` — the MTP head tensors aren't where the loader expects them. The sidecar we point at is EasiiX's, which is built for the EngramHalo ROCm fork and is a genuinely different artifact from the one this Vulkan fork documents (4137429088 bytes against 4135893184), so it doesn't satisfy this loader. Points the Model at `jockevaupptaget/Qwen3.8-Flash-Next-MTP-GGUF`, which is the build the fork was developed and benchmarked against.