### PR TITLE
feat(foreman): teach the coders BUDGET-EXHAUSTED

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -124,6 +124,12 @@ spec:
         human has to make.
       NO-GO + extra.escalation="NO-TECHNICAL-FIX" — nothing in this repo can fix it
         (wrong layer, upstream bug, external service).
+      NO-GO + extra.escalation="BUDGET-EXHAUSTED" — you ran out of turns or lost the
+        exploration tools, and the work is neither done nor impossible. Use this only
+        when you know what the remaining step is; say what it is in your summary, and
+        name any commit you already pushed. It buys another attempt, so it is the
+        honest answer to running out of room — the other two say the work needs a
+        person, which removes it from the queue.
     Put the specific blocker in your summary. These route the issue, so a wrong one
     removes real work from the queue. If you cannot find what the issue points at, read
     the files it names and work from what is there — not having found it yet is not a

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -119,5 +119,9 @@ spec:
       NO-GO + extra.escalation="DESIGN-DECISION" — a human call, including a finding that
         contradicts the issue's ask.
       NO-GO + extra.escalation="NO-TECHNICAL-FIX" — nothing in this repo can fix it.
+      NO-GO + extra.escalation="BUDGET-EXHAUSTED" — you ran out of turns or lost the
+        exploration tools, and the work is neither done nor impossible. Use this only when
+        you know what the remaining step is; say what it is and name any commit you pushed.
+        It buys another attempt; the other two say the work needs a person.
     Put the specific blocker in your summary. A GO with no diff records as NO-CHANGES and
     burns the remaining attempts.

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -128,6 +128,12 @@ spec:
         human has to make.
       NO-GO + extra.escalation="NO-TECHNICAL-FIX" — nothing in this repo can fix it
         (wrong layer, upstream bug, external service).
+      NO-GO + extra.escalation="BUDGET-EXHAUSTED" — you ran out of turns or lost the
+        exploration tools, and the work is neither done nor impossible. Use this only
+        when you know what the remaining step is; say what it is in your summary, and
+        name any commit you already pushed. It buys another attempt, so it is the
+        honest answer to running out of room — the other two say the work needs a
+        person, which removes it from the queue.
     Put the specific blocker in your summary. These route the issue, so a wrong one
     removes real work from the queue. If you cannot find what the issue points at, read
     the files it names and work from what is there — not having found it yet is not a


### PR DESCRIPTION
Adds a fourth `submit_result` outcome to the three coder prompts, so a coder that runs out of turns has an honest way to say so.

## Why

The vocabulary was `ALREADY-RESOLVED`, `DESIGN-DECISION`, `NO-TECHNICAL-FIX`. Both escalations mean *a person is needed*, and the controller parks the issue on either. So a coder that merely ran out of room had to pick one of them.

On misospace/pr-reviewer-action#536 that is exactly what happened. The coder declared `NO-TECHNICAL-FIX` while its own `blockedBy` read:

> "Tooling: grep/bash disabled and only 1 turn remaining; cannot do final code edit ... The remote branch already contains a correct partial fix from the previous attempt (42a6dee)."

The issue now carries a `NO-TECHNICAL-FIX` comment and a `needs-human` label, telling a reader the problem is unsolvable, while a real partial fix sits unshipped on its branch.

## Guarded deliberately

The wording restricts it to the case where the coder knows the remaining step, and requires naming it plus any commit already pushed. Otherwise it becomes the easy way out of any hard issue — worse than the problem it fixes, because it would burn attempts silently instead of parking loudly.

`ALREADY-RESOLVED` is untouched and still says to judge against the base branch, not the workspace.

## Pairs with

misospace/foreman-dispatch-bridge#276, which makes the bridge treat it as a retry rather than a park — consuming an attempt, escalating at the cap. Merge order does not matter: until both are in, a declaration either cannot be produced or is treated as a park, which is today's behaviour.

Coders run as Jobs and read the Agent CR per dispatch, so no `rollout restart` is needed — unlike the in-process reviewers.

https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh