### PR TITLE
fix(memini): restore the rerank batch size and widen the embed timeout

### DIFF
--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
               MEMINI_EMBED_DIMS: "1024"
               MEMINI_EMBED_QUERY_PREFIX: "Instruct: Given a user message, retrieve relevant past memories\nQuery: "
               MEMINI_EMBED_MAX_CONCURRENCY: 2
-              MEMINI_RECALL_EMBED_TIMEOUT: 5s
+              MEMINI_RECALL_EMBED_TIMEOUT: 15s
               MEMINI_WRITE_DEDUP_SCORE: "0.80"
               MEMINI_WRITE_DEDUP_ACTION: coalesce
               MEMINI_DEDUP_TIERS: episodic,semantic,procedural

--- a/kubernetes/apps/base/llm/memini/memini-rerank.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-rerank.yaml
@@ -36,8 +36,8 @@ spec:
           cpu-inference: "true"
   contextSize: 8096
   parallelSlots: 2
-  batchSize: 2048
-  uBatchSize: 2048
+  batchSize: 8192
+  uBatchSize: 8192
   env:
     - name: GOMP_CPU_AFFINITY
       value: "0-11"
@@ -45,7 +45,7 @@ spec:
       value: "granularity=fine,proc_list=[0-11],explicit"
   resources:
     cpu: "2"
-    memory: 4Gi
+    memory: 8Gi
   mode: rerank
   extraArgs:
     - --alias


### PR DESCRIPTION
Rerank began returning 500 on real recalls — `input (2793 tokens) is too large to process (current batch size: 2048)` — because uBatchSize was cut 4096→2048 to reclaim GTT on Strix, and rerank now runs on CPU where memory is ordinary node RAM, so that reduction only truncates work; a reranker needs a physical batch at least as large as its longest query+document pair, so both batch sizes now sit above contextSize with a matching memory bump. The embed timeouts were the other half of the alert: CPU embed latency is p50 4ms / p95 507ms / p99 1.72s, so the 5s ceiling sat inside the tail and two of ~358 calls exceeded it, degrading one recall to keyword-only — 15s clears the tail without masking a genuine outage.