### PR TITLE
feat(llm): llama-strix 0.5.1 with chunked QSA indexer scoring

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -36,7 +36,7 @@ spec:
   modelCache:
     claimName: llmkube-skirk-cache
   runtime: llamacpp
-  image: ghcr.io/joryirving/llama-qwen4exp:0.5.0@sha256:f0e5f96bfdf87551699875ed4638548df919b2bad4f0ae3cd4a878a091472ae0
+  image: ghcr.io/joryirving/llama-qwen4exp:0.5.1@sha256:b9cbefd6cbb99cb8b1040a43061fc82534e799c443efdd2adb7ed67667082a7c
   rolloutPolicy:
     waitForIdle: false
     idleTimeoutSeconds: 86400


### PR DESCRIPTION
Bumps llama-strix to 0.5.1, which carries a fork patch that scores the QSA sparse-attention indexer in 512-token chunks instead of one pass over the whole ubatch. The indexer was building several [n_kv, n_tok] f32 tensors per full-attention layer, 2 GiB apiece at 262k context and ubatch 2048, and the worst-case reserve graph sized the Vulkan0 compute buffer at 8.5 GiB for them regardless of actual prompt depth. Selection is independent per query token so the chosen cells are identical, and the expert matmuls still run at full ubatch, so this is not a speed-for-memory trade. Context, quantization, slots, and prompt-cache settings are unchanged; `LLAMA_QSA_CHUNK=0` restores the old single-pass behaviour if needed. Rolling this out costs one prompt-cache rebuild, and the first real GPU validation of the patch is the rollout itself.