### PR TITLE
feat(openclaw): allow Sage image understanding tool

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -153,7 +153,7 @@ data:
             name: "Sage",
             workspace: "/home/node/.openclaw/workspace-sage",
             agentDir: "/home/node/.openclaw/agents/sage/agent",
-            tools: { allow: ["web_fetch", "web_search", "memory_recall", "memory_list", "memory_remember"] },
+            tools: { allow: ["web_fetch", "web_search", "image", "memory_recall", "memory_list", "memory_remember"] },
             thinkingDefault: "low",
             model: {
               primary: "litellm/llama-nvidia-chat",


### PR DESCRIPTION
## Summary
- Add the `image` tool to Sage's explicit tool allowlist so Discord image attachments can use the configured vision path.
- Keep Sage otherwise restricted to the existing web and memory tools; no media-generation tools are granted.

## Related live remediation
- Purged all captured entries from Sage's isolated `openclaw/sage` Memini namespace because automatic capture had stored Discord chat fragments contrary to Sage's memory contract.
- Updated Sage's live workspace guidance to avoid leading `@name` mention prefixes and to answer only the latest explicit mention/direct reply in multi-user channels.

## Validation
- `kustomize build kubernetes/apps/base/llm/openclaw/app`
- `openclaw config validate --json` against the ConfigMap's rendered `openclaw.json`
- `git diff --check HEAD^ HEAD`
