### PR TITLE
feat(foreman): raise the coders' edit-free limit from 40 to 90

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -45,7 +45,7 @@ spec:
     # MiniMax-M3 has a ~1M context window (vs the nvidia base coders' 131k), and
     # big audit refactors need many read/plan turns before the first edit — 15
     # (default) and even 24 killed them mid-exploration. Size these to the model.
-    editFreeTurnsLimit: 40
+    editFreeTurnsLimit: 90
     contextSoftCap: 500000
     contextHardCap: 800000
   requestTurnTimeoutSeconds: 1800

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -46,7 +46,7 @@ spec:
     # nvidia local model has a 131k context window; give more exploration room
     # before the edit-free abort, and cap context just under the window (the
     # default hard cap of 140k sat above it).
-    editFreeTurnsLimit: 40
+    editFreeTurnsLimit: 90
     contextSoftCap: 100000
     contextHardCap: 120000
   requestTurnTimeoutSeconds: 1800

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -43,10 +43,12 @@ spec:
   maxRetries: 3
   maxOutputTokens: 20480
   stuckLoopDetection:
-    # nvidia local model has a 131k context window; give more exploration room
-    # before the edit-free abort, and cap context just under the window (the
+    # The edit-free limit exists to break loops, not to bound investigation. A
+    # coder reconstructing branch state does dozens of distinct reads before it
+    # can edit anything; at 40 that work was aborted mid-way while maxTurns 160
+    # sat unused. Context is capped just under the model's 131k window (the
     # default hard cap of 140k sat above it).
-    editFreeTurnsLimit: 40
+    editFreeTurnsLimit: 90
     contextSoftCap: 85000
     contextHardCap: 98000
   requestTurnTimeoutSeconds: 1800


### PR DESCRIPTION
The edit-free limit exists to break loops. At 40 it was also ending legitimate investigation.

## Evidence

misospace/pr-reviewer-action#536, attempt 2. The coder made **48 consecutive edit-free turns** — 30 `bash`, 8 `grep`, 11 `read_file`, **zero errors**, all distinct calls — reconstructing what a previous attempt had left on its branch. That is not a loop; a loop repeats itself and errors.

At turn 48 the monitor fired and disabled `grep`/`bash`. Three turns later the run was force-terminated. Its own submission:

> "cannot do final code edit to extend the previous attempt's Case 2 fix to also cover Case 1 ... The remote branch already contains a correct partial fix from the previous attempt (42a6dee)."

It had worked out what to do and was stopped one edit short. `maxTurns: 160` was never approached — the run used 51.

## Change

`editFreeTurnsLimit` 40 → 90 on `coder`, `coder-frontier` and `coder-revision`.

90 still halts a genuine loop well inside `maxTurns: 160`, leaving room to act afterwards, while giving roughly double the investigation the observed case needed. Nothing else moves: `maxTurns`, the context caps and `requestTurnTimeoutSeconds` are unchanged, and the wall clock remains the backstop.

The stale comment on `coder` explaining the old value is updated to say what the limit is actually for.

## Note

This does not fix misospace/foreman-dispatch-bridge#272 — a retry still is not told what its predecessor pushed, which is what consumed those 48 turns in the first place. This raises the ceiling so that discovery no longer costs the run; #272 removes the need for the discovery at all.

https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh