### PR TITLE
fix(games): lower palworld memory to 8Gi

### DIFF
--- a/kubernetes/apps/base/games/palworld/helmrelease.yaml
+++ b/kubernetes/apps/base/games/palworld/helmrelease.yaml
@@ -58,7 +58,7 @@ spec:
               requests:
                 cpu: 1000m
               limits:
-                memory: 24Gi
+                memory: 8Gi
           exporter:
             image:
               repository: docker.io/bostrt/palworld-exporter


### PR DESCRIPTION
Only `limits.memory` was set so Kubernetes copied it into the request and palworld reserved 24Gi, against a 30-day peak of 2.44Gi measured with players connected, so 8Gi keeps roughly 3x headroom and returns 16Gi of schedulable memory on ayaka; merge this when the server is empty, because the Deployment uses the Recreate strategy and the running pod is torn down before its replacement starts, dropping connected players for the length of a full server boot.