### PR TITLE
feat(openclaw): give Sage a Reddit thread reader

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -152,7 +152,7 @@ data:
             name: "Sage",
             workspace: "/home/node/.openclaw/workspace-sage",
             agentDir: "/home/node/.openclaw/agents/sage/agent",
-            tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "youtube_tldw", "sage_runtime_status", "sage_office_temperature", "memory_recall", "memory_list", "memory_remember"] },
+            tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "youtube_tldw", "reddit_thread", "sage_runtime_status", "sage_office_temperature", "memory_recall", "memory_list", "memory_remember"] },
             contextLimits: { toolResultMaxChars: 8000 },
             thinkingDefault: "low",
             model: {
@@ -302,11 +302,12 @@ data:
         },
       },
       plugins: {
-        allow: ["discord", "lossless-claw", "memini", "searxng", "comfy", "memory-wiki", "chart-renderer", "youtube-tldw", "sage-environment"],
+        allow: ["discord", "lossless-claw", "memini", "searxng", "comfy", "memory-wiki", "chart-renderer", "youtube-tldw", "reddit-thread", "sage-environment"],
         entries: {
           discord: { enabled: true },
           "chart-renderer": { enabled: true },
           "youtube-tldw": { enabled: true },
+          "reddit-thread": { enabled: true },
           comfy: {
             enabled: true,
             config: {


### PR DESCRIPTION
Reddit's JSON endpoints began returning 403 in May 2026 and the HTML is now a JS shell that serves no content, so neither `web_fetch` nor scraping reaches a thread, and self-service OAuth registration closed in late 2025 which rules out the sanctioned API without manual approval. The per-thread Atom feed still serves the submission, its comments and the external URL a link post points at, all in a single request — enough to drop a Reddit link and get back the discussion plus the article it references. This registers the `reddit-thread` extension and adds its `reddit_thread` tool to Sage's allowlist; the extension shells out to a script so feed handling can change without rebuilding the plugin.