### PR TITLE
fix(openclaw): trust only proxy pods

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -515,7 +515,7 @@ data:
         controlUi: { allowedOrigins: ["https://miso.jory.dev", "https://miso-chat.jory.dev"],},
         mode: "local",
         port: 18789,
-        trustedProxies: ["10.42.0.0/16", "192.168.0.0/16"]
+        trustedProxies: ["10.42.0.0/16"]
       },
       messages: {
         ackReactionScope: "group-mentions"


### PR DESCRIPTION
OpenClaw treated browser client addresses in 192.168.0.0/16 as proxy hops, leaving no attributable client after Envoy forwarded the request. Trust only the Envoy pod CIDR; direct LAN clients must not be trusted proxies.