### PR TITLE
tune(llm): match strix capacity, give the groomer its full window

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -66,7 +66,7 @@ spec:
               GATEPROFILE_MAP: '{"misospace/pr-reviewer-action":{"testLayout":{"testRoot":"tests","sourceRoot":"pr_reviewer"}},"misospace/windowstead":{"testLayout":{"testRoot":"tests","sourceRoot":"scripts"},"sourceExtensions":[".gd"]},"misospace/pinchflat":{"testLayout":{"testRoot":"test","sourceRoot":"lib"},"sourceExtensions":[".ex",".exs",".heex"]},"misospace/foreman-dispatch-bridge":{"testLayout":{"testRoot":"tests","sourceRoot":"bridge"}},"misospace/miso-chat":{"testLayout":{"testRoot":"tests","sourceRoot":"lib"}},"*":{"sourceExtensions":[".go",".hcl"]}}'
               REVISION_CODER_AGENTS: '{"*":"coder-revision"}'
               PR_FIX_ENABLED: "true"
-              PR_FIX_MAX_ATTEMPTS: "3"
+              PR_FIX_MAX_ATTEMPTS: "4"
               PR_FIX_LANE_AGENTS: '{"NORMAL":"coder-frontier","ESCALATED":"coder-frontier"}'
             envFrom:
               - secretRef:

--- a/kubernetes/apps/base/llm/dispatch/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
               DISPATCH_EXCLUDED_LABELS: renovate
               DISPATCH_GROOMER_DRY_RUN: false
               DISPATCH_GROOMER_MODEL: llama-strix
-              DISPATCH_GROOMER_MODEL_CONTEXT_TOKENS: 131072
+              DISPATCH_GROOMER_MODEL_CONTEXT_TOKENS: 262144
               DISPATCH_GROOMER_REPO_CONTEXT_ENABLED: true
               DISPATCH_HOSTED_GROOMER_ENABLED: true
               DISPATCH_LANE_CONFIG_JSON: '{"lanes":[{"id":"local","title":"Local","claimable":true,"role":"default","description":"Local model lane (nvidia) — the default. Determinate work: the change is already clear from the issue and its code, and a worker only has to carry it out. Free to run, so prefer it whenever the work does not need a judgement call.","color":"#3b82f6"},{"id":"frontier","title":"Frontier","claimable":true,"role":"escalation","description":"Escalation lane (MiniMax-M3 via litellm) — a large hosted model with a ~1M context. For work that needs a decision between alternatives: design or architecture changes, fixes whose correct approach is arguable, or changes that must hold several modules in mind at once. Costs tokens per run, so determinate work belongs in local however large it is.","color":"#f97316"},{"id":"backlog","title":"Backlog","claimable":false,"description":"Needs grooming before work can start. Not directly claimable.","color":"#6b7280"}],"laneAliases":{"normal":"local","escalated":"frontier","cloud":"local"}}'

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-3.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-3.yaml
@@ -16,7 +16,7 @@ spec:
       top_k: 20
       min_p: 0
       order: 3
-      max_parallel_requests: 2
+      max_parallel_requests: 1
   info:
     mode: chat
     maxInputTokens: 262144

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-chat-3.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-chat-3.yaml
@@ -17,7 +17,7 @@ spec:
       repetition_penalty: 1.0
       reasoning_effort: none
       order: 3
-      max_parallel_requests: 2
+      max_parallel_requests: 1
       allowed_openai_params:
         - reasoning_effort
   info:


### PR DESCRIPTION
Three settings the audit found disagreeing with measured reality. One file each.

## Strix pool rungs: `max_parallel_requests` 2 → 1

`llama-strix`'s `/props` reports **`total_slots: 1`** with `n_ctx` 262144 per slot (build `b1-25a849b`), while `local-pool` and `local-pool-chat` rung 3 both advertise 2. With `enable_pre_call_checks`, litellm believed there was spare capacity while a request was already in flight, so a second one queued inside llama.cpp rather than overflowing to another rung — which is the whole point of the rung ordering.

Only those two aliases share that server. `dsv4f-local`, `muse` and `strix-fp8` point at `llama-strix-dsv4f`, `llama-strix-muse` and `llama-strix-fp8`, which are separate services.

Raising the server to two slots was the alternative and is worse here: llama.cpp splits `--ctx-size` across slots, and that 262144 window is exactly what the groomer runs on.

This reverses guidance from earlier ("strix has 2"), on the strength of what the running server reports.

## Groomer context: 131072 → 262144

`DISPATCH_GROOMER_MODEL_CONTEXT_TOKENS` was 131072 while `llama-strix` both serves and declares `maxInputTokens: 262144`, with no comment explaining the halving. The groomer's exploration budget derives from that number, so it has been exploring at half the window the hardware allows.

## `PR_FIX_MAX_ATTEMPTS`: 3 → 4

A probe rather than the 5 that bridge #274 floated. `BUDGET-EXHAUSTED` now consumes an attempt but earns another (bridge 0.7.7) and merge conflicts are repaired rather than abandoned, so a fourth attempt is likelier to converge than when 3 was chosen. One extra attempt shows whether the fourth ever lands before committing to 5.

## Audit findings deliberately NOT acted on

Two things I flagged in the audit turned out to be wrong on inspection, and I'd rather record that than quietly drop them.

**`coder-revision` missing from `CODER_AGENT_SLOTS` is not a defect.** `revision_coder_agent_for` (`bridge/workload.py`) is a pure lane lookup that never consults slot accounting — `_slots_for` only governs `_pick_coder`, which selects the *base* coder from candidate lists. The revision agent is stamped onto `Workload.spec.revisionCoderAgentRef` and dispatched by the controller.

**`openPullRequestsAsDraft: false` on the coders is defensive, not dead.** The CRD documents nil as **true**, so removing it would flip those agents to opening drafts — and drafts skip review, which is the bug #9643 fixed. It stays.

Also left alone: `foreman-default-agent` (200m vs 0.025 peak) and `foreman-operator` (100m vs 0.003). Roughly 275m of over-reservation, and changing it restarts `foreman-agent`, which kills any in-flight InProcess review. Not worth that for the saving.

## Verified

`kubectl apply --dry-run=server` accepts both LiteLLMModels; both helmreleases still parse.

Claude-Session: https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh