### PR TITLE
feat(memini): alert when recall degrades or rerank saturates

### DIFF
--- a/kubernetes/apps/base/llm/memini/kustomization.yaml
+++ b/kubernetes/apps/base/llm/memini/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./memini-embed.yaml
   - ./memini-rerank.yaml
   - ./ocirepository.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/base/llm/memini/prometheusrule.yaml
+++ b/kubernetes/apps/base/llm/memini/prometheusrule.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: memini
+spec:
+  groups:
+    - name: memini.rules
+      rules:
+        - alert: MeminiRecallDegraded
+          expr: |-
+            sum(increase(memini_recall_degraded_total[30m])) > 0
+          annotations:
+            summary: >-
+              Memini recall degraded — rerank or embed unavailable, results are falling back
+              to unranked order
+          labels:
+            severity: warning
+        - alert: MeminiEmbedErrors
+          expr: |-
+            sum by (backend) (increase(memini_embed_errors_total[30m])) > 0
+          for: 10m
+          annotations:
+            summary: >-
+              Memini embed backend {{ $labels.backend }} returning errors
+          labels:
+            severity: warning
+        - alert: MeminiRerankSaturated
+          expr: |-
+            min_over_time(memini_rerank_in_flight[15m]) >= 2
+          for: 15m
+          annotations:
+            summary: >-
+              Memini rerank has been at its concurrency limit for 15m — CPU inference is
+              not keeping up with recall volume
+          labels:
+            severity: warning


### PR DESCRIPTION
Rerank now runs on CPU where a realistic 8-candidate call takes about 4s against a 25s timeout, and memini degrades rather than fails when rerank is unavailable, so a regression would otherwise surface only as quietly unranked recall results. Recall volume is roughly one call every two hours, which means a working configuration and a broken one look identical when spot-checked — these three alerts make the degraded path observable instead: recall falling back, embed backend errors, and rerank sitting at its concurrency limit long enough to indicate CPU is not keeping up.