### PR TITLE
feat(openclaw): add Sage avatar to identity

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -161,6 +161,7 @@ data:
             },
             identity: {
               name: "Sage",
+              avatar: "avatars/sage_avatar.png",
             }
           },
         ],


### PR DESCRIPTION
Adds `avatar: "avatars/sage_avatar.png"` to Sage's identity block in the OpenClaw configmap, matching the pattern used by Miso/Saffron/Matcha.

The avatar file itself (`workspace-sage/avatars/sage_avatar.png`) is already in place on the state PVC — repurposed classic Sage profile photo. Pairs with her updated workspace IDENTITY.md (she/her).

Merge + reconcile will roll the OpenClaw pod and pick this up.