### PR TITLE
fix(openclaw): persist 9.2 config migration

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -37,8 +37,10 @@ data:
               "minimax/MiniMax-M3",
             ]
           },
-          imageGenerationModel: {
-            primary: "comfy/workflow",
+          mediaModels: {
+            image: {
+              primary: "comfy/workflow",
+            },
           },
           models: {
             "litellm/kimi-k2.7": { alias: "kimi-cheap", params: { cache_prompt: true } },
@@ -64,8 +66,33 @@ data:
             "litellm/chatgpt/gpt-5.6-terra": { alias: "gpt-balanced" },
             "litellm/chatgpt/gpt-5.6-luna": { alias: "gpt-cheap" },
           },
-          contextLimits: { toolResultMaxChars: 12000 },
-          compaction: { mode: "default", timeoutSeconds: 600, reserveTokensFloor: 40000, memoryFlush: { enabled: true, softThresholdTokens: 80000, prompt: "Extract key decisions, state changes, lessons, blockers to memory/YYYY-MM-DD.md. Format: ## [HH:MM] Topic. Skip routine work. NO_FLUSH if nothing important.", systemPrompt: "Compacting session context. Extract only what's worth remembering. No fluff." },
+          modelPolicy: {
+            allow: [
+              "litellm/kimi-k2.7",
+              "litellm/kimi-k3",
+              "minimax/MiniMax-M3",
+              "minimax/MiniMax-M2.7",
+              "litellm/llama-strix",
+              "litellm/llama-strix-chat",
+              "litellm/llama-reviewer",
+              "litellm/llama-reviewer-chat",
+              "litellm/local-pool",
+              "litellm/local-pool-chat",
+              "litellm/llama-nvidia",
+              "litellm/llama-nvidia-chat",
+              "litellm/dsv4f",
+              "litellm/glm-5.3-flash",
+              "litellm/glm-5.3",
+              "litellm/frontier-pool",
+              "litellm/reasoning-pool",
+              "litellm/implementation-pool",
+              "litellm/chatgpt/gpt-6-astra",
+              "litellm/chatgpt/gpt-5.6-sol",
+              "litellm/chatgpt/gpt-5.6-terra",
+              "litellm/chatgpt/gpt-5.6-luna",
+            ],
+          },
+          compaction: { mode: "default", timeoutSeconds: 600, memoryFlush: { enabled: true, softThresholdTokens: 80000 },
           },
           maxConcurrent: 4,
           subagents: {
@@ -82,13 +109,11 @@ data:
             directPolicy: "allow",
             lightContext: true,
             isolatedSession: true,
-            includeReasoning: false,
           },
+          systemAgent: { agentId: "main" },
         },
-        list: [
-          {
-            id: "main",
-            default: true,
+        entries: {
+          main: {
             name: "Miso",
             workspace: "/home/node/.openclaw/workspace",
             agentDir: "/home/node/.openclaw/agents/main/agent",
@@ -109,12 +134,11 @@ data:
               ]
             },
           },
-          {
-            id: "matcha",
+          matcha: {
             name: "Matcha",
             workspace: "/home/node/.openclaw/workspace-matcha",
             agentDir: "/home/node/.openclaw/agents/matcha/agent",
-            tools: { allow: ["exec", "message", "read", "web_fetch", "web_search", "image", "memory_search", "memory_get", "memory_recall", "memory_list", "memory_remember"] },
+            tools: { allow: ["exec", "message", "read", "web_fetch", "web_search", "view_image", "memory_search", "memory_get", "memory_recall", "memory_list", "memory_remember"] },
             thinkingDefault: "low",
             model: {
               primary: "litellm/dsv4f",
@@ -129,8 +153,7 @@ data:
               avatar: "avatars/matcha_avatar.png",
             }
           },
-          {
-            id: "saffron",
+          saffron: {
             name: "Saffron",
             workspace: "/home/node/.openclaw/workspace-saffron",
             agentDir: "/home/node/.openclaw/agents/saffron/agent",
@@ -149,13 +172,11 @@ data:
               avatar: "avatars/saffron_avatar.png",
             }
           },
-          {
-            id: "sage",
+          sage: {
             name: "Sage",
             workspace: "/home/node/.openclaw/workspace-sage",
             agentDir: "/home/node/.openclaw/agents/sage/agent",
-            tools: { allow: ["web_fetch", "web_search", "image", "chart_generate", "youtube_tldw", "reddit_thread", "facebook_listing", "sage_runtime_status", "sage_office_temperature", "sage_reference_remember", "memory_recall", "memory_list"] },
-            contextLimits: { toolResultMaxChars: 8000 },
+            tools: { allow: ["web_fetch", "web_search", "view_image", "chart_generate", "youtube_tldw", "reddit_thread", "facebook_listing", "sage_runtime_status", "sage_office_temperature", "sage_reference_remember", "memory_recall", "memory_list"] },
             thinkingDefault: "low",
             model: {
               primary: "litellm/llama-nvidia-chat",
@@ -166,13 +187,14 @@ data:
               avatar: "avatars/sage_avatar.png",
             }
           },
-        ],
+        },
+        ownership: "explicit",
       },
       tools: {
         media: { image: { timeoutSeconds: 180 } },
         sessions: { visibility: "all" },
         agentToAgent: { enabled: true },
-        exec: { security: "full", ask: "off", strictInlineEval: false },
+        exec: { mode: "full", strictInlineEval: false },
         elevated: { enabled: true, allowFrom: { discord: ["$${DISCORD_ADMIN_USER_ID}"] } },
         web: { search: { enabled: true, provider: "searxng", openaiCodex: { enabled: true, mode: "cached" } }, fetch: { enabled: true } },
       },
@@ -236,6 +258,7 @@ data:
         { agentId: "matcha",  match: { channel: "discord", accountId: "matcha" } },
         { agentId: "matcha",  match: { channel: "discord", accountId: "matcha", peer: { kind: "channel", id: "$${MATCHA_CHANNEL_ID}" } } },
         { agentId: "sage", match: { channel: "discord", accountId: "sage" } },
+        { agentId: "main", match: { channel: "discord", accountId: "*" } },
       ],
       channels: {
         discord: {
@@ -306,7 +329,7 @@ data:
         },
       },
       plugins: {
-        allow: ["discord", "lossless-claw", "memini", "searxng", "comfy", "memory-wiki", "chart-renderer", "youtube-tldw", "reddit-thread", "facebook-listing", "sage-environment", "sage-reference-memory"],
+        allow: ["discord", "lossless-claw", "memini", "memory-core", "searxng", "comfy", "memory-wiki", "chart-renderer", "youtube-tldw", "reddit-thread", "facebook-listing", "sage-environment", "sage-reference-memory"],
         entries: {
           discord: { enabled: true },
           "chart-renderer": { enabled: true },
@@ -329,6 +352,9 @@ data:
           "admin-http-rpc": { enabled: true },
           "lossless-claw": {
             enabled: true,
+            hooks: {
+              allowConversationAccess: true,
+            },
             llm: { allowModelOverride: true, allowedModels: [ "litellm/local-pool-chat" ], },
             subagent: { allowModelOverride: true, allowedModels: [ "litellm/local-pool-chat" ], },
             config: {
@@ -410,6 +436,9 @@ data:
               }
             }
           },
+          "memory-core": {
+            enabled: true,
+          },
           "memory-wiki": {
             enabled: true,
             config: {
@@ -466,14 +495,6 @@ data:
           memory: "memini",
           contextEngine: "lossless-claw"
         },
-      },
-      diagnostics: {
-        // A deep prefill on Strix emits nothing for minutes, so the default no-progress
-        // abort (a 5 minute floor) killed runs that were still making progress. The
-        // return_progress extra_body on the local lanes keeps the stream alive; these are
-        // the backstop for when it stops arriving.
-        stuckSessionWarnMs: 600000,
-        stuckSessionAbortMs: 1500000,
       },
       session: {
         dmScope: "main",


### PR DESCRIPTION
OpenClaw 2026.9.2 migrated the live PVC config. Persist the canonical schema to prevent repeat migration, explicitly authorize Lossless-Claw conversation hooks, restore Memory Core allowlisting, and remove retired keys.