### PR TITLE
fix(llm): right-size the CPU requests for embed and rerank

### DIFF
--- a/kubernetes/apps/base/llm/memini/memini-embed.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-embed.yaml
@@ -44,7 +44,7 @@ spec:
     - name: KMP_AFFINITY
       value: "granularity=fine,proc_list=[0-11],explicit"
   resources:
-    cpu: "6"
+    cpu: "2"
     memory: 8Gi
   extraArgs:
     - --alias

--- a/kubernetes/apps/base/llm/memini/memini-rerank.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-rerank.yaml
@@ -44,7 +44,7 @@ spec:
     - name: KMP_AFFINITY
       value: "granularity=fine,proc_list=[0-11],explicit"
   resources:
-    cpu: "6"
+    cpu: "2"
     memory: 4Gi
   extraArgs:
     - --alias

--- a/kubernetes/apps/base/llm/toolhive/config/toolhive-embed.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/toolhive-embed.yaml
@@ -45,7 +45,7 @@ spec:
     - name: KMP_AFFINITY
       value: "granularity=fine,proc_list=[0-11],explicit"
   resources:
-    cpu: "6"
+    cpu: "2"
     memory: 6Gi
   extraArgs:
     - --alias


### PR DESCRIPTION
Sizing the request to match `--threads 6` was the wrong model: llmkube emits requests with no limits, so the request never capped the thread count (the process still bursts across all twelve P-core threads when free) and only bought 18 CPU of scheduling reservation. The visible effect was that memini-embed and memini-rerank became the two largest CPU requesters in the cluster, ahead of the Ceph mons and OSDs, while drawing 1-2m at idle, and toolhive-embed could not schedule at all because only ayaka still had 6 CPU free once the other two had landed. Drops all three to 2 CPU, which still guarantees a couple of cores under contention.