### PR TITLE
fix(foreman): correct the agent context budgets and coder resource ceilings

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -41,10 +41,13 @@ spec:
   temperature: "0.2"
   maxTurns: 160
   maxRetries: 3
+  contextStrategy: session
+  contextWindowTokens: 480000
   stuckLoopDetection:
     # MiniMax-M3 has a ~1M context window (vs the nvidia base coders' 131k), and
     # big audit refactors need many read/plan turns before the first edit — 15
     # (default) and even 24 killed them mid-exploration. Size these to the model.
+    repeatedToolThreshold: 5
     editFreeTurnsLimit: 90
     contextSoftCap: 500000
     contextHardCap: 800000

--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -72,9 +72,9 @@ spec:
     resources:
       requests:
         cpu: 500m
-        memory: 2Gi
+        memory: 3Gi
       limits:
-        cpu: 4
+        cpu: 8
         memory: 8Gi
     activeDeadlineSeconds: 43200
     image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:cd6309efd0f0a874e8fd9f431d539d5e7eb9f2b1f6fce802aa8b685cc05300ef

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -42,10 +42,13 @@ spec:
   maxTurns: 160
   maxRetries: 3
   maxOutputTokens: 20480
+  contextStrategy: session
+  contextWindowTokens: 90000
   stuckLoopDetection:
     # nvidia local model has a 131k context window; give more exploration room
     # before the edit-free abort, and cap context just under the window (the
     # default hard cap of 140k sat above it).
+    repeatedToolThreshold: 5
     editFreeTurnsLimit: 90
     contextSoftCap: 100000
     contextHardCap: 120000

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -73,9 +73,9 @@ spec:
     resources:
       requests:
         cpu: 500m
-        memory: 2Gi
+        memory: 3Gi
       limits:
-        cpu: 4
+        cpu: 8
         memory: 8Gi
     activeDeadlineSeconds: 43200
     image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:cd6309efd0f0a874e8fd9f431d539d5e7eb9f2b1f6fce802aa8b685cc05300ef

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -75,9 +75,9 @@ spec:
     resources:
       requests:
         cpu: 500m
-        memory: 2Gi
+        memory: 3Gi
       limits:
-        cpu: 4
+        cpu: 8
         memory: 8Gi
     activeDeadlineSeconds: 43200
     image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:cd6309efd0f0a874e8fd9f431d539d5e7eb9f2b1f6fce802aa8b685cc05300ef

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -42,12 +42,15 @@ spec:
   maxTurns: 160
   maxRetries: 3
   maxOutputTokens: 20480
+  contextStrategy: session
+  contextWindowTokens: 80000
   stuckLoopDetection:
     # The edit-free limit exists to break loops, not to bound investigation. A
     # coder reconstructing branch state does dozens of distinct reads before it
     # can edit anything; at 40 that work was aborted mid-way while maxTurns 160
     # sat unused. Context is capped just under the model's 131k window (the
     # default hard cap of 140k sat above it).
+    repeatedToolThreshold: 5
     editFreeTurnsLimit: 90
     contextSoftCap: 85000
     contextHardCap: 98000

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer-fork.yaml
@@ -39,6 +39,8 @@ spec:
   maxOutputTokens: 40960
   maxTurns: 80
   maxRetries: 3
+  contextStrategy: session
+  contextWindowTokens: 170000
   stuckLoopDetection:
     contextSoftCap: 180000
     contextHardCap: 210000

--- a/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/reviewer.yaml
@@ -37,6 +37,8 @@ spec:
   maxOutputTokens: 40960
   maxTurns: 80
   maxRetries: 3
+  contextStrategy: session
+  contextWindowTokens: 170000
   stuckLoopDetection:
     contextSoftCap: 180000
     contextHardCap: 210000


### PR DESCRIPTION
An audit of the Agent CRs against measured behaviour. Three loop-control fields were unset, so executor defaults applied that contradict the caps already tuned in these files; separately the coder Jobs are CPU-throttled and running at 98% of their memory request.

## contextWindowTokens / observationWindowTurns

Unset means a **32768-token** wire budget keeping only the **3** most recent tool results verbatim (`loop.go:235,256`); older ones are masked to one-line headers. Against the caps already in these files that is a 3-6x disagreement, so the caps could not be reached and reads were dropped long before anything nudged:

| agent | model | served context | soft / hard cap | budget was | now |
|---|---|---|---|---|---|
| `coder` | Qwen3.8-27B via `llama-nvidia` | 131072/slot | 85000 / 98000 | 32768 | 80000 |
| `coder-revision` | MiniMax-M3 | 1000000 | 100000 / 120000 | 32768 | 90000 |
| `coder-frontier` | MiniMax-M3 | 1000000 | 500000 / 800000 | 32768 | 480000 |
| `reviewer`, `reviewer-fork` | gemma-4-12b-it-qat | 262144 | 180000 / 210000 | 32768 | 170000 |

Each budget sits just under its soft cap, so the ordering is window < soft < hard: compaction degrades gracefully first, the soft cap nudges once, the hard cap aborts.

Served contexts are measured, not assumed — `llama-nvidia`'s `/props` reports `n_ctx 131072` with `total_slots 2` on build b10795, and the others come from their LiteLLMModel `info.maxInputTokens`.

## contextStrategy

Also unset, defaulting to `window`. That strategy re-masks every turn as the 3-turn window slides, so the wire prefix changes each turn and a prefix-matched KV cache is invalidated every turn — upstream calls this out explicitly (#1286, `loop.go:1512`). `session` keeps an append-only prefix and compacts only at `contextWindowTokens`, to 60% of it, so the prefix stays byte-identical across turns. Upstream recommends it for large-context models on caching runtimes, which is what llama.cpp is.

This is the same prompt-reprocess cost already seen on the local coder.

## repeatedToolThreshold

Zero on all seven agents, and **zero disables the signal** (`progress.go:42`). A nil `stuckLoopDetection` would have defaulted it to 5; supplying the struct with only the other fields set turned duplicate-call detection off. That is the signal that distinguishes a real loop from legitimate exploration, and its absence is why `editFreeTurnsLimit` had to carry the job alone at 90.

Back to the upstream default of 5 on the three coders. The reviewers keep it off — the CRD notes re-reading the same diff is normal for a review-only role.

## Coder CPU limit: 4 -> 8

The coder Jobs are genuinely throttled. At 1m resolution their peak is **3.16 cores** against the 4-core limit, and up to **48% of CFS periods were throttled** over 7 days. A 1m average that close to the ceiling means the repo's test and build commands burst well past it inside individual scheduling periods. Limits are ceilings rather than reservations, so 8 reserves nothing extra.

## Coder memory request: 2Gi -> 3Gi

Working set peaks at **2005Mi** against a 2Gi request — 98% of it. Usage above the request is the first thing reclaimed under node memory pressure, so this is the one direction that risks an eviction rather than just slowness. The 8Gi limit stays; the peak is 24% of it.

## Verified

- All four context fields exist on the deployed CRD (`agents.foreman.llmkube.dev`), `contextStrategy` with enum `[window, session]`.
- `kubectl apply --dry-run=server` accepts all five Agents.
- No OOMKills and no container restarts anywhere in the namespace.

## Correcting #9758

That PR raised `foreman-llmkube-agent`'s CPU limit to 6 on the premise that a 2-core limit was throttling review. Measured over 7 days, that pod's throttled fraction is **0.0** — it has never been throttled. `foreman-default-agent` peaks at 1.7%. Review is model-bound waiting on HTTP, not CPU-bound. The request trim in that PR was right and stands; the limit raise rested on something unverified. Nothing needs undoing, but `foreman-default-agent` deliberately does **not** get the same change here.

## Not in this PR

- `coder-revision`'s comment says "nvidia local model has a 131k context window", but it runs MiniMax-M3 at 1M and is capped at 100k/120k. The comment is stale and the caps may be far more conservative than intended. Left alone rather than changed silently.
- `foreman-default-agent` requests 200m against a 0.025 peak and `foreman-operator` 100m against 0.003 — about 275m of over-reservation in total, not worth a rollout.
- `foreman-dispatch-bridge` runs `limits.memory == requests.memory` at 128Mi with a 69Mi peak and no OOMKills.

## After merge

`reviewer` and `reviewer-fork` run InProcess and cache the Agent CR at startup, so they need `kubectl rollout restart deployment/foreman-agent` to pick this up. The coders are Job-based and read the CR per dispatch.

Claude-Session: https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh