### PR TITLE
fix(llm): widen the embed and rerank timeouts for CPU inference

### DIFF
--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
               MEMINI_RERANK: http://litellm.llm:4000/v1
               MEMINI_RERANK_MODEL: rerank
               MEMINI_RERANK_MAX_CONCURRENCY: 2
-              MEMINI_RERANK_TIMEOUT: 12s
+              MEMINI_RERANK_TIMEOUT: 25s
               MEMINI_RERANK_POOL: "8"
             envFrom:
               - secretRef:

--- a/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/virtualmcpserver.yaml
@@ -16,7 +16,7 @@ spec:
       embeddingModel: toolhive-embed
       embeddingProvider: openai
       embeddingService: http://litellm.llm:4000/v1
-      embeddingServiceTimeout: 60s
+      embeddingServiceTimeout: 180s
   incomingAuth:
     type: anonymous
   outgoingAuth:


### PR DESCRIPTION
Measured on the new CPU pods, a 570-input toolhive optimizer batch takes 36.5s against its 60s ceiling and two concurrent 8-candidate memini reranks finish in 3.6s and 7.5s against a 12s ceiling; both succeed today but at only 1.6x margin on workloads that scale linearly, and since the embedding batch is serial at roughly 64ms per input about 900 tools would breach 60s with any node contention eating the rest. Raises embeddingServiceTimeout to 180s and MEMINI_RERANK_TIMEOUT to 25s — these are ceilings, not delays, so there is no cost while requests stay fast.