### PR TITLE
fix(openclaw): restore Discord slash commands for the admin user

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -281,9 +281,9 @@ data:
             matcha: {
               token: "$${MATCHA_BOT_TOKEN}",
               guilds: {
-                "$${DISCORD_SERVER_ID}": {
+                "tako-tuesday": {
                   channels: {
-                    "$${MATCHA_CHANNEL_ID}": { enabled: true, requireMention: false },
+                    matcha: { enabled: true, requireMention: false },
                   },
                 },
               },

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -182,8 +182,7 @@ data:
         nativeSkills: "auto",
         restart: false,
         ownerAllowFrom: ["discord:$${DISCORD_ADMIN_USER_ID}"],
-        allowFrom: { discord: ["user:$${DISCORD_ADMIN_USER_ID}"] },
-        useAccessGroups: false,
+        allowFrom: { discord: ["$${DISCORD_ADMIN_USER_ID}"] },
       },
       models: {
         providers: {
@@ -268,10 +267,16 @@ data:
             default: {
               token: "$${DISCORD_BOT_TOKEN}",
               responsePrefix: "[{model}]",
+              guilds: {
+                "tako-tuesday": { users: ["$${DISCORD_ADMIN_USER_ID}"] },
+              },
             },
             saffron: {
               token: "$${SAFFRON_BOT_TOKEN}",
               responsePrefix: "[{model}]",
+              guilds: {
+                "tako-tuesday": { users: ["$${DISCORD_ADMIN_USER_ID}"] },
+              },
             },
             matcha: {
               token: "$${MATCHA_BOT_TOKEN}",
@@ -290,6 +295,7 @@ data:
                 "western-subaru-club": {
                   requireMention: true,
                 },
+                "tako-tuesday": { users: ["$${DISCORD_ADMIN_USER_ID}"] },
               },
             },
           },


### PR DESCRIPTION
Native Discord slash commands have returned "You are not authorized to use this command" since #9726 because commands.allowFrom.discord used a user: prefix: the Discord plugin's own gate strips it, but core command-auth compares the bare sender snowflake to the configured entries after a plain lowercase pass, so the entry never matched (the log line is "Ignoring /stop from unauthorized sender"). Before #9726 nothing was set in ownerAllowFrom, so native commands fell through the nativeCommandAuthorized path, which is why DMs used to work. This switches the entry to the bare ID, drops the useAccessGroups: false from #9728 (not consulted once commands.allowFrom is set, and the guild denial it aimed at comes from the groupPolicy allowlist check that runs before it), and allowlists the home guild for the default, saffron and sage accounts restricted to the admin user so slash commands also work in guild channels. Guilds and channels are keyed by slug because the OpenClaw config loader substitutes ${VAR} in values only, never in object keys; that same gap meant Matcha's templated guild and channel keys were literal strings and its allowlist never matched, so those are re-keyed by slug here too. Validated with kustomize build and openclaw config validate against the rendered file in the running pod.