### PR TITLE
feat(llm): llama-strix 0.5.5, prompt cache actually survives a restart

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -85,6 +85,8 @@ spec:
     - "1024"
     - --cont-batching
     - --cache-prompt
+    - --cache-ram
+    - "12288"
     - --cache-dir
     - /prompt-cache
     - --cache-disk

--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -43,7 +43,7 @@ spec:
     - name: prompt-cache
       mountPath: /prompt-cache
   runtime: llamacpp
-  image: ghcr.io/joryirving/llama-qwen4exp:0.5.3@sha256:77d785e07e3e854e5272cc07f3be89065935f3f6def379c8b8b0a5add11344f9
+  image: ghcr.io/joryirving/llama-qwen4exp:0.5.5@sha256:ad2cad06d11dca5f220c859369e627349925683a7d885803c760b2e7cdcc985f
   rolloutPolicy:
     waitForIdle: true
     idleTimeoutSeconds: 86400


### PR DESCRIPTION
Two fixes on top of 0.5.3, both found while checking why swapping between sessions still re-decoded. Spilling a state dropped its context checkpoints, and this architecture cannot rewind a recurrent state, so a spilled state was only reusable by an exact continuation and a client that rewrites its history re-decoded its whole prompt after every swap. Separately, keeping files across a restart only helped states that had already overflowed to disk, so a rollout still paid a full re-decode of whatever was resident, which is the common case. Checkpoints now travel with the state file, and the resident cache is flushed to disk on shutdown. Verified on gemma-3-270m, which uses SWA and therefore exercises the checkpoint path: a prompt costing 3997 tokens to decode was cached in RAM without ever spilling, flushed at shutdown, adopted on the next start and then decoded in 5 tokens with identical output; the written file was also byte-compared against the live state to confirm the tokens, target and draft blobs and every checkpoint round-trip exactly. The file version is bumped, so states written by 0.5.3 are discarded on first start rather than misparsed.