### PR TITLE
fix(cluster): right-size memory requests and drop two idle game servers

### DIFF
--- a/kubernetes/apps/base/database/cloudnative-pg/helmrelease.yaml
+++ b/kubernetes/apps/base/database/cloudnative-pg/helmrelease.yaml
@@ -11,5 +11,8 @@ spec:
   interval: 15m
   dependsOn: []
   values:
+    resources:
+      requests:
+        memory: 384Mi
     crds:
       create: true

--- a/kubernetes/apps/base/downloads/metube/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/metube/helmrelease.yaml
@@ -36,6 +36,9 @@ spec:
               STATE_DIR: "/config"
               YTDL_OPTIONS: '{"http_headers":{"User-Agent": "Mozilla/5.0 (Windows
                 NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0"},"cookiefile":"/config/cookies.txt"}'
+            resources:
+              requests:
+                memory: 640Mi
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"

--- a/kubernetes/apps/base/downloads/pinchflat/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/pinchflat/helmrelease.yaml
@@ -52,7 +52,7 @@ spec:
               requests:
                 cpu: 10m
               limits:
-                memory: 8Gi
+                memory: 2Gi
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"

--- a/kubernetes/apps/base/downloads/tdarr-node/helmrelease.yaml
+++ b/kubernetes/apps/base/downloads/tdarr-node/helmrelease.yaml
@@ -47,6 +47,7 @@ spec:
                 - name: gpu
               requests:
                 cpu: 100m
+                memory: 512Mi
               limits:
                 cpu: 2000m
     persistence:

--- a/kubernetes/apps/base/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/base/media/plex/app/helmrelease.yaml
@@ -61,6 +61,7 @@ spec:
                 - name: gpu
               requests:
                 cpu: 100m
+                memory: 8G
               limits:
                 memory: 16G
     persistence:

--- a/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
@@ -134,6 +134,9 @@ spec:
           dashboards: grafana
     kube-state-metrics:
       fullnameOverride: kube-state-metrics
+      resources:
+        requests:
+          memory: 384Mi
       metricLabelsAllowlist:
         - pods=[*]
         - deployments=[*]
@@ -172,7 +175,7 @@ spec:
           requests:
             cpu: 100m
           limits:
-            memory: 3000Mi
+            memory: 4Gi
         version: v2.55.1 # override 'unsupported Prometheus version' error for prompp
         image:
           registry: mirror.gcr.io

--- a/kubernetes/apps/base/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/victoria-logs/app/helmrelease.yaml
@@ -14,6 +14,9 @@ spec:
       enabled: true
     fullnameOverride: victoria-logs
     server:
+      resources:
+        requests:
+          memory: 2Gi
       persistentVolume:
         enabled: true
         size: 100Gi

--- a/kubernetes/apps/base/observability/victoria-logs/collector/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/victoria-logs/collector/helmrelease.yaml
@@ -11,6 +11,9 @@ spec:
   interval: 1h
   values:
     fullnameOverride: victoria-logs-collector
+    resources:
+      requests:
+        memory: 384Mi
     podMonitor:
       enabled: true
     remoteWrite:

--- a/kubernetes/apps/main/games/kustomization.yaml
+++ b/kubernetes/apps/main/games/kustomization.yaml
@@ -9,10 +9,10 @@ replacements:
   - path: ../../../components/replacements/ks.yaml
 resources:
   # - ./core-keeper.yaml
-  - ./enshrouded.yaml
+  # - ./enshrouded.yaml
   - ./games-on-whales.yaml
   - ./minecraft.yaml
   - ./palworld.yaml
   - ./romm.yaml
-  - ./valheim.yaml
+  # - ./valheim.yaml
   # - ./vrising.yaml

--- a/kubernetes/components/postgres/cluster.yaml
+++ b/kubernetes/components/postgres/cluster.yaml
@@ -13,6 +13,9 @@ metadata:
     cnpg.io/skipEmptyWalArchiveCheck: enabled
 spec:
   instances: 3
+  resources:
+    requests:
+      memory: 512Mi
   imageName: ghcr.io/cloudnative-pg/postgresql:18.6
   primaryUpdateStrategy: unsupervised
   enableSuperuserAccess: true


### PR DESCRIPTION
Because these manifests set only `limits.memory`, Kubernetes copies each limit into the request, so every limit has also been a reservation; this sizes them against 7-30 day observed peaks (pinchflat 8Gi to 2Gi against a 0.99Gi peak, plex given an explicit 8G request with its 16G limit untouched against an 8.04Gi peak, prometheus raised 3000Mi to 4Gi because it peaked at 2.91Gi of 2.93Gi), prunes enshrouded and valheim so their volumes live only in kopiur, and adds requests with no new limits to the containers that were BestEffort and therefore first to be evicted under node pressure, covering all 42 CNPG instances through the shared component plus victoria-logs server and collector, kube-state-metrics, cloudnative-pg, metube and tdarr-node; palworld is split into its own PR because its Deployment uses the Recreate strategy and any resource change drops active players.