### PR TITLE
feat(openclaw): allow Sage in Tako Tuesday guild

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -291,6 +291,9 @@ data:
                 "western-subaru-club": {
                   requireMention: true,
                 },
+                "tako-tuesday": {
+                  requireMention: true,
+                },
                 "*": { users: ["$${DISCORD_ADMIN_USER_ID}"] },
               },
             },


### PR DESCRIPTION
Sage's Discord bot is already invited to Tako Tuesday — this adds the guild to her OpenClaw allowlist with `requireMention: true`, same as WSC.

Same role, same mention gating. Plain-text "Sage" will trigger her there too (derived mention pattern), same as WSC.