### PR TITLE
fix(foreman): give the infra probe a key, and open coder PRs ready for review

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/externalsecret.yaml
@@ -14,6 +14,17 @@ spec:
       engineVersion: v2
       data:
         DISPATCH_AGENT_TOKEN: "{{ .DISPATCH_AGENT_TOKEN }}"
+        # The infra probe asks LiteLLM whether a model that failed a Workload
+        # is answering again, and redrives the parked issue when it is. Without
+        # a key it sends no Authorization header, LiteLLM returns 401, every
+        # model reads as unhealthy, and infra-parked work can never recover —
+        # the probe is the only thing that says "the backend is back".
+        #
+        # Same key the coder agents use (foreman/app/externalsecret.yaml), so
+        # it is already scoped to exactly the models they run against.
+        INFRA_PROBE_API_KEY: "{{ .LITELLM_FOREMAN_API_KEY }}"
   dataFrom:
     - extract:
         key: dispatch
+    - extract:
+        key: litellm

--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -4,6 +4,12 @@ kind: Agent
 metadata:
   name: coder-frontier
 spec:
+  # LLMKube 0.9.23 began opening every Foreman PR as a draft, and our AI PR
+  # reviewer skips drafts by design (ai-pr-review.yaml gates on
+  # `!github.event.pull_request.draft`), which is the normal reading of what a
+  # draft means. That inserted a manual "mark ready" step into an unattended
+  # loop. Requested upstream as LLMKube#1706 and shipped in 0.9.24 (#1707).
+  openPullRequestsAsDraft: false
   role: coder
   provider: cloud-proxy
   providerConfig:

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -4,6 +4,12 @@ kind: Agent
 metadata:
   name: coder-revision
 spec:
+  # LLMKube 0.9.23 began opening every Foreman PR as a draft, and our AI PR
+  # reviewer skips drafts by design (ai-pr-review.yaml gates on
+  # `!github.event.pull_request.draft`), which is the normal reading of what a
+  # draft means. That inserted a manual "mark ready" step into an unattended
+  # loop. Requested upstream as LLMKube#1706 and shipped in 0.9.24 (#1707).
+  openPullRequestsAsDraft: false
   role: coder
   provider: cloud-proxy
   providerConfig:

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -4,6 +4,12 @@ kind: Agent
 metadata:
   name: coder
 spec:
+  # LLMKube 0.9.23 began opening every Foreman PR as a draft, and our AI PR
+  # reviewer skips drafts by design (ai-pr-review.yaml gates on
+  # `!github.event.pull_request.draft`), which is the normal reading of what a
+  # draft means. That inserted a manual "mark ready" step into an unattended
+  # loop. Requested upstream as LLMKube#1706 and shipped in 0.9.24 (#1707).
+  openPullRequestsAsDraft: false
   role: coder
   provider: cloud-proxy
   providerConfig:


### PR DESCRIPTION
Two foreman fixes, both config-only, both restoring unattended operation.

## 1. The infra probe has never had a key

`INFRA_PROBE_API_KEY` has never appeared anywhere in this repo's history, while the probe defaults to **enabled** and defaults the key to empty — so it sends no `Authorization` header:

```
infra-model-unhealthy
  error=401 Client Error: Unauthorized for url: http://litellm.llm:4000/v1/chat/completions
899:infra-unhealthy:name:15
897:infra-unhealthy:name:34
```

The probe is what asks whether a model that killed a Workload is answering again, and redrives the parked issue once it is. If it can never succeed, infra-parked work can never recover, because nothing else makes that call. The attempt counters above — 15 and 34 on held workloads — show how long it has been looping.

It now uses `LITELLM_FOREMAN_API_KEY`, the same key the coder agents already take from the `litellm` item (`foreman/app/externalsecret.yaml:17`), so it is already scoped to exactly the models it needs to test. No new secret or virtual key.

## 2. Coder PRs open ready for review

LLMKube 0.9.23 (#1703) began opening every Foreman PR as a draft. Our AI PR reviewer skips drafts by design — `ai-pr-review.yaml` gates on `!github.event.pull_request.draft`, which is the normal reading of what a draft means, and that workflow also serves human PRs so changing it there would be wrong.

The result was a manual "mark ready" step per PR in a loop meant to be unattended: foreman opened a draft, nothing reviewed it, and it waited for a person.

Requested upstream as [LLMKube#1706](https://github.com/defilantech/LLMKube/issues/1706) and shipped in 0.9.24 ([#1707](https://github.com/defilantech/LLMKube/pull/1707)) as a per-Agent field defaulting to `true`, so this opts us out explicitly. Set on the three agents that open PRs; gates and reviewers do not.

## After this

`infra-model-unhealthy` should stop appearing in the bridge logs and the held workloads should redrive, and new coder PRs should arrive ready for review and get reviewed without intervention.

## Note

The 401 log lines report `"model":"name"`, but `infra_model_from_labels` returns `"unknown"` when no model label is present and never `"name"` — that looks like a logging artifact, and a wrong model name would give a 400 or 404 rather than the 401 we see. Easier to judge once the probe is authenticating; not what is breaking this.