### PR TITLE
fix(openclaw): cap tool result chars to keep the preemptive guard reachable

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -62,12 +62,7 @@ data:
             "litellm/chatgpt/gpt-5.6-terra": { alias: "gpt-balanced" },
             "litellm/chatgpt/gpt-5.6-luna": { alias: "gpt-cheap" },
           },
-          // Tool results were 88% of Sage's transcript (385 KB of 436 KB), which inflated
-          // OpenClaw's bytes/4 context estimate to 109k tokens against a real 4.1k context
-          // and aborted every turn in preflight. Pruning soft-trims old tool results in
-          // memory before each call; only toolResult messages are eligible and the last 3
-          // assistant turns are never touched, so conversation text is untouched.
-          contextPruning: { mode: "cache-ttl", ttl: "5m" },
+          contextLimits: { toolResultMaxChars: 12000 },
           compaction: { mode: "default", timeoutSeconds: 600, reserveTokensFloor: 40000, memoryFlush: { enabled: true, softThresholdTokens: 80000, prompt: "Extract key decisions, state changes, lessons, blockers to memory/YYYY-MM-DD.md. Format: ## [HH:MM] Topic. Skip routine work. NO_FLUSH if nothing important.", systemPrompt: "Compacting session context. Extract only what's worth remembering. No fluff." },
           },
           maxConcurrent: 4,
@@ -158,6 +153,7 @@ data:
             workspace: "/home/node/.openclaw/workspace-sage",
             agentDir: "/home/node/.openclaw/agents/sage/agent",
             tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "memory_recall", "memory_list", "memory_remember"] },
+            contextLimits: { toolResultMaxChars: 8000 },
             thinkingDefault: "low",
             model: {
               primary: "litellm/llama-nvidia-chat",


### PR DESCRIPTION
OpenClaw's tool-result context guard aborts a turn before any model call once estimated context exceeds `contextWindow * 4 * 0.9` chars, and it counts toolResult messages at 2x, while the auto per-result cap is 32000 chars at a 131072 window and 64000 at 262144 — so about 7.4 max-size tool results exhaust the guard budget at either scale, and lossless-claw can't absorb it because `resolveFreshTailOrdinal` gates both `freshTailCount` and `freshTailMaxTokens` behind `latestUserProtected`, leaving everything after the last user message protected verbatim at any size. This sets `agents.defaults.contextLimits.toolResultMaxChars` to 12000 with sage at 8000 (sage hit it first because web_fetch returns near-max results, but every agent is exposed at the same ratio), and drops the `contextPruning` block, which is not a key lossless-claw 0.15.3 reads and was silently ignored.