### PR TITLE
fix(llm): reviewer fallback to a working MiniMax alias, and address smurf-pc by name

### DIFF
--- a/kubernetes/apps/base/llm/gemma-wake/configmap.yaml
+++ b/kubernetes/apps/base/llm/gemma-wake/configmap.yaml
@@ -20,11 +20,11 @@ data:
     broadcast_ip = "10.69.1.255"
     wol_port = 9
     # Liveness uses the 10G SFP NIC, which carries LM Studio traffic.
-    health_check = "tcp://192.168.30.14:1234"
+    health_check = "tcp://smurf-pc.internal:1234"
 
     [[routes]]
     machine = "smurf-pc"
     hostname = "gemma-wake.llm"
     # Proxy traffic uses the 10G SFP NIC rather than the WoL NIC.
-    destination = "http://192.168.30.14:1234"
-    health_check = "tcp://192.168.30.14:1234"
+    destination = "http://smurf-pc.internal:1234"
+    health_check = "tcp://smurf-pc.internal:1234"

--- a/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
+++ b/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
@@ -101,7 +101,7 @@ spec:
     - llama-nvidia:
       - llama-strix
     - llama-reviewer:
-      - MiniMax-M3
+      - MiniMax-M3-chat
     - auto:
       - dsv4f
       - MiniMax-M3-chat


### PR DESCRIPTION
The `llama-reviewer` fallback pointed at `MiniMax-M3`, which 404s:

```
Error doing the fallback: litellm.APIConnectionError: MinimaxException - 404 page not found
```

`MiniMax-M3` is `minimax/MiniMax-M3` against `https://api.minimax.io/anthropic/v1/messages`; `MiniMax-M3-chat` is `openai/MiniMax-M3` against `https://api.minimax.io/v1`, declares `supportsFunctionCalling: true`, and already serves coder-frontier. Point the fallback at that one.

This only surfaced today. Fallbacks fire on failure, and gemma had never failed, so the path was never exercised — LM Studio returned four 500s around a model reload and both the primary and the failover went down together, failing `wl-misospace-alert-triage-92-review-92-0`.

Also commits the `gemma-wake` hostname change that was sitting uncommitted in the working tree.

Note: `MiniMax-M3` is still referenced by hermes (`default: MiniMax-M3`) and openclaw. If those route through litellm they hit the same 404 — not touched here, worth checking separately.

https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh