### PR TITLE
feat(llm): run the embed and rerank models on CPU only

### DIFF
--- a/kubernetes/apps/base/llm/memini/memini-embed.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-embed.yaml
@@ -8,14 +8,7 @@ spec:
   format: gguf
   quantization: Q8_0
   hardware:
-    accelerator: intel
-    gpu:
-      enabled: true
-      vendor: intel
-      layers: 99
-      resourceClaims:
-        - name: gpu
-          resourceClaimTemplateName: memini-gpu
+    accelerator: cpu
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
@@ -26,35 +19,33 @@ metadata:
 spec:
   modelRef: memini-embed
   runtime: llamacpp
-  image: ghcr.io/ggml-org/llama.cpp:server-vulkan@sha256:f862c901a0089bc3dc326bd24f208bfcd147839783328d252e911a004c94ff3c
+  image: ghcr.io/ggml-org/llama.cpp:server@sha256:fcca4dac388066ca93db561751e8caf5fc7d46d9df5f00a7422026db68468e31
   rolloutPolicy:
     waitForIdle: true
     idleTimeoutSeconds: 86400
   replicas: 1
   priority: normal
   podLabels:
-    igpu-workload: "true"
+    cpu-inference: "true"
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: kubernetes.io/hostname
       whenUnsatisfiable: ScheduleAnyway
       labelSelector:
         matchLabels:
-          igpu-workload: "true"
+          cpu-inference: "true"
   contextSize: 32768
   parallelSlots: 2
   batchSize: 16384
   uBatchSize: 16384
   env:
-    - name: ZES_ENABLE_SYSMAN
-      value: "1"
-    - name: ONEAPI_DEVICE_SELECTOR
-      value: level_zero:gpu
-    - name: UR_L0_ENABLE_RELAXED_ALLOCATION_LIMITS
-      value: "1"
+    - name: GOMP_CPU_AFFINITY
+      value: "0-11"
+    - name: KMP_AFFINITY
+      value: "granularity=fine,proc_list=[0-11],explicit"
   resources:
-    cpu: "250m"
-    memory: 2Gi
+    cpu: "6"
+    memory: 8Gi
   extraArgs:
     - --alias
     - memini-embed

--- a/kubernetes/apps/base/llm/memini/memini-rerank.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-rerank.yaml
@@ -8,14 +8,7 @@ spec:
   format: gguf
   quantization: Q8_0
   hardware:
-    accelerator: rocm
-    gpu:
-      enabled: true
-      vendor: amd
-      layers: 99
-      resourceClaims:
-        - name: gpu
-          resourceClaimTemplateName: llama-strix-gpu
+    accelerator: cpu
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
@@ -25,29 +18,33 @@ metadata:
     krr/ignore: "true"
 spec:
   modelRef: memini-rerank
-  modelCache:
-    claimName: llmkube-skirk-cache
   runtime: llamacpp
-  image: docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:1c655ca0443655f2e7603d054770b07cd8c79267145728b3261295f005053947
+  image: ghcr.io/ggml-org/llama.cpp:server@sha256:fcca4dac388066ca93db561751e8caf5fc7d46d9df5f00a7422026db68468e31
   rolloutPolicy:
     waitForIdle: true
     idleTimeoutSeconds: 86400
-  command:
-    - llama-server
   replicas: 1
   priority: normal
-  nodeSelector:
-    topology.kubernetes.io/gpus: amd
-  tolerations:
-    - key: llm-workload
-      operator: Exists
-      effect: NoSchedule
+  podLabels:
+    cpu-inference: "true"
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          cpu-inference: "true"
   contextSize: 8096
   parallelSlots: 2
   batchSize: 2048
   uBatchSize: 2048
+  env:
+    - name: GOMP_CPU_AFFINITY
+      value: "0-11"
+    - name: KMP_AFFINITY
+      value: "granularity=fine,proc_list=[0-11],explicit"
   resources:
-    cpu: "500m"
+    cpu: "6"
     memory: 4Gi
   extraArgs:
     - --alias
@@ -63,8 +60,7 @@ spec:
     - "6"
     - --threads-batch
     - "12"
-    - --load-mode
-    - none
+    - --mmap
   endpoint:
     port: 8080
     type: ClusterIP

--- a/kubernetes/apps/base/llm/toolhive/config/toolhive-embed.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/toolhive-embed.yaml
@@ -8,14 +8,7 @@ spec:
   format: gguf
   quantization: Q8_0
   hardware:
-    accelerator: rocm
-    gpu:
-      enabled: true
-      vendor: amd
-      layers: 99
-      resourceClaims:
-        - name: gpu
-          resourceClaimTemplateName: llama-strix-gpu
+    accelerator: cpu
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
@@ -25,33 +18,35 @@ metadata:
     krr/ignore: "true"
 spec:
   modelRef: toolhive-embed
-  modelCache:
-    claimName: llmkube-skirk-cache
   runtime: llamacpp
-  image: docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:1c655ca0443655f2e7603d054770b07cd8c79267145728b3261295f005053947
+  image: ghcr.io/ggml-org/llama.cpp:server@sha256:fcca4dac388066ca93db561751e8caf5fc7d46d9df5f00a7422026db68468e31
   rolloutPolicy:
     waitForIdle: true
     idleTimeoutSeconds: 86400
-  command:
-    - llama-server
   replicas: 1
   priority: normal
-  nodeSelector:
-    topology.kubernetes.io/gpus: amd
-  tolerations:
-    - key: llm-workload
-      operator: Exists
-      effect: NoSchedule
+  podLabels:
+    cpu-inference: "true"
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          cpu-inference: "true"
   contextSize: 32768
   parallelSlots: 32
   flashAttention: true
-  cacheTypeK: q8_0
-  cacheTypeV: q8_0
   batchSize: 1024
   uBatchSize: 1024
+  env:
+    - name: GOMP_CPU_AFFINITY
+      value: "0-11"
+    - name: KMP_AFFINITY
+      value: "granularity=fine,proc_list=[0-11],explicit"
   resources:
-    cpu: "500m"
-    memory: 4Gi
+    cpu: "6"
+    memory: 6Gi
   extraArgs:
     - --alias
     - toolhive-embed
@@ -66,8 +61,7 @@ spec:
     - "6"
     - --threads-batch
     - "12"
-    - --load-mode
-    - none
+    - --mmap
   endpoint:
     port: 8080
     type: ClusterIP


### PR DESCRIPTION
Moves memini-embed off the Intel iGPU and memini-rerank plus toolhive-embed off Strix onto the i9-13900H nodes with no accelerator, freeing roughly 7 GiB of otherwise pinned and unreclaimable GTT on skirk; all three switch to the official CPU llama.cpp server image, dropping the `llm-workload` toleration is what actually keeps them off skirk since that node holds the only NoSchedule taint, the two that were on Strix lose the skirk-local `modelCache` and fall back to the shared ceph-filesystem one (0.6B Q8 weights, so mmap is a one-time cold fault), threads are pinned to the P-cores via `GOMP_CPU_AFFINITY`/`KMP_AFFINITY` the same way the comfyui CPU work had to, and CPU requests go 250m/500m to 6 (requests-only in the CRD, so `--threads-batch 12` still bursts). Expect rerank latency to regress toward the Iris numbers rather than the 1.3s Strix ones — worth measuring `memory_recall` before and after to confirm the trade is acceptable.