### PR TITLE
fix(openclaw): use Memini memory only

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -138,7 +138,7 @@ data:
             name: "Matcha",
             workspace: "/home/node/.openclaw/workspace-matcha",
             agentDir: "/home/node/.openclaw/agents/matcha/agent",
-            tools: { allow: ["exec", "message", "read", "web_fetch", "web_search", "view_image", "memory_search", "memory_get", "memory_recall", "memory_list", "memory_remember"] },
+            tools: { allow: ["exec", "message", "read", "web_fetch", "web_search", "view_image", "memory_recall", "memory_list", "memory_remember"] },
             thinkingDefault: "low",
             model: {
               primary: "litellm/dsv4f",
@@ -157,7 +157,7 @@ data:
             name: "Saffron",
             workspace: "/home/node/.openclaw/workspace-saffron",
             agentDir: "/home/node/.openclaw/agents/saffron/agent",
-            tools: { allow: ["exec", "read", "write", "message", "web_fetch", "web_search", "browser", "sessions_spawn", "memory_search", "memory_get", "memory_recall", "memory_list", "memory_remember", "toolhive__find_tool","toolhive__call_tool"] },
+            tools: { allow: ["exec", "read", "write", "message", "web_fetch", "web_search", "browser", "sessions_spawn", "memory_recall", "memory_list", "memory_remember", "toolhive__find_tool","toolhive__call_tool"] },
             thinkingDefault: "high",
             model: {
               primary: "litellm/reasoning-pool",
@@ -329,7 +329,7 @@ data:
         },
       },
       plugins: {
-        allow: ["discord", "lossless-claw", "memini", "memory-core", "searxng", "comfy", "memory-wiki", "chart-renderer", "youtube-tldw", "reddit-thread", "facebook-listing", "sage-environment", "sage-reference-memory", "minimax", "litellm", "browser", "admin-http-rpc", "openai"],
+        allow: ["discord", "lossless-claw", "memini", "searxng", "comfy", "memory-wiki", "chart-renderer", "youtube-tldw", "reddit-thread", "facebook-listing", "sage-environment", "sage-reference-memory", "minimax", "litellm", "browser", "admin-http-rpc", "openai"],
         entries: {
           discord: { enabled: true },
           "chart-renderer": { enabled: true },
@@ -435,9 +435,6 @@ data:
                 language: "en"
               }
             }
-          },
-          "memory-core": {
-            enabled: true,
           },
           "memory-wiki": {
             enabled: true,


### PR DESCRIPTION
Memini already owns the sole OpenClaw memory slot. Remove the inactive memory-core provider and its stale search/get tool aliases so agents see one memory system.