### PR TITLE
fix(container): update image ghcr.io/renovatebot/renovate (44.64.0 → 44.65.5)

### DIFF
--- a/kubernetes/apps/base/renovate/renovate-jobs/joryirving.yaml
+++ b/kubernetes/apps/base/renovate/renovate-jobs/joryirving.yaml
@@ -73,7 +73,7 @@ spec:
             "password": "$(DOCKERHUB_TOKEN)"
           }
         ]
-  image: ghcr.io/renovatebot/renovate:44.64.0
+  image: ghcr.io/renovatebot/renovate:44.65.5
   parallelism: 5
   provider:
     name: github

--- a/kubernetes/apps/base/renovate/renovate-jobs/misospace.yaml
+++ b/kubernetes/apps/base/renovate/renovate-jobs/misospace.yaml
@@ -76,7 +76,7 @@ spec:
             "password": "$(DOCKERHUB_TOKEN)"
           }
         ]
-  image: ghcr.io/renovatebot/renovate:44.64.0
+  image: ghcr.io/renovatebot/renovate:44.65.5
   parallelism: 5
   provider:
     name: github


### PR DESCRIPTION
## Summary

Renovate has been crash-looping since 2026-09-04 13:40 UTC — every discovery and repository job dies immediately:

```
unhandledRejection: ERR_MODULE_NOT_FOUND
Cannot find package 'tar' imported from /usr/local/renovate/dist/modules/datasource/apk/index.js
```

## Root cause

The `44.62.2 → 44.64.0` bump in #9753 pulled a broken image: 44.64.0's apk datasource imports `tar`, which was only a devDependency and is pruned from the published image.

Fixed upstream in 44.64.1: **"promote `tar` to a prod dependency"** (renovatebot/renovate#45699, closes #45697). This PR jumps straight to the current latest, 44.65.5.

## Evidence

- First crash: 2026-09-04T13:40Z (misospace-discovery), minutes after the 44.64.0 rollout
- Both `joryirving` and `misospace` discovery jobs have failed hourly since; zero successful runs
- VictoriaLogs: `kubernetes.pod_namespace:"renovate" AND _msg:"unhandledRejection"` — 105 crashes in 2 days

Ironically, renovate can no longer update itself, so this bump is manual.
