### PR TITLE
feat(openclaw): give Sage a Facebook listing reader

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -152,7 +152,7 @@ data:
             name: "Sage",
             workspace: "/home/node/.openclaw/workspace-sage",
             agentDir: "/home/node/.openclaw/agents/sage/agent",
-            tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "youtube_tldw", "reddit_thread", "sage_runtime_status", "sage_office_temperature", "memory_recall", "memory_list", "memory_remember"] },
+            tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "youtube_tldw", "reddit_thread", "facebook_listing", "sage_runtime_status", "sage_office_temperature", "memory_recall", "memory_list", "memory_remember"] },
             contextLimits: { toolResultMaxChars: 8000 },
             thinkingDefault: "low",
             model: {
@@ -302,12 +302,13 @@ data:
         },
       },
       plugins: {
-        allow: ["discord", "lossless-claw", "memini", "searxng", "comfy", "memory-wiki", "chart-renderer", "youtube-tldw", "reddit-thread", "sage-environment"],
+        allow: ["discord", "lossless-claw", "memini", "searxng", "comfy", "memory-wiki", "chart-renderer", "youtube-tldw", "reddit-thread", "facebook-listing", "sage-environment"],
         entries: {
           discord: { enabled: true },
           "chart-renderer": { enabled: true },
           "youtube-tldw": { enabled: true },
           "reddit-thread": { enabled: true },
+          "facebook-listing": { enabled: true },
           comfy: {
             enabled: true,
             config: {


### PR DESCRIPTION
Facebook answers an ordinary browser user-agent with a 400 but serves OpenGraph tags to its own link-preview crawler, and share links redirect to the underlying Marketplace item, so a share URL resolves cleanly to title, category, location, photo and canonical listing URL. Two limits are structural rather than bugs — Facebook truncates the description at 200 characters, and the price is rendered client-side so it never appears in the preview payload at all — and the tool states both explicitly, instructing Sage to report them as unavailable rather than infer them. Adds the `facebook-listing` extension and its `facebook_listing` tool to Sage's allowlist, following the same script-backed pattern as `reddit-thread`.