### PR TITLE
feat(toolhive): add plan shop eat mcp

### DIFF
--- a/.agents/instructions/sorting.instructions.md
+++ b/.agents/instructions/sorting.instructions.md
@@ -20,6 +20,18 @@ Whenever asked to sort these files, follow these instructions:
     - `annotations`
     - `labels`
 
+## ExternalSecret conventions
+
+Before adding or editing an `ExternalSecret`, read 1-2 neighboring `externalsecret.yaml` files and match their structure, templating, naming anchors, and indentation. Apply this to integrations within existing apps as well as new apps.
+
+For the usual 1Password-backed secret:
+
+- Use `secretStoreRef` with `kind: ClusterSecretStore` and `name: onepassword`.
+- Keep `spec` fields in this order: `refreshInterval` (if used locally), `secretStoreRef`, `target`, `dataFrom`. This overrides alphabetical sorting.
+- Use `dataFrom.extract.key` for the 1Password item, matching neighboring manifests. Do not replace it with individual `data.remoteRef.property` mappings just because only one field is needed.
+- When selecting, renaming, or formatting output keys, use `target.template.data`; for example, `Authorization: "Bearer {{ .MCP_ACCESS_TOKEN }}"`. Keep credentials out of manifests.
+- Preserve specialized existing configurations. If a different retrieval structure is required, explain the concrete reason instead of silently introducing a new pattern.
+
 ## HelmRelease rules for app-template
 
 This section gives instructions specifically for HelmReleases that are based on the `app-template` chart. In this repository, that is typically identified by `spec.chartRef.name: app-template`.

--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/plan-shop-eat-mcp/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/plan-shop-eat-mcp/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-plan-shop-eat
+spec:
+  data:
+    - remoteRef:
+        key: plan shop eat
+        property: MCP_ACCESS_TOKEN
+      secretKey: MCP_ACCESS_TOKEN
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: *name
+    template:
+      data:
+        Authorization: "Bearer {{ .MCP_ACCESS_TOKEN }}"

--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/plan-shop-eat-mcp/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/plan-shop-eat-mcp/externalsecret.yaml
@@ -5,11 +5,6 @@ kind: ExternalSecret
 metadata:
   name: &name toolhive-plan-shop-eat
 spec:
-  data:
-    - remoteRef:
-        key: plan shop eat
-        property: MCP_ACCESS_TOKEN
-      secretKey: MCP_ACCESS_TOKEN
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword
@@ -18,3 +13,6 @@ spec:
     template:
       data:
         Authorization: "Bearer {{ .MCP_ACCESS_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: plan shop eat

--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/plan-shop-eat-mcp/kustomization.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/plan-shop-eat-mcp/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./mcpserverentry.yaml

--- a/kubernetes/apps/base/llm/toolhive/mcp-servers/plan-shop-eat-mcp/mcpserverentry.yaml
+++ b/kubernetes/apps/base/llm/toolhive/mcp-servers/plan-shop-eat-mcp/mcpserverentry.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserverentry_v1beta1.json
+apiVersion: toolhive.stacklok.dev/v1beta1
+kind: MCPServerEntry
+metadata:
+  name: plan-shop-eat
+spec:
+  groupRef:
+    name: mcp-tools
+  headerForward:
+    addHeadersFromSecret:
+      - headerName: Authorization
+        valueSecretRef:
+          key: Authorization
+          name: toolhive-plan-shop-eat
+  remoteUrl: https://planshopeat.netlify.app/mcp
+  transport: streamable-http

--- a/kubernetes/apps/main/llm/toolhive.yaml
+++ b/kubernetes/apps/main/llm/toolhive.yaml
@@ -198,6 +198,24 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: plan-shop-eat-mcp
+spec:
+  dependsOn:
+    - name: toolhive
+    - name: toolhive-config
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/toolhive/mcp-servers/plan-shop-eat-mcp
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: seerr-mcp
 spec:
   dependsOn:


### PR DESCRIPTION
Connect Plan Shop Eat to ToolHive's `mcp-tools` group through a direct Streamable HTTP entry. External Secrets reads `MCP_ACCESS_TOKEN` from `Kubernetes/plan shop eat` in 1Password and supplies the bearer Authorization header; no token is stored in Git.

Document the existing ExternalSecret structure in the shared agent YAML instructions: inspect neighboring manifests, use `dataFrom.extract` with `target.template.data`, and preserve the established field order.

Validated authenticated initialization and discovery of all six documented tools, server-side dry runs of both resources, and `flate test all` for the LLM namespace (75 passed). The broader main-cluster check had 418 passes, 2 skips, and 16 unrelated failures caused by missing `ocharted.jory.dev` registry credentials. End-to-end gateway discovery and ExternalSecret reconciliation require deployment after merge.
