### PR TITLE
feat(llm): bring vision and comfyui back onto skirk

### DIFF
--- a/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
@@ -13,7 +13,7 @@ spec:
   values:
     controllers:
       comfyui:
-        replicas: 0
+        replicas: 1
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/base/llm/litellm/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
   # - ./llama-strix-dsv4f.yaml
   # - ./llama-strix-fp8.yaml
   # - ./llama-reviewer.yaml
-  # - ./llama-vision.yaml
+  - ./llama-vision.yaml
   - ./prometheusrule.yaml
   - ./llmkube-skirk-cache.yaml
   - ./servicemonitor.yaml


### PR DESCRIPTION
Streaming the 51B engram table from NVMe drops llama-strix's process RSS from 27.6GiB to 1.2GiB and turns it into reclaimable page cache, for a measured 7.6% decode cost (33.0 to 30.5 tok/s at 1.45k depth, with MTP drafting taking streaming from the old 11 tok/s up to 30.5). That reclaimable headroom is exactly what kept these two off the box, so this restores llama-vision to the kustomization and scales comfyui back to one replica. Worth noting the eviction path is untested until something genuinely competes for memory — that is the point of putting them back, and the sweep gets re-run afterwards to confirm decode holds when the kernel actually has to evict engram pages.