### PR TITLE
perf(llama-strix): 0.4.5 PLE direct reads, --lazy-mode on-direct

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -52,7 +52,7 @@ spec:
   modelCache:
     claimName: llmkube-skirk-cache
   runtime: llamacpp
-  image: ghcr.io/joryirving/llama-qwen4exp:0.4.4@sha256:5baf044f1eb2d5cba4cff9056231130503436c94bdbb178b4b711359760b73c8
+  image: ghcr.io/joryirving/llama-qwen4exp:0.4.5@sha256:c86d62b7f3db7925130bfa8c80fd622c43fc87967be7dc19a4486398535acbdb
   rolloutPolicy:
     waitForIdle: false
     idleTimeoutSeconds: 86400
@@ -116,7 +116,7 @@ spec:
     - --load-mode
     - mmap
     - --lazy-mode
-    - "on"
+    - on-direct
     - --chat-template-kwargs
     - '{"preserve_thinking":true}'
   probeOverrides:


### PR DESCRIPTION
Bumps llama-strix to `0.4.5` (adds the upstream llama.cpp PLE direct-read patch on top of the current fable-loadfix tree) and switches `--lazy-mode on` to `on-direct`: `on` demand-pages the ~20GB PLE table through mmap and leaves those pages resident in the Strix UMA pool, whereas `on-direct` reads the gathered rows with explicit `pread()`s, recovering the RAM and speeding up deep prefill. Not yet gated against the deep-prefill segfault, so watch the `PLE direct read enabled` load line and test a ~68k prompt after the swap.