### PR TITLE
fix(llm): trim comfyui and rerank memory ceilings on skirk

### DIFF
--- a/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/comfyui/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
               HIP_VISIBLE_DEVICES: "0"
               ROCR_VISIBLE_DEVICES: "0"
               PYTORCH_HIP_ALLOC_CONF: "max_split_size_mb:256,garbage_collection_threshold:0.6"
-              CLI_ARGS: "--listen 0.0.0.0 --port 8188 --use-pytorch-cross-attention --disable-mmap --reserve-vram 110 --highvram"
+              CLI_ARGS: "--listen 0.0.0.0 --port 8188 --use-pytorch-cross-attention --disable-mmap --reserve-vram 114 --highvram"
             resources:
               requests:
                 cpu: 500m

--- a/kubernetes/apps/base/llm/memini/memini-rerank.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-rerank.yaml
@@ -44,8 +44,8 @@ spec:
       effect: NoSchedule
   contextSize: 8096
   parallelSlots: 2
-  batchSize: 4096
-  uBatchSize: 4096
+  batchSize: 2048
+  uBatchSize: 2048
   resources:
     cpu: "500m"
     memory: 4Gi


### PR DESCRIPTION
Lowers two pinned-memory ceilings on skirk without touching llama-strix: comfyui `--reserve-vram` 110 -> 114 drops its self-budget from a 14 GiB to a 10 GiB ceiling (SDXL uses ~7), and memini-rerank batch/ubatch 4096 -> 2048 halves compute buffers that were ~4 GiB for a 0.6B model. Skirk currently sits at 108-120 of 124.9 GiB pinned (strix GTT 77, prompt cache up to 12, comfy 14, rerank+embed 7) and OOMs when comfy renders against a full prompt cache; this buys back ~6 GiB at peak while the llama-strix indexer patch lands separately.