### PR TITLE
fix(towonel): publish UDP 8211 on the columbina hub for palworld

### DIFF
--- a/ansible/columbina/playbook.yaml
+++ b/ansible/columbina/playbook.yaml
@@ -182,6 +182,8 @@
           proto: udp
         - port: "27015"
           proto: udp
+        - port: "8211"
+          proto: udp
         - port: "7881"
           proto: tcp
         - port: "7882"

--- a/docker/columbina/01-towonel/docker-compose.yaml
+++ b/docker/columbina/01-towonel/docker-compose.yaml
@@ -52,6 +52,7 @@ services:
       - "2458:2458/udp"
       - "15637:15637/udp"
       - "27015:27015/udp"
+      - "8211:8211/udp"
       - "7881:7881/tcp"
       - "7882:7882/udp"
     restart: unless-stopped


### PR DESCRIPTION
Palworld was unreachable through towonel because the hub container on columbina never published 8211/udp to the host, even though the operator had reserved the port and the agent was serving it. This adds the port mapping to the compose file so doco-cd picks it up, and the matching ufw rule to the columbina playbook. Connecting internally by palworld.jory.dev hairpins through the VPS, so this fixes that path too.