### PR TITLE
feat(openclaw): add narrow Sage environment tools

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -152,7 +152,7 @@ data:
             name: "Sage",
             workspace: "/home/node/.openclaw/workspace-sage",
             agentDir: "/home/node/.openclaw/agents/sage/agent",
-            tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "youtube_tldw", "memory_recall", "memory_list", "memory_remember"] },
+            tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "youtube_tldw", "sage_runtime_status", "sage_office_temperature", "memory_recall", "memory_list", "memory_remember"] },
             contextLimits: { toolResultMaxChars: 8000 },
             thinkingDefault: "low",
             model: {
@@ -299,7 +299,7 @@ data:
         },
       },
       plugins: {
-        allow: ["discord", "lossless-claw", "memini", "searxng", "comfy", "memory-wiki", "chart-renderer", "youtube-tldw"],
+        allow: ["discord", "lossless-claw", "memini", "searxng", "comfy", "memory-wiki", "chart-renderer", "youtube-tldw", "sage-environment"],
         entries: {
           discord: { enabled: true },
           "chart-renderer": { enabled: true },

--- a/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
@@ -29,6 +29,7 @@ spec:
         OPENAI_CODEX_USERNAME: "{{ .OPENAI_CODEX_USERNAME }}"
         SAFFRON_BOT_TOKEN: "{{ .SAFFRON_BOT_TOKEN }}"
         SAGE_BOT_TOKEN: "{{ .SAGE_BOT_TOKEN }}"
+        HOMEASSISTANT_TOKEN: "{{ .HOMEASSISTANT_TOKEN }}"
         WEATHER_UNDERGROUND_API_KEY: "{{ .WEATHER_UNDERGROUND_API_KEY }}"
         CONTEXT7_API_KEY: "{{ .OPENCLAW_API_KEY }}"
         MEMINI_API_KEY: "{{ .MEMINI_API_KEY }}"
@@ -54,6 +55,8 @@ spec:
         key: dispatch
     - extract:
         key: waypoint
+    - extract:
+        key: home-assistant
     - extract:
         key: wunderground
     - extract:


### PR DESCRIPTION
Adds the GitOps wiring for two fixed-scope tools implemented on OpenClaw's PVC:

- `sage_runtime_status`: public, read-only current power/temperature/utilization for Sage's `llama-nvidia` GPU via fixed Prometheus queries. It explicitly describes the GPU as shared and does not claim per-answer energy attribution.
- `sage_office_temperature`: public, read-only access to exactly `sensor.airthings_wave2_133155_temperature`. No entity parameter, history, occupancy, controls, or HA discovery.

Config changes:
- allow the `sage-environment` plugin
- add both tool names only to Sage's allowlist
- inject the existing `home-assistant` secret's `HOMEASSISTANT_TOKEN` into OpenClaw for the fixed HA state lookup

The plugin is built and validated on the OpenClaw PVC. Merge/reconcile restarts OpenClaw and loads it.
