### PR TITLE
chore(foreman): pin the coder image carrying the rebar3 fix

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -77,7 +77,7 @@ spec:
         cpu: 8
         memory: 8Gi
     activeDeadlineSeconds: 43200
-    image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:cd6309efd0f0a874e8fd9f431d539d5e7eb9f2b1f6fce802aa8b685cc05300ef
+    image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:37f45f0f30d4d8ff2461aa181afe014fed2eb99bb9c9ce57ba31144422cd851e
     mode: Job
     serviceAccountName: foreman-coder
   requiredCapability:

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -78,7 +78,7 @@ spec:
         cpu: 8
         memory: 8Gi
     activeDeadlineSeconds: 43200
-    image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:cd6309efd0f0a874e8fd9f431d539d5e7eb9f2b1f6fce802aa8b685cc05300ef
+    image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:37f45f0f30d4d8ff2461aa181afe014fed2eb99bb9c9ce57ba31144422cd851e
     mode: Job
     serviceAccountName: foreman-coder
   requiredCapability:

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -80,7 +80,7 @@ spec:
         cpu: 8
         memory: 8Gi
     activeDeadlineSeconds: 43200
-    image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:cd6309efd0f0a874e8fd9f431d539d5e7eb9f2b1f6fce802aa8b685cc05300ef
+    image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:37f45f0f30d4d8ff2461aa181afe014fed2eb99bb9c9ce57ba31144422cd851e
     mode: Job
     serviceAccountName: foreman-coder
   requiredCapability:


### PR DESCRIPTION
Bumps the three coder Agents from `cd6309ef` to `37f45f0f`.

This is the first coder image to carry [llmkube-images#302](https://github.com/misospace/llmkube-images/pull/302) (registers rebar3 where Mix looks for it) — #302 merged hours ago but its release build failed the vulnerability scan, so it never published until [#304](https://github.com/misospace/llmkube-images/pull/304) fixed the gate.

## Verified in the artifact, not the tag

```
rebar3 registered : /opt/mix/elixir/1-20-otp-27/rebar3
deepmerge-ts      : 8.0.2
mysql2            : 3.22.0
tsc               : 6.0.3
os                : Debian GNU/Linux 13 (trixie)
```

The outgoing pin `cd6309ef` has no `/opt/mix/elixir` directory at all, so Mix cannot find rebar3, installs its own copy into root-owned `/opt/mix`, and fails as uid 65534. That is what has been blocking the pinchflat Elixir work — and it was never the `elixir-gate` image, which nothing dispatches.

`kubectl apply --dry-run=server` accepts all three.

## After this reconciles

misospace/pinchflat#79, #80 and #81 can be requeued. They were parked waiting on a fixed `elixir-gate` image, which was the wrong image the whole time.

Claude-Session: https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh