### PR TITLE
fix(openclaw): stop the liveness watchdog aborting deep prefills

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -45,15 +45,15 @@ data:
             "litellm/kimi-k3": { alias: "kimi", params: { cache_prompt: true } },
             "minimax/MiniMax-M3": { alias: "minimax", params: { cacheRetention: "short" } },
             "minimax/MiniMax-M2.7": { alias: "minimax-old", params: { cacheRetention: "short" } },
-            "litellm/llama-strix": { alias: "skirk", params: { cache_prompt: true } },
-            "litellm/llama-strix-chat": { alias: "skirk-chat", params: { cache_prompt: true } },
-            "litellm/llama-reviewer": { alias: "reviewer", params: { cache_prompt: true } },
-            "litellm/llama-reviewer-chat": { alias: "reviewer-chat", params: { cache_prompt: true } },
-            "litellm/local-pool": { alias: "local", params: { cache_prompt: true } },
-            "litellm/local-pool-chat": { alias: "local-chat", params: { cache_prompt: true } },
+            "litellm/llama-strix": { alias: "skirk", params: { cache_prompt: true, extra_body: { return_progress: true } } },
+            "litellm/llama-strix-chat": { alias: "skirk-chat", params: { cache_prompt: true, extra_body: { return_progress: true } } },
+            "litellm/llama-reviewer": { alias: "reviewer", params: { cache_prompt: true, extra_body: { return_progress: true } } },
+            "litellm/llama-reviewer-chat": { alias: "reviewer-chat", params: { cache_prompt: true, extra_body: { return_progress: true } } },
+            "litellm/local-pool": { alias: "local", params: { cache_prompt: true, extra_body: { return_progress: true } } },
+            "litellm/local-pool-chat": { alias: "local-chat", params: { cache_prompt: true, extra_body: { return_progress: true } } },
             "litellm/llama-vision": { alias: "vision" },
-            "litellm/llama-nvidia": { alias: "nvidia", params: { cache_prompt: true } },
-            "litellm/llama-nvidia-chat": { alias: "nvidia-chat", params: { cache_prompt: true } },
+            "litellm/llama-nvidia": { alias: "nvidia", params: { cache_prompt: true, extra_body: { return_progress: true } } },
+            "litellm/llama-nvidia-chat": { alias: "nvidia-chat", params: { cache_prompt: true, extra_body: { return_progress: true } } },
             "litellm/dsv4f": { alias: "dsv4f", params: { cache_prompt: true } },
             "litellm/glm-5.3-flash": { alias: "glm-flash", params: { cache_prompt: true } },
             "litellm/glm-5.3": { alias: "glm-5.3", params: { cache_prompt: true } },
@@ -419,6 +419,14 @@ data:
           memory: "memini",
           contextEngine: "lossless-claw"
         },
+      },
+      diagnostics: {
+        // A deep prefill on Strix emits nothing for minutes, so the default no-progress
+        // abort (a 5 minute floor) killed runs that were still making progress. The
+        // return_progress extra_body on the local lanes keeps the stream alive; these are
+        // the backstop for when it stops arriving.
+        stuckSessionWarnMs: 600000,
+        stuckSessionAbortMs: 1500000,
       },
       session: {
         dmScope: "main",


### PR DESCRIPTION
Runs against llama-strix were being killed mid-prefill with `stuck session recovery: age=391s action=abort_embedded_run`. That is not a timeout, the litellm provider allows 1800s and the proxy 1200s; it is the no-progress watchdog, whose abort threshold floors at five minutes. A 157k-token prefill takes about nine minutes and emits nothing while it runs, so a run that was making progress looked stalled and the conversation had to be restarted by hand. This asks llama.cpp for prompt-processing progress on the local lanes via `params.extra_body.return_progress`, the documented path for vendor-specific fields on OpenAI-compatible proxies, which the same params block already uses for `cache_prompt`. Verified end to end through the proxy that LiteLLM forwards the parameter and passes the `prompt_progress` chunks back, with the first chunk arriving at 0.0s against a 17.9s total where today nothing arrives until prefill completes. It also raises `diagnostics.stuckSessionWarnMs`/`stuckSessionAbortMs` as a backstop, since the default floor is shorter than a legitimate prefill on this hardware. Config validated by evaluating the rendered JSON5.