### PR TITLE
fix(openclaw): accept Memini capabilities

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -56,7 +56,7 @@ spec:
                 # renovate: datasource=github-tags depName=eleboucher/memini
                 MEMINI_PLUGIN_VERSION=0.7.23
                 if [ "$(cat "$HOME/.openclaw/extensions/memini/.clawver" 2>/dev/null)" != "$MEMINI_PLUGIN_VERSION" ]; then
-                  if node dist/index.js plugins install "clawhub:@eleboucher/memini@$MEMINI_PLUGIN_VERSION" --pin --force --acknowledge-clawhub-risk; then
+                  if node dist/index.js plugins install "clawhub:@eleboucher/memini@$MEMINI_PLUGIN_VERSION" --pin --force --accept-capabilities --acknowledge-install-policy-warning; then
                     printf '%s' "$MEMINI_PLUGIN_VERSION" > "$HOME/.openclaw/extensions/memini/.clawver"
                   else
                     echo "WARN: memini plugin install failed; starting with whatever is present"


### PR DESCRIPTION
OpenClaw 2026.9.2 replaced Memini's installer acknowledgement flag. Use the current capability and install-policy acknowledgements so the pinned 0.7.23 plugin can install on restart instead of silently retaining 0.7.22.