### PR TITLE
feat(llm): give llama-strix a disk-backed prompt cache

### DIFF
--- a/kubernetes/apps/base/llm/litellm/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   # - ./llama-vision.yaml
   - ./prometheusrule.yaml
   - ./llmkube-skirk-cache.yaml
+  - ./llama-strix-prompt-cache.yaml
   - ./servicemonitor.yaml
   - ./dashboard
   - ./models

--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -35,6 +35,13 @@ spec:
   modelRef: llama-strix
   modelCache:
     claimName: llmkube-skirk-cache
+  extraVolumes:
+    - name: prompt-cache
+      persistentVolumeClaim:
+        claimName: llama-strix-prompt-cache
+  extraVolumeMounts:
+    - name: prompt-cache
+      mountPath: /prompt-cache
   runtime: llamacpp
   image: ghcr.io/joryirving/llama-qwen4exp:0.5.1@sha256:b9cbefd6cbb99cb8b1040a43061fc82534e799c443efdd2adb7ed67667082a7c
   rolloutPolicy:
@@ -80,6 +87,10 @@ spec:
     - --cache-prompt
     - --cache-ram
     - "12288"
+    - --cache-dir
+    - /prompt-cache
+    - --cache-disk
+    - "49152"
     - --kv-unified
     - --temp
     - "1.0"

--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -43,7 +43,7 @@ spec:
     - name: prompt-cache
       mountPath: /prompt-cache
   runtime: llamacpp
-  image: ghcr.io/joryirving/llama-qwen4exp:0.5.1@sha256:b9cbefd6cbb99cb8b1040a43061fc82534e799c443efdd2adb7ed67667082a7c
+  image: ghcr.io/joryirving/llama-qwen4exp:0.5.2@sha256:3609f48ec167ec4644dd22e300c283a54e8d243f25c4ffa8b4ccfa9e83714ce2
   rolloutPolicy:
     waitForIdle: true
     idleTimeoutSeconds: 86400

--- a/kubernetes/apps/base/llm/litellm/llama-strix-prompt-cache.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-strix-prompt-cache.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: llama-strix-prompt-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-hostpath
+  resources:
+    requests:
+      storage: 64Gi


### PR DESCRIPTION
The prompt cache drops the oldest state when a new prompt needs room, so a long conversation that loses the race costs minutes of prefill to rebuild a multi-GiB state. Image 0.5.2 carries a fork patch adding `--cache-dir`, which writes states evicted from RAM to disk and reads them back on a later prefix match, with `--cache-disk` bounding the directory; only the state blobs move, so prefix matching still never touches disk. This mounts a dedicated 64Gi local-hostpath PVC at /prompt-cache with a 48 GiB budget, since the model cache is mounted read-only in the server container and needs its own volume. RAM stays at the 8 GiB default and the disk tier absorbs the rest, which is the right shape now that RAM is the contended resource on skirk. Verified against a small model before building: a spilled prompt restores in under a millisecond and then decodes 1 token instead of 906, byte-identical to a fresh decode, the disk budget holds the directory at its cap, and stale files from a hard kill are swept at startup.