### PR TITLE
fix(ci): give AI review tool headroom

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -96,8 +96,11 @@ jobs:
           ci_timeout_sec: "600"
           search_url: "https://search.jory.dev/search"
           tool_mode: native_loop
-          tool_max_rounds: "2"
-          tool_max_requests: "4"
+          # Leave room for standards-directed multi-hop checks: read the
+          # repository's exact target, discover the upstream source, fetch it,
+          # and then let the reviewer synthesize the evidence.
+          tool_max_rounds: "4"
+          tool_max_requests: "8"
           tool_loop_wall_clock_sec: "600"
           tool_planning_timeout_sec: "300"
           tool_planning_max_context_bytes: "15000"


### PR DESCRIPTION
The reviewer exhausted its four-call budget before it could follow this repository's mandatory Talos/Kubernetes evidence chain. Keep the reusable action on the released v2.2.1 semver pin and allow four rounds/eight requests in this consumer workflow. The generic standards-preservation fix is tracked separately in [misospace/pr-reviewer-action#542](https://github.com/misospace/pr-reviewer-action/pull/542).