### PR TITLE
feat(llm): wake Gemma host on request

### DIFF
--- a/kubernetes/apps/base/llm/gemma-wake/README.md
+++ b/kubernetes/apps/base/llm/gemma-wake/README.md
@@ -1,0 +1,23 @@
+# Gemma wake proxy
+
+This app fronts the Windows `smurf-pc` LM Studio server with a Wake-on-LAN
+reverse proxy. It is intentionally limited to the Gemma LiteLLM routes; the
+ComfyUI `:8188` endpoints remain direct.
+
+The proxy runs with host networking because Wake-on-LAN packets must leave on
+the cluster node's LAN interface. Keep the service internal and do not add an
+external route.
+
+The target values below were observed on 2026-09-01 and must remain aligned
+with the Windows PC's DHCP reservation:
+
+- 10G SFP traffic address: `192.168.30.14`
+- built-in 1G WoL MAC: `b4:2e:99:3e:2c:f3`
+- 1G WoL broadcast: `192.168.30.255`
+
+The MAC and address intentionally belong to different NICs: WoL targets the
+built-in 1G adapter, while liveness checks and LM Studio requests use the 10G
+SFP adapter.
+
+The proxy only wakes the PC. Windows power management remains responsible for
+putting it to sleep; no shutdown command is configured.

--- a/kubernetes/apps/base/llm/gemma-wake/configmap.yaml
+++ b/kubernetes/apps/base/llm/gemma-wake/configmap.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#configmap-v1-core
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gemma-wake-config
+data:
+  config.toml: |
+    port = ":8080"
+    timeout = "5m"
+    response_header_timeout = "20m"
+    poll_interval = "5s"
+    health_check_interval = "30s"
+    health_cache_duration = "10s"
+
+    [[machines]]
+    name = "smurf-pc"
+    # Wake-on-LAN uses the built-in 1G NIC.
+    mac_address = "b4:2e:99:3e:2c:f3"
+    broadcast_ip = "192.168.30.255"
+    wol_port = 9
+    # Liveness uses the 10G SFP NIC, which carries LM Studio traffic.
+    health_check = "tcp://192.168.30.14:1234"
+
+    [[routes]]
+    machine = "smurf-pc"
+    hostname = "gemma-wake.llm"
+    # Proxy traffic uses the 10G SFP NIC rather than the WoL NIC.
+    destination = "http://192.168.30.14:1234"
+    health_check = "tcp://192.168.30.14:1234"

--- a/kubernetes/apps/base/llm/gemma-wake/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/gemma-wake/helmrelease.yaml
@@ -1,0 +1,75 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gemma-wake
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gemma-wake
+  interval: 15m
+  dependsOn: []
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      securityContext:
+        fsGroup: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+    controllers:
+      gemma-wake:
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/darksworm/doormouse
+              tag: latest@sha256:36673ebe28bb235d434964d7129b1285f98827f6da166c2234c2108c858a4e25
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  failureThreshold: 6
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              readOnlyRootFilesystem: true
+    persistence:
+      config:
+        type: configMap
+        name: gemma-wake-config
+        globalMounts:
+          - path: /app/config.toml
+            subPath: config.toml
+            readOnly: true
+    service:
+      app:
+        controller: gemma-wake
+        ports:
+          http:
+            port: 8080

--- a/kubernetes/apps/base/llm/gemma-wake/kustomization.yaml
+++ b/kubernetes/apps/base/llm/gemma-wake/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/gemma-wake/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/gemma-wake/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gemma-wake
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/litellm/models/llama-reviewer-chat.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/llama-reviewer-chat.yaml
@@ -8,7 +8,7 @@ spec:
   proxyRef: litellm
   params:
     model: openai/gemma-4-12b-it-qat
-    apiBase: http://smurf-pc.internal:1234/v1
+    apiBase: http://gemma-wake.llm:8080/v1
     apiKey: sk-noauth
     additional:
       temperature: 1.0

--- a/kubernetes/apps/base/llm/litellm/models/llama-reviewer.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/llama-reviewer.yaml
@@ -8,7 +8,7 @@ spec:
   proxyRef: litellm
   params:
     model: openai/gemma-4-12b-it-qat
-    apiBase: http://smurf-pc.internal:1234/v1
+    apiBase: http://gemma-wake.llm:8080/v1
     apiKey: sk-noauth
     additional:
       temperature: 1.0

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-2.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-2.yaml
@@ -8,7 +8,7 @@ spec:
   proxyRef: litellm
   params:
     model: openai/gemma-4-12b-it-qat
-    apiBase: http://smurf-pc.internal:1234/v1
+    apiBase: http://gemma-wake.llm:8080/v1
     apiKey: sk-noauth
     additional:
       temperature: 1.0

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-chat-2.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-chat-2.yaml
@@ -8,7 +8,7 @@ spec:
   proxyRef: litellm
   params:
     model: openai/gemma-4-12b-it-qat
-    apiBase: http://smurf-pc.internal:1234/v1
+    apiBase: http://gemma-wake.llm:8080/v1
     apiKey: sk-noauth
     additional:
       temperature: 1.0

--- a/kubernetes/apps/main/llm/gemma-wake.yaml
+++ b/kubernetes/apps/main/llm/gemma-wake.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: gemma-wake
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/gemma-wake
+  postBuild:
+    substitute:
+      APP: gemma-wake
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/main/llm/kustomization.yaml
+++ b/kubernetes/apps/main/llm/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./comfyui.yaml
   - ./dispatch.yaml
   - ./foreman.yaml
+  - ./gemma-wake.yaml
   - ./hermes.yaml
   - ./litellm-operator.yaml
   - ./litellm.yaml


### PR DESCRIPTION
Adds a host-networked doormouse proxy in front of the Gemma LiteLLM routes so the sleeping Windows LM Studio host is woken only when Gemma is requested. WoL uses the built-in 1G NIC MAC `b4:2e:99:3e:2c:f3`; liveness checks and proxy traffic use the 10G SFP address `192.168.30.14`. ComfyUI remains direct and unchanged.

Validation:
- `flate test all --path ./kubernetes/clusters/main --namespace llm --no-progress` — 70 passed
- Helm render confirms host networking and Service port 8080
- Embedded TOML parses and confirms the two-NIC split

The configured WoL broadcast is `192.168.30.255`, assuming that is the 1G NIC LAN broadcast.