### PR TITLE
fix(openclaw): remove Sage memory write access

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -152,7 +152,7 @@ data:
             name: "Sage",
             workspace: "/home/node/.openclaw/workspace-sage",
             agentDir: "/home/node/.openclaw/agents/sage/agent",
-            tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "youtube_tldw", "reddit_thread", "sage_runtime_status", "sage_office_temperature", "memory_recall", "memory_list", "memory_remember"] },
+            tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "youtube_tldw", "reddit_thread", "sage_runtime_status", "sage_office_temperature", "memory_recall", "memory_list"] },
             contextLimits: { toolResultMaxChars: 8000 },
             thinkingDefault: "low",
             model: {


### PR DESCRIPTION
Removes `memory_remember` from Sage's tool allowlist while retaining read-only `memory_recall` and `memory_list`.

Why: public Discord users successfully induced Sage to persist fabricated accessibility/identity claims and escalating formatting gimmicks. The poisoned memories have been removed, and Sage's workspace prompt now rejects these requests, but prompt-only enforcement is insufficient for a public bot.

Follow-up: replace general memory writes with a narrow source-backed Subaru reference-memory tool.
