### PR TITLE
feat(llama-strix): adopt myhacsint production fork, UD-IQ4_XS + shared MTP

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -36,7 +36,7 @@ spec:
   modelCache:
     claimName: llmkube-skirk-cache
   runtime: llamacpp
-  image: ghcr.io/joryirving/llama-qwen4exp:0.5.0
+  image: ghcr.io/joryirving/llama-qwen4exp:0.5.0@sha256:f0e5f96bfdf87551699875ed4638548df919b2bad4f0ae3cd4a878a091472ae0
   rolloutPolicy:
     waitForIdle: false
     idleTimeoutSeconds: 86400

--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -9,6 +9,7 @@ spec:
     - UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf
     - UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00002-of-00003.gguf
     - UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00003-of-00003.gguf
+    - MTP/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf
     - mmproj-F16.gguf
   mmproj: mmproj-F16.gguf
   format: gguf
@@ -23,23 +24,6 @@ spec:
       resourceClaims:
         - name: gpu
           resourceClaimTemplateName: llama-strix-gpu
----
-apiVersion: inference.llmkube.dev/v1alpha1
-kind: Model
-metadata:
-  name: llama-strix-mtp
-spec:
-  source: hf://unsloth/Qwen3.8-Flash-Next-GGUF
-  files:
-    - MTP/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf
-  format: gguf
-  quantization: Q8_0
-  hardware:
-    accelerator: vulkan
-    gpu:
-      enabled: true
-      vendor: amd
-      runtime: vulkan
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
@@ -72,14 +56,14 @@ spec:
   jinja: true
   speculativeDecoding:
     type: draft-mtp
-    draftModelRef: llama-strix-mtp
+    draftModel: MTP/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf
     nDraftMax: 7
     pMin: 0.75
   cacheTypeK: q8_0
   cacheTypeV: q8_0
   reasoningBudget: 16384
   reasoningBudgetMessage: "Stop reasoning and produce the implementation, tool call, or final answer."
-  batchSize: 2048
+  batchSize: 4096
   uBatchSize: 2048
   resources:
     cpu: "500m"

--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -101,6 +101,8 @@ spec:
     - mmap
     - --tensor-read-lazy
     - auto
+    - --chat-template-kwargs
+    - '{"reasoning_effort":"medium"}'
     - --reasoning-preserve
     - --no-host
     - --no-repack

--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -6,13 +6,13 @@ metadata:
 spec:
   source: hf://unsloth/Qwen3.8-Flash-Next-GGUF
   files:
-    - UD-Q3_K_XL/Qwen3.8-Flash-Next-UD-Q3_K_XL-00001-of-00003.gguf
-    - UD-Q3_K_XL/Qwen3.8-Flash-Next-UD-Q3_K_XL-00002-of-00003.gguf
-    - UD-Q3_K_XL/Qwen3.8-Flash-Next-UD-Q3_K_XL-00003-of-00003.gguf
+    - UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf
+    - UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00002-of-00003.gguf
+    - UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00003-of-00003.gguf
     - mmproj-F16.gguf
   mmproj: mmproj-F16.gguf
   format: gguf
-  quantization: UD-Q3_K_XL
+  quantization: UD-IQ4_XS
   hardware:
     accelerator: vulkan
     gpu:
@@ -29,9 +29,9 @@ kind: Model
 metadata:
   name: llama-strix-mtp
 spec:
-  source: hf://jockevaupptaget/Qwen3.8-Flash-Next-MTP-GGUF
+  source: hf://unsloth/Qwen3.8-Flash-Next-GGUF
   files:
-    - mtp-Qwen-Qwen3.8-Flash-Next-Q8_0.gguf
+    - MTP/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf
   format: gguf
   quantization: Q8_0
   hardware:
@@ -52,7 +52,7 @@ spec:
   modelCache:
     claimName: llmkube-skirk-cache
   runtime: llamacpp
-  image: ghcr.io/joryirving/llama-qwen4exp:0.4.5@sha256:c86d62b7f3db7925130bfa8c80fd622c43fc87967be7dc19a4486398535acbdb
+  image: ghcr.io/joryirving/llama-qwen4exp:0.5.0
   rolloutPolicy:
     waitForIdle: false
     idleTimeoutSeconds: 86400
@@ -73,13 +73,13 @@ spec:
   speculativeDecoding:
     type: draft-mtp
     draftModelRef: llama-strix-mtp
-    nDraftMax: 6
+    nDraftMax: 7
     pMin: 0.75
   cacheTypeK: q8_0
   cacheTypeV: q8_0
   reasoningBudget: 16384
   reasoningBudgetMessage: "Stop reasoning and produce the implementation, tool call, or final answer."
-  batchSize: 6144
+  batchSize: 2048
   uBatchSize: 2048
   resources:
     cpu: "500m"
@@ -115,9 +115,14 @@ spec:
     - "16"
     - --load-mode
     - mmap
-    - --lazy-mode
-    - on-direct
+    - --tensor-read-lazy
+    - auto
     - --reasoning-preserve
+    - --no-host
+    - --no-repack
+    - --spec-draft-adaptive
+    - --spec-draft-n-min
+    - "0"
   probeOverrides:
     startup:
       httpGet:


### PR DESCRIPTION
Moves llama-strix onto the production-tested myhacsint Strix Halo qwen4exp fork (image `0.5.0@sha256:f0e5f96b`) to fix the ~20GB resident-PLE and, hopefully, the idle SIGSEGV crashloop. Switches the model to `UD-IQ4_XS`, folds the official Unsloth `shared-Q8_0` MTP sidecar into the target model (staged via `files:`, referenced by `speculativeDecoding.draftModel` / `-md`, retiring the separate jockevaupptaget Model CR), and adopts their `--tensor-read-lazy auto` lazy path plus `--no-host --no-repack` and adaptive MTP draft sizing; context stays 262144, batch 4096 / ubatch 2048. All nine runtime flags were verified accepted against the built binary. Honest caveat: their "cancel child generation on disconnect" fix lives in the multi-model router path, no upstream fix targets an idle segfault specifically, and PR 27879/27909 are not evidenced in the tree — so the real proof is a post-merge idle soak. What we know for certain: it fixes the 20GB and drops all 16 of our local RADV patches, which were the prime segv suspect.