### PR TITLE
feat(llm): llama-strix 0.5.3, prompt cache survives restarts

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -43,7 +43,7 @@ spec:
     - name: prompt-cache
       mountPath: /prompt-cache
   runtime: llamacpp
-  image: ghcr.io/joryirving/llama-qwen4exp:0.5.2@sha256:3609f48ec167ec4644dd22e300c283a54e8d243f25c4ffa8b4ccfa9e83714ce2
+  image: ghcr.io/joryirving/llama-qwen4exp:0.5.3@sha256:77d785e07e3e854e5272cc07f3be89065935f3f6def379c8b8b0a5add11344f9
   rolloutPolicy:
     waitForIdle: true
     idleTimeoutSeconds: 86400

--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -58,7 +58,7 @@ spec:
       operator: Exists
       effect: NoSchedule
   contextSize: 262144
-  parallelSlots: 2
+  parallelSlots: 1
   flashAttention: true
   jinja: true
   speculativeDecoding:
@@ -85,8 +85,6 @@ spec:
     - "1024"
     - --cont-batching
     - --cache-prompt
-    - --cache-ram
-    - "12288"
     - --cache-dir
     - /prompt-cache
     - --cache-disk


### PR DESCRIPTION
Makes the prompt cache survive restarts, and shrinks the RAM side of it now that it can.

0.5.2 spills prompt cache states to /prompt-cache but wipes the directory on shutdown and again at startup, so a rollout still cost a full re-decode of Miso's context. 0.5.3 adopts the state files whose model and context fingerprint still matches, reading each header and validating the token list against the model, while still deleting foreign, corrupt and truncated files and anything past the disk budget so a crash cannot leave the directory growing. A layout mismatch is caught by the byte count the state restore reports, so it degrades to a normal cache miss rather than bad output. Verified on a small model: 49 states adopted across a restart then 1 token decoded instead of 906, byte-identical to before the restart. With that in place a large RAM tier is no longer what protects a long conversation, so this also drops --cache-ram to the 8 GiB default and goes to a single slot, freeing the second sequence's recurrent state and per-slot working set; context depth is unchanged because --kv-unified shares the 262144 cells across slots. One caveat: the slot count is part of the fingerprint, so this particular rollout discards the spilled states once and rebuilds from the next prompt.