### PR TITLE
feat(llm): whisper.cpp transcription on Strix, with an Iris backup

### DIFF
--- a/kubernetes/apps/base/llm/whisper/app/helmrelease-iris.yaml
+++ b/kubernetes/apps/base/llm/whisper/app/helmrelease-iris.yaml
@@ -1,0 +1,103 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: whisper-iris
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: whisper
+  interval: 15m
+  values:
+    controllers:
+      whisper-iris:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          fetch:
+            image:
+              repository: docker.io/kyuz0/amd-strix-halo-toolboxes
+              tag: vulkan-radv@sha256:e826113103d41100bfab93bcdf95aa6141285a4391f871dc40b8887dfe67ca3f
+            command:
+              - bash
+              - -c
+              - |
+                set -euo pipefail
+                cd /cache
+                if [ ! -x "bin/$${WHISPER_VERSION}/whisper-server" ]; then
+                  curl -fsSL -o w.tgz "https://github.com/lemonade-sdk/whisper.cpp-rocm/releases/download/$${WHISPER_VERSION}/whisper-$${WHISPER_VERSION}-linux-vulkan-x86_64.tar.gz"
+                  python3 -c "import tarfile;tarfile.open('w.tgz').extractall('x')"
+                  mkdir -p "bin/$${WHISPER_VERSION}"
+                  mv x/whisper-*-linux-vulkan-x86_64/* "bin/$${WHISPER_VERSION}/"
+                  rm -rf x w.tgz
+                fi
+                if [ ! -s "$${WHISPER_MODEL_FILE}" ]; then
+                  curl -fsSL -o "$${WHISPER_MODEL_FILE}" "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/$${WHISPER_MODEL_FILE}"
+                fi
+                ls -l "bin/$${WHISPER_VERSION}/whisper-server" "$${WHISPER_MODEL_FILE}"
+            env:
+              WHISPER_VERSION: v1.8.4
+              WHISPER_MODEL_FILE: ggml-large-v3-turbo-q8_0.bin
+        containers:
+          app:
+            image:
+              repository: docker.io/kyuz0/amd-strix-halo-toolboxes
+              tag: vulkan-radv@sha256:e826113103d41100bfab93bcdf95aa6141285a4391f871dc40b8887dfe67ca3f
+            securityContext:
+              privileged: true
+            command:
+              - /cache/bin/v1.8.4/whisper-server
+            args:
+              - --model
+              - /cache/ggml-large-v3-turbo-q8_0.bin
+              - --host
+              - 0.0.0.0
+              - --port
+              - "8080"
+              - --threads
+              - "4"
+            env:
+              LD_LIBRARY_PATH: /cache/bin/v1.8.4
+            resources:
+              requests:
+                cpu: 500m
+                memory: 4Gi
+              limits:
+                memory: 8Gi
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /, port: 8080 }
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /, port: 8080 }
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  failureThreshold: 6
+    defaultPodOptions:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: whisper-iris
+    service:
+      app:
+        ports:
+          http:
+            port: 8080
+    persistence:
+      cache:
+        existingClaim: whisper-iris-cache
+        globalMounts:
+          - path: /cache

--- a/kubernetes/apps/base/llm/whisper/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/whisper/app/helmrelease.yaml
@@ -1,0 +1,102 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: whisper
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: whisper
+  interval: 15m
+  values:
+    controllers:
+      whisper:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          fetch:
+            image:
+              repository: docker.io/kyuz0/amd-strix-halo-toolboxes
+              tag: vulkan-radv@sha256:e826113103d41100bfab93bcdf95aa6141285a4391f871dc40b8887dfe67ca3f
+            command:
+              - bash
+              - -c
+              - |
+                set -euo pipefail
+                cd /cache
+                if [ ! -x "bin/$${WHISPER_VERSION}/whisper-server" ]; then
+                  curl -fsSL -o w.tgz "https://github.com/lemonade-sdk/whisper.cpp-rocm/releases/download/$${WHISPER_VERSION}/whisper-$${WHISPER_VERSION}-linux-vulkan-x86_64.tar.gz"
+                  python3 -c "import tarfile;tarfile.open('w.tgz').extractall('x')"
+                  mkdir -p "bin/$${WHISPER_VERSION}"
+                  mv x/whisper-*-linux-vulkan-x86_64/* "bin/$${WHISPER_VERSION}/"
+                  rm -rf x w.tgz
+                fi
+                if [ ! -s "$${WHISPER_MODEL_FILE}" ]; then
+                  curl -fsSL -o "$${WHISPER_MODEL_FILE}" "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/$${WHISPER_MODEL_FILE}"
+                fi
+                ls -l "bin/$${WHISPER_VERSION}/whisper-server" "$${WHISPER_MODEL_FILE}"
+            env:
+              WHISPER_VERSION: v1.8.4
+              WHISPER_MODEL_FILE: ggml-large-v3-turbo-q8_0.bin
+        containers:
+          app:
+            image:
+              repository: docker.io/kyuz0/amd-strix-halo-toolboxes
+              tag: vulkan-radv@sha256:e826113103d41100bfab93bcdf95aa6141285a4391f871dc40b8887dfe67ca3f
+            securityContext:
+              privileged: true
+            command:
+              - /cache/bin/v1.8.4/whisper-server
+            args:
+              - --model
+              - /cache/ggml-large-v3-turbo-q8_0.bin
+              - --host
+              - 0.0.0.0
+              - --port
+              - "8080"
+              - --threads
+              - "4"
+            env:
+              LD_LIBRARY_PATH: /cache/bin/v1.8.4
+            resources:
+              requests:
+                cpu: 500m
+                memory: 4Gi
+              limits:
+                memory: 8Gi
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /, port: 8080 }
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /, port: 8080 }
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  failureThreshold: 6
+    defaultPodOptions:
+      nodeSelector:
+        topology.kubernetes.io/gpus: amd
+      tolerations:
+        - key: llm-workload
+          operator: Exists
+          effect: NoSchedule
+    service:
+      app:
+        ports:
+          http:
+            port: 8080
+    persistence:
+      cache:
+        existingClaim: whisper-cache
+        globalMounts:
+          - path: /cache

--- a/kubernetes/apps/base/llm/whisper/app/kustomization.yaml
+++ b/kubernetes/apps/base/llm/whisper/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./helmrelease-iris.yaml
+  - ./ocirepository.yaml
+  - ./persistentvolumeclaim.yaml

--- a/kubernetes/apps/base/llm/whisper/app/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/whisper/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: whisper
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/whisper/app/persistentvolumeclaim.yaml
+++ b/kubernetes/apps/base/llm/whisper/app/persistentvolumeclaim.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: whisper-cache
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: local-hostpath
+  resources:
+    requests:
+      storage: 8Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: whisper-iris-cache
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 8Gi

--- a/kubernetes/apps/main/llm/kustomization.yaml
+++ b/kubernetes/apps/main/llm/kustomization.yaml
@@ -23,3 +23,4 @@ resources:
   - ./repo-wiki.yaml
   - ./searxng.yaml
   - ./toolhive.yaml
+  - ./whisper.yaml

--- a/kubernetes/apps/main/llm/whisper.yaml
+++ b/kubernetes/apps/main/llm/whisper.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app whisper
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/whisper/app
+  postBuild:
+    substitute:
+      APP: *app
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system


### PR DESCRIPTION
Benchmarked `large-v3-turbo` q8_0 on 297s of speech: CPU does 1.6x realtime at both 6 and 12 threads (threads make no difference — it saturates below 6), the Iris Xe iGPU does 3.0x, and Strix over Vulkan does 19.8x for a GTT delta of only 1164 MiB, so a 20-minute video is ~61s on Strix versus 12.6 minutes on CPU. ROCm is not usable — the lemonade gfx1151 build detects the GPU but aborts in graph compute with an empty ROCm error even with the Tensile paths set — so both instances run the Vulkan build. This adds two resident deployments, whisper on Strix and whisper-iris as fallback, where omitting the `llm-workload` toleration is what keeps the Iris one off skirk; Strix caches to local NVMe since it is pinned there anyway while Iris caches to ceph-block to stay reschedulable across the MS-01 nodes. The binary and model are fetched by an initContainer into the cache PVC rather than baked into an image, because no upstream whisper.cpp image ships a Vulkan build — both are version-pinned in env.