### PR TITLE
fix(openclaw): pin published Memini release

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -53,8 +53,8 @@ spec:
                 # Install the memini memory plugin from ClawHub, version-guarded:
                 # only fetches when the pinned version differs from what's on the
                 # persistent volume, so normal restarts stay offline.
-                # renovate: datasource=github-tags depName=eleboucher/memini
-                MEMINI_PLUGIN_VERSION=0.7.23
+                # ClawHub's latest published Memini artifact. Git tags can lead it.
+                MEMINI_PLUGIN_VERSION=0.7.22
                 if [ "$(cat "$HOME/.openclaw/extensions/memini/.clawver" 2>/dev/null)" != "$MEMINI_PLUGIN_VERSION" ]; then
                   if node dist/index.js plugins install "clawhub:@eleboucher/memini@$MEMINI_PLUGIN_VERSION" --force --accept-capabilities --acknowledge-install-policy-warning; then
                     printf '%s' "$MEMINI_PLUGIN_VERSION" > "$HOME/.openclaw/extensions/memini/.clawver"


### PR DESCRIPTION
Memini v0.7.23 exists only as a Git tag. ClawHub publishes v0.7.22, so pin the installable artifact and stop Renovate from treating unpublished tags as deployable releases.