### PR TITLE
fix(foreman): stop the fork agent reserving 2 cores it does not use

### DIFF
--- a/kubernetes/apps/base/llm/foreman/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/foreman/app/helmrelease.yaml
@@ -94,12 +94,13 @@ spec:
         coderGitSecretKey: GITHUB_TOKEN
         gateCache:
           name: foreman-llmkube-gate-cache
-        # reviewer-fork runs InProcess in this pod; the chart default caps CPU at
-        # 2, which throttles review. Burst to 6 cores.
+        # reviewer-fork runs InProcess in this pod, and the chart's 2-core limit
+        # throttled review, so the limit is raised to 6. The request stays small:
+        # it is a reservation, not a ceiling, and the pod is idle between reviews.
         resources:
           requests:
-            cpu: "2"
-            memory: 512Mi
+            cpu: 200m
+            memory: 256Mi
           limits:
             cpu: "6"
             memory: 8Gi


### PR DESCRIPTION
`foreman-llmkube-agent` requested `cpu: 2` and `memory: 512Mi`. Measured usage:

```
foreman-llmkube-agent-6c9df66998-5b7nt   cpu=1m    mem=17Mi
foreman-default-agent-8657568d8b-txqwk   cpu=5m    mem=21Mi
foreman-default-agent-8657568d8b-zdwkm   cpu=1m    mem=21Mi
```

So it reserved 2 full cores against ~1m of use, while its sibling requests `200m` for the same workload shape.

## How it happened

The existing comment shows the intent:

> reviewer-fork runs InProcess in this pod; the chart default caps CPU at 2, which throttles review. Burst to 6 cores.

Raising the **limit** to 6 was right — that is the ceiling review was hitting. The request was raised to 2 alongside it, and the request is a reservation the scheduler holds whether or not the pod uses it.

## Change

Request drops to `200m` / `256Mi`, matching `foreman-default-agent`. Limits are untouched at `6` / `8Gi`, so the burst headroom the comment is about is unchanged. The comment now distinguishes the two.

## Why it matters here

Not currently causing anything to pend — the one Pending pod in `llm` is `toolhive-embed` on a taint, unrelated. But CPU reservation is 54–66% across three nodes, and `coder.yaml` carries a note about Job-mode coders previously sitting Pending on "Insufficient cpu" at `MAX_IN_PROGRESS 14`, which is exactly the pressure this adds 1.8 cores of headroom against.

https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh