### PR TITLE
fix(gemma-wake): keep NET_BIND_SERVICE so doormouse v2 can exec

### DIFF
--- a/kubernetes/apps/base/llm/gemma-wake/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/gemma-wake/helmrelease.yaml
@@ -56,6 +56,8 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:
+                add:
+                  - NET_BIND_SERVICE
                 drop:
                   - ALL
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Problem

gemma-wake has been in `CrashLoopBackOff` since #9782 deployed doormouse `36673eb → 1764b83` (v2.0.0, released today). The container dies before running a single line of application code:

```
exec /usr/local/bin/doormouse: operation not permitted
```

The HelmRelease is flapping: helm-controller times out waiting for the Deployment, rolls back to the previous release, and Flux immediately re-issues the upgrade into the same failure. The WoL proxy for smurf-pc (LM Studio traffic on the 10G NIC) is down until this merges.

## Root cause

v2.0.0's breaking change was "run container images as a non-root user" — the release image now runs `setcap cap_net_bind_service=+ep /usr/local/bin/doormouse` so it can bind ports below 1024 as UID 1000 (decoded from the image's `security.capability` xattr: `permitted: 0x400`, effective flag set).

With `capabilities: drop: [ALL]` the pod's capability bounding set is empty, and the kernel refuses to `execve` a file whose capabilities it cannot grant — hence EPERM before `main()`. Upstream documents this exact hazard in the Dockerfile ("Drop it and the container will not start at all: the kernel refuses to exec a file whose capability it cannot grant") and the README's note on `allowPrivilegeEscalation: false` setups.

## Fix

Add `NET_BIND_SERVICE` back alongside `drop: [ALL]`. The app only binds `:8080` (unprivileged), so the capability is never exercised at runtime — it just needs to exist in the bounding set for exec to succeed. `allowPrivilegeEscalation: false` and `readOnlyRootFilesystem: true` are unchanged; no meaningful security regression.

## Verification

Reproduced and verified locally in Docker with pod-equivalent constraints (`--user 65532:65532 --cap-drop ALL --security-opt no-new-privileges`):

- `--cap-drop ALL` → exact production failure: `exec /usr/local/bin/doormouse: operation not permitted`
- `--cap-drop ALL --cap-add NET_BIND_SERVICE` → binary execs, loads the production config verbatim, configures the `gemma-wake.llm → smurf-pc` route, serves on `:8080`, shuts down cleanly on SIGTERM
- Root/default-capability control runs confirm plain permissions are not the issue

`flate test all --path ./kubernetes/clusters/main`: gemma-wake HelmRelease + OCIRepository pass (the 16 failures in my run are all pre-existing `ocharted.jory.dev` credential issues, unrelated).

## Follow-up (not in this PR)

We track `latest@digest`, so a same-day major release flowed in with no major-version gate. Doormouse publishes version-line tags (`2`, `2.0`) — worth considering for renovate so v3 can't repeat this.