### PR TITLE
fix(gemma-wake): broadcast WoL on the node VLAN, add cold-start timeouts

### DIFF
--- a/kubernetes/apps/base/llm/gemma-wake/configmap.yaml
+++ b/kubernetes/apps/base/llm/gemma-wake/configmap.yaml
@@ -17,7 +17,7 @@ data:
     name = "smurf-pc"
     # Wake-on-LAN uses the built-in 1G NIC.
     mac_address = "b4:2e:99:3e:2c:f3"
-    broadcast_ip = "192.168.30.255"
+    broadcast_ip = "10.69.1.255"
     wol_port = 9
     # Liveness uses the 10G SFP NIC, which carries LM Studio traffic.
     health_check = "tcp://192.168.30.14:1234"

--- a/kubernetes/apps/base/llm/litellm/models/llama-reviewer-chat.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/llama-reviewer-chat.yaml
@@ -11,6 +11,8 @@ spec:
     apiBase: http://gemma-wake.llm:8080/v1
     apiKey: sk-noauth
     additional:
+      timeout: 300
+      num_retries: 3
       temperature: 1.0
       top_p: 0.95
       top_k: 64

--- a/kubernetes/apps/base/llm/litellm/models/llama-reviewer.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/llama-reviewer.yaml
@@ -11,6 +11,8 @@ spec:
     apiBase: http://gemma-wake.llm:8080/v1
     apiKey: sk-noauth
     additional:
+      timeout: 300
+      num_retries: 3
       temperature: 1.0
       top_p: 0.95
       top_k: 64

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-2.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-2.yaml
@@ -11,6 +11,8 @@ spec:
     apiBase: http://gemma-wake.llm:8080/v1
     apiKey: sk-noauth
     additional:
+      timeout: 300
+      num_retries: 3
       temperature: 1.0
       top_p: 0.95
       top_k: 64

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-chat-2.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-chat-2.yaml
@@ -11,6 +11,8 @@ spec:
     apiBase: http://gemma-wake.llm:8080/v1
     apiKey: sk-noauth
     additional:
+      timeout: 300
+      num_retries: 3
       temperature: 1.0
       top_p: 0.95
       top_k: 64


### PR DESCRIPTION
Fixes the WoL broadcast address: magic packets must go out on the originator VLAN (the UDM forwards to the target MAC), so `192.168.30.255` never reached the NIC. Uses the node subnet `10.69.1.255` instead - verified e2e waking smurf-pc from a full shutdown (48s cold boot, held request returned 200). Also adds `timeout: 300` + `num_retries: 3` to the four gemma-wake-routed models to absorb cold-start boot latency.