### PR TITLE
feat(llama-strix): swap to the uncensored build and try q4_0 KV

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-flash-next.yaml
@@ -4,16 +4,16 @@ kind: Model
 metadata:
   name: llama-strix
 spec:
-  source: hf://unsloth/Qwen3.8-Flash-Next-GGUF
+  source: hf://orcarouter/Qwen3.8-Flash-Next-Uncensored-GGUF
   files:
-    - UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf
-    - UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00002-of-00003.gguf
-    - UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00003-of-00003.gguf
-    - MTP/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf
-    - mmproj-F16.gguf
-  mmproj: mmproj-F16.gguf
+    - Qwen3.8-Flash-Next-Uncensored-IQ4_XS-00001-of-00003.gguf
+    - Qwen3.8-Flash-Next-Uncensored-IQ4_XS-00002-of-00003.gguf
+    - Qwen3.8-Flash-Next-Uncensored-IQ4_XS-00003-of-00003.gguf
+    - Qwen3.8-Flash-Next-Uncensored-MTP-draft.gguf
+    - mmproj-Qwen3.8-Flash-Next-Uncensored-F16.gguf
+  mmproj: mmproj-Qwen3.8-Flash-Next-Uncensored-F16.gguf
   format: gguf
-  quantization: UD-IQ4_XS
+  quantization: IQ4_XS
   hardware:
     accelerator: vulkan
     gpu:
@@ -63,11 +63,11 @@ spec:
   jinja: true
   speculativeDecoding:
     type: draft-mtp
-    draftModel: MTP/mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf
+    draftModel: Qwen3.8-Flash-Next-Uncensored-MTP-draft.gguf
     nDraftMax: 7
     pMin: 0.75
-  cacheTypeK: q8_0
-  cacheTypeV: q8_0
+  cacheTypeK: q4_0
+  cacheTypeV: q4_0
   reasoningBudget: 16384
   reasoningBudgetMessage: "Stop reasoning and produce the implementation, tool call, or final answer."
   batchSize: 4096


### PR DESCRIPTION
Points the model at orcarouter's abliterated Flash-Next: IQ4_XS at 97.5 GB against the 93.7 we ran, plus its own 4.1 GB MTP draft and F16 projector. The architecture metadata was verified against the running model before choosing it (qwen4exp, 48 blocks, 262144 context, 512 experts, indexer top_k 2048, all identical), and it is the only uncensored build shipping an MTP head at a workable size since the ungated alternatives either omit the head or land at 125 GB; note its files sit at the repo root rather than under a quant subdirectory. This also drops KV from q8_0 to q4_0. My earlier "never q4_0" claim overstated its own evidence: the 20x prefill collapse in llama.cpp #27109 was measured for `K=q4_1` on CUDA, and the Strix regression that cost a revert was q5_0 on the ROCm image, whereas on the Vulkan backend now in use `ggml_vk_fa_kv_native` admits q4_0 alongside q8_0 so it has a native flash-attention path. That makes it untested rather than known-bad, worth about 1.6 GiB of the 3.2 GiB cache. Worth watching prefill at depth on the first deep prompt: ~290-300 t/s at 100k is healthy, and anything near CPU speed means q4_0 falls off the fast path after all and this reverts to q8_0 in one line. **Merge only after the staging Job has completed**, since llmkube cannot fetch a gated repo itself, and expect the spilled prompt cache to be discarded once because the model fingerprint changes.