### PR TITLE
fix(forgejo): point ssh dns at lbip

### DIFF
--- a/kubernetes/apps/base/self-hosted/forgejo/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/forgejo/helmrelease.yaml
@@ -66,7 +66,6 @@ spec:
         type: LoadBalancer
         annotations:
           external-dns.alpha.kubernetes.io/hostname: forgejo-ssh.jory.dev
-          external-dns.alpha.kubernetes.io/target: internal.jory.dev
           lbipam.cilium.io/ips: 10.69.10.46
         externalTrafficPolicy: Local
         port: 22


### PR DESCRIPTION
Remove the internal Gateway target override from the Forgejo SSH Service so external-dns publishes forgejo-ssh.jory.dev to the Service LoadBalancer IP 10.69.10.46.