### PR TITLE
revert: llama-flash-next parallelSlots back to 1

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -67,7 +67,7 @@ spec:
       operator: Exists
       effect: NoSchedule
   contextSize: 262144
-  parallelSlots: 2
+  parallelSlots: 1
   flashAttention: true
   jinja: true
   speculativeDecoding:


### PR DESCRIPTION
Crashloops with `--parallel 2` + draft-mtp — boots healthy, dies on first generation request. Restore service while the fork-side fix is worked; re-land slots=2 with a fixed image.