### PR TITLE
chore(foreman): pin the coder image with curl and the erlang CVE fix

### DIFF
--- a/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-frontier.yaml
@@ -77,7 +77,7 @@ spec:
         cpu: 8
         memory: 8Gi
     activeDeadlineSeconds: 43200
-    image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:37f45f0f30d4d8ff2461aa181afe014fed2eb99bb9c9ce57ba31144422cd851e
+    image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:3e78752dba541573777696abae37b2945574647f83d330b77f63a908bfce9edb
     mode: Job
     serviceAccountName: foreman-coder
   requiredCapability:

--- a/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder-revision.yaml
@@ -78,7 +78,7 @@ spec:
         cpu: 8
         memory: 8Gi
     activeDeadlineSeconds: 43200
-    image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:37f45f0f30d4d8ff2461aa181afe014fed2eb99bb9c9ce57ba31144422cd851e
+    image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:3e78752dba541573777696abae37b2945574647f83d330b77f63a908bfce9edb
     mode: Job
     serviceAccountName: foreman-coder
   requiredCapability:

--- a/kubernetes/apps/base/llm/foreman/agents/coder.yaml
+++ b/kubernetes/apps/base/llm/foreman/agents/coder.yaml
@@ -80,7 +80,7 @@ spec:
         cpu: 8
         memory: 8Gi
     activeDeadlineSeconds: 43200
-    image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:37f45f0f30d4d8ff2461aa181afe014fed2eb99bb9c9ce57ba31144422cd851e
+    image: ghcr.io/misospace/llmkube-coder:0.9.24@sha256:3e78752dba541573777696abae37b2945574647f83d330b77f63a908bfce9edb
     mode: Job
     serviceAccountName: foreman-coder
   requiredCapability:


### PR DESCRIPTION
Bumps the three coder Agents from `37f45f0f` to `3e78752d`.

Carries [llmkube-images#308](https://github.com/misospace/llmkube-images/pull/308) (curl and unzip retained — pinchflat's `tooling/fetch-sqlean.sh` shells out to curl) and [#309](https://github.com/misospace/llmkube-images/pull/309) (erlang 27.3.4.17, closing seven High CVEs that had blocked every coder release since #306).

## Verified in the artifact, not the tag

```
curl   : /usr/bin/curl
unzip  : /usr/bin/unzip
rebar3 : /opt/mix/elixir/1-20-otp-27/rebar3
erlang : 15.2.7.13   (ERTS for OTP 27.3.4.17)
mysql2 : 3.22.0
godot  : /usr/local/bin/godot
```

`15.2.7.13` is the ERTS version grype itself named as the fix for CVE-2026-75538, so the bump is confirmed from the outside rather than from the tag. #302's rebar3 registration and #304's mysql2 both survive.

`kubectl apply --dry-run=server` accepts all three.

## Time-sensitive

`misospace/pinchflat` 79–82 have had their `needs-human` park cleared, so each requeues when its tombstone hits the 48h TTL — #80 and #81 first, within a few hours. Until this is pinned those runs hit `curl: command not found` and burn a fresh coder attempt each.

If this cannot land before then, re-adding `needs-human` to #80 and #81 holds them without cost.

Claude-Session: https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh