### PR TITLE
fix(openclaw): pin the pod hostname so a restart keeps the prompt prefix

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -12,6 +12,10 @@ spec:
   dependsOn: []
   values:
     defaultPodOptions:
+      # OpenClaw puts its own hostname in the Runtime block near the end of the system
+      # prompt, so a pod name change rewrites the prompt ~30k tokens in and invalidates
+      # every cached token after it. Pin it so restarts keep the prefix.
+      hostname: openclaw
       automountServiceAccountToken: true
       securityContext:
         runAsUser: 1000


### PR DESCRIPTION
OpenClaw ends its system prompt with a Runtime block that includes its own hostname, which defaults to the pod name, so every restart rewrites the prompt about 30k tokens in and invalidates every cached token after it. A long conversation then re-decodes from scratch on the next message, which at ~290 t/s is roughly nine minutes for Miso's context. Measured directly from the spilled prompt cache states rather than inferred: two states of the same conversation share exactly 30,669 tokens then diverge, and detokenising that boundary lands on `host=openclaw-588bdc7cfb-skb4j` at the end of the Runtime block, a pod that has since been replaced twice. Nothing can be resumed from the branch either, because the earliest context checkpoint sits at 30,828, 159 tokens past it. Pinning the hostname keeps that line stable across restarts; it is a single-replica Deployment so the pod name carries no information anything depends on.