### PR TITLE
fix(openclaw): use wildcard guild entries so slash commands resolve in guilds

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -264,20 +264,20 @@ data:
               token: "$${DISCORD_BOT_TOKEN}",
               responsePrefix: "[{model}]",
               guilds: {
-                "tako-tuesday": { users: ["$${DISCORD_ADMIN_USER_ID}"] },
+                "*": { users: ["$${DISCORD_ADMIN_USER_ID}"] },
               },
             },
             saffron: {
               token: "$${SAFFRON_BOT_TOKEN}",
               responsePrefix: "[{model}]",
               guilds: {
-                "tako-tuesday": { users: ["$${DISCORD_ADMIN_USER_ID}"] },
+                "*": { users: ["$${DISCORD_ADMIN_USER_ID}"] },
               },
             },
             matcha: {
               token: "$${MATCHA_BOT_TOKEN}",
               guilds: {
-                "tako-tuesday": {
+                "*": {
                   channels: {
                     matcha: { enabled: true, requireMention: false },
                   },
@@ -291,7 +291,7 @@ data:
                 "western-subaru-club": {
                   requireMention: true,
                 },
-                "tako-tuesday": { users: ["$${DISCORD_ADMIN_USER_ID}"] },
+                "*": { users: ["$${DISCORD_ADMIN_USER_ID}"] },
               },
             },
           },


### PR DESCRIPTION
Follow-up to #9734: slash commands worked in DMs but guild channels still answered "This channel is not allowed." because the Discord plugin hands its native-command surface the raw account config, whose guild map only has the keys as written, while the message path gets a resolved copy with guild IDs added; a slash interaction's guild object is built from guild_id alone with no name, so a slug key can never match it, and object keys are not env-substituted so an ID key would mean a literal guild ID in the repo. The guild entries become "*", which the resolver falls back to after ID and slug: equivalent for the default, saffron and matcha bots, which are only in the home guild, and Sage keeps its explicit western-subaru-club entry, which still wins for messages there. Validated with kustomize build and openclaw config validate against the rendered file in the running pod.