### PR TITLE
fix(openclaw): enable context pruning so tool results stop inflating the estimate

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -62,7 +62,12 @@ data:
             "litellm/chatgpt/gpt-5.6-terra": { alias: "gpt-balanced" },
             "litellm/chatgpt/gpt-5.6-luna": { alias: "gpt-cheap" },
           },
-          contextPruning: { mode: "off" },
+          // Tool results were 88% of Sage's transcript (385 KB of 436 KB), which inflated
+          // OpenClaw's bytes/4 context estimate to 109k tokens against a real 4.1k context
+          // and aborted every turn in preflight. Pruning soft-trims old tool results in
+          // memory before each call; only toolResult messages are eligible and the last 3
+          // assistant turns are never touched, so conversation text is untouched.
+          contextPruning: { mode: "cache-ttl", ttl: "5m" },
           compaction: { mode: "default", timeoutSeconds: 600, reserveTokensFloor: 40000, memoryFlush: { enabled: true, softThresholdTokens: 80000, prompt: "Extract key decisions, state changes, lessons, blockers to memory/YYYY-MM-DD.md. Format: ## [HH:MM] Topic. Skip routine work. NO_FLUSH if nothing important.", systemPrompt: "Compacting session context. Extract only what's worth remembering. No fluff." },
           },
           maxConcurrent: 4,


### PR DESCRIPTION
Sage's transcript was 436 KB, of which tool results were 385 KB, 88% of the file, from web_fetch and web_search payloads. OpenClaw estimates context as `bytes/4` over the whole on-disk transcript whenever no usage data exists, which turned a real 4.1k context (as measured by the gateway) into an estimated 109k. Against a 131k window minus a 16k output reservation and a 40k compaction floor, every turn aborted in preflight before any model call, so compaction never ran: the built-in overflow handler is skipped because lossless-claw owns compaction, and lossless-claw's trigger needs token counts that did not exist. Pruning soft-trims old tool results in memory before each call; only toolResult messages are eligible, the last three assistant turns are never touched, and nothing before the first user message is pruned, so conversation text and bootstrap reads are unaffected. This is the companion to declaring `supportsUsageInStreaming`: that stops the fallback being consulted at all by making real usage available, while this stops the bloat that made the fallback catastrophic rather than merely wrong. `reserveTokensFloor` stays at 40000 as the docs advise; it was never the problem, it was being subtracted from a budget compared against a 26x overestimate.