### PR TITLE
feat(llm): add SillyTavern

### DIFF
--- a/kubernetes/apps/base/llm/litellm/virtualkeys/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/kustomization.yaml
@@ -13,5 +13,6 @@ resources:
   - ./pi.yaml
   - ./pr-review.yaml
   - ./repo-wiki.yaml
+  - ./sillytavern.yaml
   - ./toolhive.yaml
   - ./zed.yaml

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/sillytavern.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/sillytavern.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMVirtualKey
+metadata:
+  name: sillytavern
+spec:
+  proxyRef: litellm
+  keyAlias: SillyTavern
+  secretName: litellm-key-sillytavern
+  secretKey: api-key
+  models:
+  - local-pool
+  - llama-strix
+  - llama-nvidia
+  - MiniMax-M3-chat
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: sillytavern
+spec:
+  secretStoreRefs:
+  - name: onepassword
+    kind: ClusterSecretStore
+  selector:
+    secret:
+      name: litellm-key-sillytavern
+  data:
+  - match:
+      secretKey: api-key
+      remoteRef:
+        remoteKey: litellm
+        property: LITELLM_SILLYTAVERN_API_KEY

--- a/kubernetes/apps/base/llm/sillytavern/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/sillytavern/helmrelease.yaml
@@ -25,7 +25,8 @@ spec:
               SILLYTAVERN_BROWSERLAUNCH_ENABLED: "false"
               # Required behind a reverse proxy: Origin differs from the app host
               SILLYTAVERN_DISABLECSRFPROTECTION: "true"
-              # Acknowledge listen-without-auth; network trust comes from envoy-internal
+              # Acknowledge listen-without-app-auth; access is gated by gateway
+              # OIDC via securitypolicy.yaml
               SILLYTAVERN_SECURITYOVERRIDE: "true"
               # Default config whitelists loopback only, which would 403 every request
               SILLYTAVERN_WHITELISTMODE: "false"

--- a/kubernetes/apps/base/llm/sillytavern/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/sillytavern/helmrelease.yaml
@@ -1,0 +1,85 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: sillytavern
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: sillytavern
+  interval: 15m
+  dependsOn: []
+  values:
+    controllers:
+      sillytavern:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/sillytavern/sillytavern
+              tag: 1.18.0@sha256:7b30a1698b605d01dbd01a20459600c035f0d2c866912b69d7eee98065dcedd3
+            env:
+              # In-container browser launch is a no-op that only logs errors
+              SILLYTAVERN_BROWSERLAUNCH_ENABLED: "false"
+              # Required behind a reverse proxy: Origin differs from the app host
+              SILLYTAVERN_DISABLECSRFPROTECTION: "true"
+              # Acknowledge listen-without-auth; network trust comes from envoy-internal
+              SILLYTAVERN_SECURITYOVERRIDE: "true"
+              # Default config whitelists loopback only, which would 403 every request
+              SILLYTAVERN_WHITELISTMODE: "false"
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            resources:
+              requests:
+                cpu: 100m
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1001
+        runAsNonRoot: true
+        runAsUser: 1001
+    persistence:
+      backups:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /home/node/app/backups
+            subPath: backups
+      config:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /home/node/app/config
+            subPath: config
+      data:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /home/node/app/data
+            subPath: data
+      extensions:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /home/node/app/public/scripts/extensions/third-party
+            subPath: extensions
+      plugins:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /home/node/app/plugins
+            subPath: plugins
+    route:
+      app:
+        hostnames: ["tavern.jory.dev"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    service:
+      app:
+        ports:
+          http:
+            port: 8000

--- a/kubernetes/apps/base/llm/sillytavern/kustomization.yaml
+++ b/kubernetes/apps/base/llm/sillytavern/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/llm/sillytavern/kustomization.yaml
+++ b/kubernetes/apps/base/llm/sillytavern/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/base/llm/sillytavern/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/sillytavern/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: sillytavern
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/sillytavern/securitypolicy.yaml
+++ b/kubernetes/apps/base/llm/sillytavern/securitypolicy.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: sillytavern-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: sillytavern
+  oidc:
+    provider:
+      issuer: https://sso.jory.dev/application/o/opencode/
+    clientIDRef:
+      group: ""
+      kind: Secret
+      name: opencode-oidc
+    clientSecret:
+      group: ""
+      kind: Secret
+      name: opencode-oidc
+    redirectURL: https://tavern.jory.dev/oauth2/callback
+    logoutPath: /logout
+    scopes: ["openid", "email", "profile"]

--- a/kubernetes/apps/main/llm/kustomization.yaml
+++ b/kubernetes/apps/main/llm/kustomization.yaml
@@ -22,5 +22,6 @@ resources:
   - ./opencode.yaml
   - ./repo-wiki.yaml
   - ./searxng.yaml
+  - ./sillytavern.yaml
   - ./toolhive.yaml
   - ./whisper.yaml

--- a/kubernetes/apps/main/llm/sillytavern.yaml
+++ b/kubernetes/apps/main/llm/sillytavern.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app sillytavern
+spec:
+  components:
+    - ../../../../components/kopiur/backup
+  dependsOn:
+    - name: litellm
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/sillytavern
+  postBuild:
+    substitute:
+      APP: *app
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system

--- a/terraform/authentik/applications.tofu
+++ b/terraform/authentik/applications.tofu
@@ -154,6 +154,11 @@ locals {
           matching_mode     = "strict"
           redirect_uri_type = "authorization"
           url               = "https://generate.${var.CLUSTER_DOMAIN}/oauth2/callback"
+        },
+        {
+          matching_mode     = "strict"
+          redirect_uri_type = "authorization"
+          url               = "https://tavern.${var.CLUSTER_DOMAIN}/oauth2/callback"
         }
       ]
       property_mappings = local.default_property_mappings


### PR DESCRIPTION
## What

Deploys [SillyTavern](https://docs.sillytavern.app) 1.18.0 to the `llm` namespace on **main** — a character/roleplay-focused LLM chat frontend complementing open-webui. Four commits:

1. **App** (`kubernetes/apps/base/llm/sillytavern/` + main overlay): `app-template` 5.1.0 via per-app OCIRepository; image `ghcr.io/sillytavern/sillytavern` pinned `1.18.0@sha256:7b30a169…`; port 8000 with HTTP probes; `1001:1001` (image's `node` user); one kopiur-provisioned PVC subPath-mounted at `config`/`data`/`plugins`/`extensions`/`backups`; HTTPRoute `tavern.jory.dev` on `envoy-internal`. Env overrides disable whitelist/CSRF (proxied use) and browser-launch, and acknowledge listen-without-app-auth since access is gateway-gated.
2. **litellm virtual key** (`virtualkeys/sillytavern.yaml`): scoped to `local-pool`, `llama-strix`, `llama-nvidia`, `MiniMax-M3-chat`. PushSecret mirrors the key to the shared `litellm` 1Password item (`LITELLM_SILLYTAVERN_API_KEY`) — SillyTavern cannot take connection keys via env (they live in `secrets.json` with no env mapping in 1.18.0 source), so the UI paste comes from 1Password.
3. **Gateway OIDC** (`securitypolicy.yaml`): Envoy `SecurityPolicy` on the route reusing the **opencode** Authentik application and `opencode-oidc` secret — the same reuse pattern as `generate.jory.dev`. No new client IDs/secrets: Envoy Gateway is the OIDC client and the secret already exists in `llm` via opencode's ExternalSecret.
4. **Authentik (tofu)**: registers `https://tavern.jory.dev/oauth2/callback` as an additional redirect URI on the OpenCode application; applied by tofu-controller on merge.

## Why

Roleplay/character UI on the existing litellm fleet, gated by SSO, with attributable usage via a scoped virtual key.

## Post-merge first-run

- Visit `https://tavern.jory.dev` → Authentik login (opencode app) → SillyTavern.
- API Connections → Chat Completion → Custom (OpenAI-compatible): `http://litellm.llm:4000/v1` + key from 1Password (`LITELLM_SILLYTAVERN_API_KEY`). Stored on the PVC; one-time.

## Validation

- `flate test all --path ./kubernetes/clusters/main`: `llm/sillytavern` (Kustomization, HelmRelease, OCIRepository) and `llm/litellm` render clean; the 16 failures are the pre-existing ocharted credential failures already on `main`.
- `tofu fmt --check` + `tofu validate` pass for `terraform/authentik`.
- No new secrets in Git (pattern-scanned diff); hostname `tavern.jory.dev` unused; image digest resolved via crane.