### PR TITLE
refactor(llm): move llama.cpp flags with CRD fields out of extraArgs

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
@@ -56,6 +56,10 @@ spec:
     gpu: 1
     cpu: "500m"
     memory: 16Gi
+  speculativeDecoding:
+    type: draft-mtp
+    nDraftMax: 2
+    pMin: 0.75
   extraArgs:
     - --alias
     - llama-nvidia
@@ -63,12 +67,6 @@ spec:
     - --image-min-tokens
     - "1024"
     - --cont-batching
-    - --spec-type
-    - draft-mtp
-    - --spec-draft-p-min
-    - "0.75"
-    - --spec-draft-n-max
-    - "2"
     - --spec-draft-type-k
     - q8_0
     - --spec-draft-type-v

--- a/kubernetes/apps/base/llm/memini/memini-embed.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-embed.yaml
@@ -46,14 +46,10 @@ spec:
   resources:
     cpu: "2"
     memory: 8Gi
+  mode: embedding
   extraArgs:
     - --alias
     - memini-embed
-    - --embeddings
-    - --pooling
-    - last
-    - --cache-ram
-    - "0"
     - --cont-batching
     - --threads
     - "6"

--- a/kubernetes/apps/base/llm/memini/memini-rerank.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-rerank.yaml
@@ -46,14 +46,10 @@ spec:
   resources:
     cpu: "2"
     memory: 4Gi
+  mode: rerank
   extraArgs:
     - --alias
     - memini-rerank
-    - --rerank
-    - --pooling
-    - rank
-    - --cache-ram
-    - "0"
     - --cont-batching
     - --kv-unified
     - --threads

--- a/kubernetes/apps/base/llm/toolhive/config/toolhive-embed.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/toolhive-embed.yaml
@@ -47,14 +47,10 @@ spec:
   resources:
     cpu: "2"
     memory: 6Gi
+  mode: embedding
   extraArgs:
     - --alias
     - toolhive-embed
-    - --embeddings
-    - --pooling
-    - last
-    - --cache-ram
-    - "0"
     - --cont-batching
     - --kv-unified
     - --threads


### PR DESCRIPTION
An audit of all five InferenceServices for `extraArgs` that duplicate first-class CRD fields. Three moves, plus one status bug found on the way.

## What moves

| service | was in `extraArgs` | now |
|---|---|---|
| `llama-nvidia` | `--spec-type draft-mtp --spec-draft-p-min 0.75 --spec-draft-n-max 2` | `speculativeDecoding: {type, nDraftMax, pMin}` |
| `memini-rerank` | `--rerank --pooling rank --cache-ram 0` | `mode: rerank` |
| `memini-embed`, `toolhive-embed` | `--embeddings --pooling last --cache-ram 0` | `mode: embedding` |

`llama-strix` already used `speculativeDecoding` for the identical feature, so the same setting lived in two different places depending on which server you looked at. The operator emits `-md` only when a draft model actually resolves (`runtime_llamacpp_args.go:265`), so `llama-nvidia` needs no `draftModel`.

## The rerank one is a real bug, in a second commit

`memini-rerank` reports `status.mode=chat`. The operator infers mode by looking for `--reranking` (`runtime_args.go:53`) and the config passes llama.cpp's other spelling, `--rerank`; the endpoint path is `/v1/chat/completions`, so the path fallback misses it too.

**Serving was never affected.** `appendModeArgs` is handed `spec.Mode` directly rather than the inferred value (`runtime_llamacpp.go:154`), so with `mode` unset the operator contributed nothing and the hand-written flags did all the work. The wrong value only ever reached `status.mode` and sglang's arg builder, neither of which touches a llamacpp rerank path.

It is a separate commit because it is the only change that alters the emitted command line: the operator renders `--reranking --embedding --pooling rank --cache-ram 0` where the config had `--rerank --pooling rank --cache-ram 0`. Per `llama-server --help` on the running pod, `--rerank, --reranking` and `--embedding, --embeddings` are aliases, so the one real change is the added `--embedding` — which is what the operator considers correct for a reranker. Revert that commit alone if the reranker misbehaves.

The other three render an identical command line.

## What deliberately stays in extraArgs

`llama-strix`'s `--cache-dir /prompt-cache --cache-disk 49152` look like `pagedSSDCacheDir` / `pagedSSDCacheMaxSize`, but those fields are oMLX-only and explicitly ignored by the llamacpp runtime, so they must not move.

No CRD equivalent exists for `--spec-draft-type-k/-v`, `-sps`, `--spec-draft-adaptive`, `--spec-draft-n-min`, `--kv-unified`, `--cache-prompt`, `--cache-ram 40960`, `--threads*`, the sampling parameters, `--n-predict`, `--chat-template-kwargs`, `--reasoning-preserve`, `--tensor-read-lazy`, `--load-mode`, `--no-host`, `--no-repack`, `--image-min-tokens`, `--cont-batching`, `--no-mmproj-offload` or `--alias`.

## Verified

- `kubectl apply --dry-run=server` accepts all four.
- Alias claims read off `llama-server --help` in the running `memini-rerank` pod, not from documentation.

## Noted, not changed

`llama-strix` splits its speculative-decoding config across both places: `nDraftMax: 7` and `pMin: 0.75` in the field, `--spec-draft-adaptive --spec-draft-n-min 0` in `extraArgs`. Not wrong, since those two have no fields, but the feature is described in two places.

Claude-Session: https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh