### PR TITLE
feat(dispatch): size groomer exploration from the local-pool window

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/helmrelease.yaml
@@ -21,6 +21,7 @@ spec:
               DISPATCH_EXCLUDED_LABELS: renovate
               DISPATCH_GROOMER_DRY_RUN: false
               DISPATCH_GROOMER_MODEL: local-pool
+              DISPATCH_GROOMER_MODEL_CONTEXT_TOKENS: 131072
               DISPATCH_GROOMER_REPO_CONTEXT_ENABLED: true
               DISPATCH_HOSTED_GROOMER_ENABLED: true
               DISPATCH_LANE_CONFIG_JSON: '{"lanes":[{"id":"local","title":"Local","claimable":true,"role":"default","description":"Local model lane (nvidia) — the default: all groomed, ready work starts here.","color":"#3b82f6"},{"id":"frontier","title":"Frontier","claimable":true,"role":"escalation","description":"Escalation lane (MiniMax-M3 via litellm) — fed by the bridge when local attempts are exhausted, not by grooming.","color":"#f97316"},{"id":"backlog","title":"Backlog","claimable":false,"description":"Needs grooming before work can start. Not directly claimable.","color":"#6b7280"}],"laneAliases":{"normal":"local","escalated":"frontier","cloud":"local"}}'


### PR DESCRIPTION
Sets `DISPATCH_GROOMER_MODEL_CONTEXT_TOKENS: 131072` so the groomer derives its exploration budget from the model window instead of the shipped `medium` preset.

131072 is `local-pool` rung 1 (llama-nvidia), the smallest of the three rungs — gemma and strix are both 262144 — so the budget fits whichever rung serves the request. That works out to roughly 157 KB of exploration, 39 KB per file, 300s.

The current 8 KB borrowed budget produced 86 `hit its byte budget` warnings and 26 timeouts across 62 runs here, with the loop stopping at ~6.8 of 12 tool calls.

Depends on misospace/dispatch#918 and a release carrying it. Merging earlier is harmless — the variable is simply ignored by 0.5.51.

https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh