### PR TITLE
feat(openclaw): give Sage YouTube transcript summaries

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -152,7 +152,7 @@ data:
             name: "Sage",
             workspace: "/home/node/.openclaw/workspace-sage",
             agentDir: "/home/node/.openclaw/agents/sage/agent",
-            tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "memory_recall", "memory_list", "memory_remember"] },
+            tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "youtube_tldw", "memory_recall", "memory_list", "memory_remember"] },
             contextLimits: { toolResultMaxChars: 8000 },
             thinkingDefault: "low",
             model: {
@@ -298,10 +298,11 @@ data:
         },
       },
       plugins: {
-        allow: ["discord", "lossless-claw", "memini", "searxng", "comfy", "memory-wiki", "chart-renderer"],
+        allow: ["discord", "lossless-claw", "memini", "searxng", "comfy", "memory-wiki", "chart-renderer", "youtube-tldw"],
         entries: {
           discord: { enabled: true },
           "chart-renderer": { enabled: true },
+          "youtube-tldw": { enabled: true },
           comfy: {
             enabled: true,
             config: {

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -468,8 +468,8 @@ data:
       session: {
         dmScope: "main",
         reset: {
-          mode: "idle",
-          idleMinutes: 1440,
+          mode: "daily",
+          atHour: 2,
         },
         maintenance: {
           mode: "enforce",

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -468,8 +468,8 @@ data:
       session: {
         dmScope: "main",
         reset: {
-          mode: "daily",
-          atHour: 2,
+          mode: "idle",
+          idleMinutes: 1440,
         },
         maintenance: {
           mode: "enforce",


### PR DESCRIPTION
## What changed

- enable the persistent `youtube-tldw` plugin
- allow only its `youtube_tldw` tool for Sage
- keep Sage without generic `exec` access

The YouTube tool accepts only public HTTPS `youtube.com` / `youtu.be` URLs, invokes the existing fixed transcript extractor with `execFile` (no shell), limits transcript output to 120,000 characters, cleans its temporary directory, and is unavailable in sandboxed runs.

## Validation

- `npm run plugin:build`
- `npm run plugin:validate`
- live transcript smoke test against a public YouTube video; returned timestamped transcript
- `npm audit --omit=dev` (0 vulnerabilities)
- installed plugin inspected as `youtube-tldw` with optional `youtube_tldw` tool
- `kustomize build kubernetes/apps/base/llm/openclaw/app`
- rendered OpenClaw configuration validates successfully
