### PR TITLE
fix(llm): raise llama-nvidia memory to 48Gi

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-nvidia.yaml
@@ -55,7 +55,7 @@ spec:
   resources:
     gpu: 1
     cpu: "500m"
-    memory: 16Gi
+    memory: 48Gi
   speculativeDecoding:
     type: draft-mtp
     nDraftMax: 2


### PR DESCRIPTION
llmkube 0.9.25 emits `resources.memory` as both the request and the limit where 0.9.24 set only the request, so llama-nvidia's 40 GiB RAM prompt cache pushed the pod past its new 16Gi cap and it OOM-looped 11 times; 48Gi is sized from 7 days of pre-upgrade working set (p50 44.4 GiB, p95 46.5 GiB, peaks 44-52 GiB) and is close to the most ganyu can reserve given its other pods already request 71.9 GiB of 123 GiB allocatable, with the request/limit coupling tracked upstream as `defilantech/LLMKube#1763`.