### PR TITLE
fix(kopiur): shorten epochs and run quick maintenance hourly

### DIFF
--- a/kubernetes/apps/base/storage/kopiur/repository/repository.yaml
+++ b/kubernetes/apps/base/storage/kopiur/repository/repository.yaml
@@ -38,8 +38,8 @@ spec:
         cron: "0 3 * * *"
         jitter: 1h
       quick:
-        cron: "0 */6 * * *"
-        jitter: 30m
+        cron: "0 * * * *"
+        jitter: 10m
       timezone: America/Edmonton
     takeoverPolicy: Force
   mode: ReadWrite
@@ -52,4 +52,4 @@ spec:
       runAsUser: 1000
   parameters:
     epoch:
-      minDuration: 6h
+      minDuration: 1h


### PR DESCRIPTION
## Summary

Mirrors the Kopiur epoch/maintenance tuning from onedr0p/home-ops#11650 for this repository's shared `volsync` ClusterRepository.

## Changes

- Lower `parameters.epoch.minDuration` from `6h` to `1h`.
- Run quick maintenance hourly instead of every six hours.
- Reduce quick-maintenance jitter from `30m` to `10m`.
- Keep the existing daily full maintenance schedule and `America/Edmonton` timezone unchanged.

Kopia advances epochs during maintenance and compacts closed epochs after they age out of the live write window. Shorter epochs plus hourly quick maintenance should keep live index-blob growth bounded and reduce repository/cache pressure.

Reference: https://github.com/onedr0p/home-ops/pull/11650
