### PR TITLE
feat(llm): pre-stage the uncensored Flash-Next weights into the skirk cache

### DIFF
--- a/kubernetes/apps/base/llm/litellm/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - ./servicemonitor.yaml
   - ./dashboard
   - ./models
+  - ./prestage

--- a/kubernetes/apps/base/llm/litellm/prestage/job.yaml
+++ b/kubernetes/apps/base/llm/litellm/prestage/job.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: llama-strix-uncensored-prestage
+  annotations:
+    # llmkube's model-downloader is a bare `curl -f -L -o` with no Authorization
+    # header, and hfTokenSecretRef only exists on the vllm/tgi/sglang runtimes, so
+    # the llamacpp path cannot fetch a gated repo. Stage the files into the cache
+    # first; the init container only downloads when the file is absent, so it will
+    # find these and skip.
+    #
+    # The cache directory is sha256(spec.source)[:16]:
+    #   hf://orcarouter/Qwen3.8-Flash-Next-Uncensored-GGUF -> 6c3699adf55ca6bf
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    spec:
+      restartPolicy: OnFailure
+      # the cache is a node-bound local-hostpath volume
+      nodeSelector:
+        kubernetes.io/hostname: skirk
+      tolerations:
+        - key: llm-workload
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: stage
+          image: docker.io/python:3.14-slim
+          envFrom:
+            - secretRef:
+                name: huggingface
+          env:
+            - name: HF_HUB_ENABLE_HF_TRANSFER
+              value: "0"
+            - name: REPO
+              value: orcarouter/Qwen3.8-Flash-Next-Uncensored-GGUF
+            - name: DEST
+              value: /models/6c3699adf55ca6bf
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              pip install --no-cache-dir --quiet "huggingface_hub[hf_xet]"
+              mkdir -p "$${DEST}"
+              hf download "$${REPO}" \
+                --local-dir "$${DEST}" \
+                --include "Qwen3.8-Flash-Next-Uncensored-IQ4_XS-*.gguf" \
+                --include "Qwen3.8-Flash-Next-Uncensored-MTP-draft.gguf" \
+                --include "mmproj-Qwen3.8-Flash-Next-Uncensored-F16.gguf"
+              rm -rf "$${DEST}/.cache"
+              echo "--- staged ---"
+              ls -la "$${DEST}"
+              du -sh "$${DEST}"
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              memory: 4Gi
+          volumeMounts:
+            - name: models
+              mountPath: /models
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: llmkube-skirk-cache

--- a/kubernetes/apps/base/llm/litellm/prestage/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/prestage/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./job.yaml


### PR DESCRIPTION
llmkube cannot fetch a gated HuggingFace repo on the llamacpp path: the model-downloader init container is a bare `curl -f -L -o` with no Authorization header, and `hfTokenSecretRef` exists only on the vllm, tgi, sglang and personaPlex runtimes. `sourceSecretRef` would put HF_TOKEN in the downloader's environment but nothing there reads it. orcarouter's repo is gated (auto) and is the only uncensored build shipping an MTP head at a workable size, IQ4_XS at 97.5 GB against the 93.7 we run now, plus a 4.1 GB MTP draft and an F16 projector; the ungated alternatives either omit the MTP head entirely or land at 125 GB. This Job stages those files into the cache first, and since the downloader only fetches when a file is absent it will find them and skip. The destination is `sha256(source)[:16]`, which is how llmkube derives the cache directory, verified by the current model hashing to the live `f869f01c859f8577`. Pinned to skirk because the cache is a node-bound local-hostpath volume. This downloads weights only; the Model still points at the Unsloth build until swapped separately.