### PR TITLE
chore(sonarr,radarr,prowlarr): require auth and drop sonarr allowed hosts

### DIFF
--- a/kubernetes/apps/base/downloads/prowlarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/prowlarr/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
               PROWLARR__APP__INSTANCENAME: "{{ .Release.Name }}"
               PROWLARR__APP__THEME: dark
               PROWLARR__AUTH__METHOD: External
-              PROWLARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              PROWLARR__AUTH__REQUIRED: Enabled
               PROWLARR__LOG__DBENABLED: "False"
               PROWLARR__LOG__LEVEL: info
               PROWLARR__POSTGRES__HOST: "{{ .Release.Name }}-rw.downloads.svc"

--- a/kubernetes/apps/base/downloads/radarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/radarr/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
               RADARR__APP__INSTANCENAME: Radarr
               RADARR__APP__THEME: dark
               RADARR__AUTH__METHOD: External
-              RADARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              RADARR__AUTH__REQUIRED: Enabled
               RADARR__LOG__DBENABLED: "False"
               RADARR__LOG__LEVEL: info
               RADARR__POSTGRES__HOST: "{{ .Release.Name }}-rw.downloads.svc"

--- a/kubernetes/apps/base/downloads/sonarr/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/sonarr/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
               SONARR__APP__INSTANCENAME: Sonarr
               SONARR__APP__THEME: dark
               SONARR__AUTH__METHOD: External
-              SONARR__AUTH__REQUIRED: DisabledForLocalAddresses
+              SONARR__AUTH__REQUIRED: Enabled
               SONARR__LOG__DBENABLED: "False"
               SONARR__LOG__LEVEL: info
               SONARR__POSTGRES__HOST: "{{ .Release.Name }}-rw.downloads.svc"
@@ -43,7 +43,6 @@ spec:
                     key: password
               SONARR__POSTGRES__PORT: "5432"
               SONARR__POSTGRES__USER: "{{ .Release.Name }}"
-              SONARR__SERVER__ALLOWEDHOSTS: sonarr.jory.dev,sonarr.downloads,sonarr.downloads.svc,sonarr.downloads.svc.cluster.local
               SONARR__SERVER__PORT: &port 80
               SONARR__SERVER__TRUSTEDNETWORKS: 10.42.0.0/16
               SONARR__UPDATE__BRANCH: develop


### PR DESCRIPTION
Imitates onedr0p/home-ops#11653.

Sets `*__AUTH__REQUIRED` to `Enabled` on sonarr, radarr, and prowlarr, and drops `SONARR__SERVER__ALLOWEDHOSTS`.

**Why `Enabled`:** with `AUTH__METHOD: External` the scheme is wired to `NoAuthenticationHandler`, so every request is already authenticated and the `DisabledForLocalAddresses` bypass in `UiAuthorizationHandler` never runs (it's also skipped whenever `X-Forwarded-For` is present). Flipping it is a behavioral no-op here.

**Why drop `ALLOWEDHOSTS`:** Sonarr 4.0.19.3011 (Sonarr/Sonarr@27aac304) makes `AllowedHostsCheck` warn when the list contains `*`. Mine was an explicit list (`sonarr.jory.dev,...`) rather than `*`, so the warning wasn't firing — but with auth required, the check passes with an empty list, and removing it avoids the upstream `ValidHosts()` settings-save quirk entirely. Radarr and Prowlarr had no `ALLOWEDHOSTS` set.

Sonarr is already on 4.0.19.3011; radarr 6.4.3.10645 and prowlarr 2.6.3.5592 get the same change ahead of their ports.
