### PR TITLE
feat(litellm): cap each local-pool rung at its backend's slot count

### DIFF
--- a/kubernetes/apps/base/llm/litellm/models/local-pool-1.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-1.yaml
@@ -16,6 +16,7 @@ spec:
       top_k: 20
       min_p: 0
       order: 1
+      max_parallel_requests: 1
   info:
     mode: chat
     maxInputTokens: 131072

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-1.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-1.yaml
@@ -16,7 +16,7 @@ spec:
       top_k: 20
       min_p: 0
       order: 1
-      max_parallel_requests: 1
+      max_parallel_requests: 2
   info:
     mode: chat
     maxInputTokens: 131072

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-2.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-2.yaml
@@ -15,6 +15,7 @@ spec:
       top_p: 0.95
       top_k: 64
       order: 2
+      max_parallel_requests: 4
   info:
     mode: chat
     maxInputTokens: 262144

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-3.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-3.yaml
@@ -16,6 +16,7 @@ spec:
       top_k: 20
       min_p: 0
       order: 3
+      max_parallel_requests: 2
   info:
     mode: chat
     maxInputTokens: 262144

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-chat-1.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-chat-1.yaml
@@ -16,6 +16,7 @@ spec:
       presence_penalty: 1.5
       reasoning_effort: none
       order: 1
+      max_parallel_requests: 2
       allowed_openai_params:
         - reasoning_effort
   info:

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-chat-2.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-chat-2.yaml
@@ -16,6 +16,7 @@ spec:
       top_k: 64
       reasoning_effort: none
       order: 2
+      max_parallel_requests: 4
       allowed_openai_params:
         - reasoning_effort
   info:

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-chat-3.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-chat-3.yaml
@@ -17,6 +17,7 @@ spec:
       repetition_penalty: 1.0
       reasoning_effort: none
       order: 3
+      max_parallel_requests: 2
       allowed_openai_params:
         - reasoning_effort
   info:


### PR DESCRIPTION
Sets `max_parallel_requests` on every rung of `local-pool` and `local-pool-chat` to the backend's real slot count: nvidia 2, gemma 4, strix 2. A full rung is then skipped and the next `order` is used, instead of queueing on the busy server.

`enable_pre_call_checks: true` is already set (`litellmproxy.yaml:97`), so an at-capacity deployment is filtered out *before* selection — no 429, no cooldown.

Caveat: the counter is per deployment entry, not per backend. The foreman coder reaches nvidia through the auto-registered bare `llama-nvidia` alias, which has no CR and so cannot be capped; it keeps its own counter. nvidia can still be oversubscribed by one.

https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh