### PR TITLE
fix(openclaw): restore Discord admin slash commands

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -183,6 +183,7 @@ data:
         restart: false,
         ownerAllowFrom: ["discord:$${DISCORD_ADMIN_USER_ID}"],
         allowFrom: { discord: ["user:$${DISCORD_ADMIN_USER_ID}"] },
+        useAccessGroups: false,
       },
       models: {
         providers: {


### PR DESCRIPTION
## What changed

- set `commands.useAccessGroups: false`
- keep the explicit Discord admin `commands.allowFrom` and `commands.ownerAllowFrom` lists

This prevents Discord guild/channel access policy from rejecting native slash commands before the explicit admin command allowlist is evaluated. The explicit allowlist remains the sole command authorization source, so this does not open commands to other users.

## Validation

- `kustomize build kubernetes/apps/base/llm/openclaw/app`
- rendered configuration passes `openclaw config validate --json`
