### PR TITLE
perf(llama-strix): stream the n-gram table from NVMe again

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -109,7 +109,10 @@ spec:
     - "8"
     - --threads-batch
     - "16"
-    - --no-mmap
+    - --load-mode
+    - mmap
+    - --tensor-read-lazy
+    - "on"
     - --chat-template-kwargs
     - '{"preserve_thinking":true}'
   probeOverrides:


### PR DESCRIPTION
Restores `--load-mode mmap` + `--tensor-read-lazy on`, which I dropped when moving to the Vulkan fork on the mistaken basis that they were a UMA workaround made redundant by `--no-mmap` — they were actually what kept the 51B engram table file-backed on local NVMe rather than resident. Streaming measured 11 tok/s previously, but that predates both the fork's kernel work and MTP speculative decoding, and MTP is precisely what should amortise the random reads that make streaming slow: roughly 6 tokens are drafted per verify step at ~0.79 acceptance, so their n-gram rows are known upfront and batch rather than blocking one read per token. Current resident baseline for comparison is 33.0 tok/s decode and ~340 tok/s prefill at 1.45k depth, with GTT at 64.3GiB and RSS at 27.6GiB; if streaming lands close to that it frees tens of GiB and vision and comfyui can come back to skirk.