### PR TITLE
perf(llama-strix): offload the MTP draft head to the GPU

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -110,6 +110,8 @@ spec:
     - --threads-batch
     - "16"
     - --no-mmap
+    - --spec-draft-ngl
+    - "999"
     - --chat-template-kwargs
     - '{"preserve_thinking":true}'
   probeOverrides:


### PR DESCRIPTION
llmkube passes `-md` for the draft model but never `--spec-draft-ngl`, so the 4B MTP head defaults to CPU and puts a host round-trip inside every speculative step — the fork's own recommended invocation sets it to 999. Baseline before this change, measured at ~1.45k prompt depth over three runs: prefill 340 tok/s (333-344), decode 31.8 tok/s (29.5-33.3), with 203 of 256 output tokens arriving via the draft, so the head is drafting correctly and this is purely about where it executes.