### PR TITLE
fix(litellm): let llama-reviewer actually reach its MiniMax fallback

### DIFF
--- a/kubernetes/apps/base/llm/litellm/models/llama-reviewer.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/llama-reviewer.yaml
@@ -12,7 +12,7 @@ spec:
     apiKey: sk-noauth
     additional:
       timeout: 300
-      num_retries: 3
+      num_retries: 1
       temperature: 1.0
       top_p: 0.95
       top_k: 64


### PR DESCRIPTION
The `llama-reviewer → MiniMax-M3-chat` fallback is configured but **unreachable on the reviewer path**, because the retry budget outlives the agent's turn budget.

## Why it never fires

`llama-reviewer` is served by `gemma-wake` — doormouse, a wake-on-LAN proxy in front of smurf-pc. **It never signals that the machine is unavailable.** By design it absorbs the wait: WoL packets, polling every 5s, up to its own `timeout = "5m"`. Nothing tells litellm the upstream is down, and `enable_pre_call_checks` inspects litellm's own capacity and context accounting, not upstream liveness.

With the machine off and unwakeable:

| step | budget |
|---|---|
| doormouse holds, then errors | ~5m |
| litellm `timeout: 300` fires at the same moment | 5m |
| `num_retries: 3` → up to 4 attempts | **~20m** |
| fallback to `MiniMax-M3-chat` | only after that |
| **reviewer `requestTurnTimeoutSeconds`** | **900 (15m)** |

The turn is killed five minutes before the fallback is reached. MiniMax is never consulted; the review just dies.

## The change

`num_retries: 3 → 1` on `llama-reviewer`. Two attempts, ~10 minutes worst case, leaving ~5 minutes of turn budget for MiniMax to answer — ample, since a whole 18-turn review on that model took 185s.

**Not 0**, deliberately: litellm may treat a zero as unset and fall back to the router-level `num_retries: 2`, which is three attempts and *exactly* the 900s turn budget with no headroom. `1` is unambiguous.

The local retry is largely redundant anyway. doormouse already polled for a full 5 minutes inside the first attempt, so a second litellm attempt only helps in the narrow window where the machine wakes between 5 and 10 minutes.

`timeout: 300` is left alone — it is generous but it is what lets a genuine cold boot succeed, and cutting it would trade real wakes for faster failure.

## Verified

`kubectl apply --dry-run=server` accepts the model.

## Noted, not changed

`llama-reviewer-chat` points at the same `gemma-wake` backend with the same `timeout: 300` / `num_retries: 3`, **and has no fallback declared at all** — the `fallbacks` list only names `llama-reviewer`. Its consumer is openclaw (`openclaw/app/configmap.yaml`), i.e. interactive chat where a human is waiting rather than an agent with a turn budget.

Left alone on purpose: adding a fallback there would silently move an interactive session onto a paid hosted model, which is a different decision from unblocking an automated reviewer. Worth deciding separately.

Claude-Session: https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh