### PR TITLE
fix(foreman): open reviewer PRs ready for review

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
@@ -4,6 +4,7 @@ kind: Agent
 metadata:
   name: reviewer-fork
 spec:
+  openPullRequestsAsDraft: false
   role: reviewer
   # Same model as the primary reviewer, pinned to the fork agent via the
   # reviewer-fork role so it clones the fork branch and opens the cross-repo PR

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -4,6 +4,7 @@ kind: Agent
 metadata:
   name: reviewer
 spec:
+  openPullRequestsAsDraft: false
   role: reviewer
   provider: cloud-proxy
   providerConfig:


### PR DESCRIPTION
The reviewer agent opens the PR, but `openPullRequestsAsDraft: false` was only set on the three coder agents, which do not. So PRs still land as drafts and `ai-pr-review.yaml` skips them (it gates on `!draft`) — the loop stalls with no review. Live example: misospace/dispatch#905, `draft=true`, review `skipping`.

https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh