### PR TITLE
feat(openclaw): add narrow Sage reference memory

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -152,7 +152,7 @@ data:
             name: "Sage",
             workspace: "/home/node/.openclaw/workspace-sage",
             agentDir: "/home/node/.openclaw/agents/sage/agent",
-            tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "youtube_tldw", "reddit_thread", "facebook_listing", "sage_runtime_status", "sage_office_temperature", "memory_recall", "memory_list"] },
+            tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "youtube_tldw", "reddit_thread", "facebook_listing", "sage_runtime_status", "sage_office_temperature", "sage_reference_remember", "memory_recall", "memory_list"] },
             contextLimits: { toolResultMaxChars: 8000 },
             thinkingDefault: "low",
             model: {
@@ -302,7 +302,7 @@ data:
         },
       },
       plugins: {
-        allow: ["discord", "lossless-claw", "memini", "searxng", "comfy", "memory-wiki", "chart-renderer", "youtube-tldw", "reddit-thread", "facebook-listing", "sage-environment"],
+        allow: ["discord", "lossless-claw", "memini", "searxng", "comfy", "memory-wiki", "chart-renderer", "youtube-tldw", "reddit-thread", "facebook-listing", "sage-environment", "sage-reference-memory"],
         entries: {
           discord: { enabled: true },
           "chart-renderer": { enabled: true },


### PR DESCRIPTION
Adds the GitOps wiring for the PVC-backed `sage-reference-memory` plugin.

The replacement tool, `sage_reference_remember`, is exposed only to Sage and accepts one concise Subaru-domain fact plus 1-5 external HTTP(S) citations, a category, and optional market/model year.

Enforced in plugin code:
- namespace fixed to `openclaw/sage`
- tier fixed to `semantic`
- tags fixed to `sage-reference` and `subaru`
- rejects Discord/social/shortener sources
- rejects profiles, preferences, instructions, formatting requests, jokes, and chat logs
- no caller-controlled namespace, ID, tier, tags, or arbitrary metadata
- bounded fields and 10-second request timeout

Verification on the PVC:
- strict TypeScript build passes
- 67/67 validation checks pass
- OpenClaw plugin validation passes
- live store round-trip passed and test memories were removed

This restores narrowly scoped source-backed reference writes without reintroducing general `memory_remember` access.
