### PR TITLE
fix(network): drop broken http3 advertisement from envoy ClientTrafficPolicy

### DIFF
--- a/kubernetes/apps/base/network/envoy-gateway/config/envoy.yaml
+++ b/kubernetes/apps/base/network/envoy-gateway/config/envoy.yaml
@@ -146,7 +146,6 @@ spec:
         - 10.42.0.0/16
   http2:
     onInvalidMessage: TerminateStream
-  http3: {}
   proxyProtocol:
     optional: true
   targetSelectors:


### PR DESCRIPTION
## Root cause

The cluster-wide `ClientTrafficPolicy` enables both `http3: {}` and `proxyProtocol: optional` on every Gateway. Envoy Gateway generates the `https-quic` (UDP/443) listener **with the proxy_protocol listener filter attached**, which Envoy rejects — QUIC listeners can't take TCP connection filters:

```
gRPC config for ...Listener rejected: Error adding/updating listener(s)
network/envoy-internal/https-quic: Didn't find a registered implementation for
'envoy.filters.listener.proxy_protocol'
```

Same bug class as [envoyproxy/gateway#5005](https://github.com/envoyproxy/gateway/issues/5005). The rejection predates today (present before the sillytavern deploy) and hits **both** envoy-internal and envoy-external (~80 rejections per pod in the last 2h) — cluster-wide HTTP/3 has been dead while TCP keeps serving and advertising `alt-svc: h3=":443"`.

## Impact

Browsers cache the alt-svc advertisement and then race a QUIC listener that never loaded: intermittent asset failures ("page loads weird") and hard navigation failures — surfaced today by SillyTavern's OIDC callback (`tavern.jory.dev/oauth2/callback` → Chrome "site can't be reached", with zero TCP access-log entries because the request only ever hit UDP).

## Fix

Remove `http3: {}` from the ClientTrafficPolicy. This stops generating the broken QUIC listener and stops advertising alt-svc, so browsers use HTTP/2 — which is what is actually serving today. **No functional loss**; proxyProtocol on the TCP listeners is untouched. H3 can be re-enabled later once upstream cleanly separates the listener filters (or proxyProtocol is scoped to the TCP listener).

## Validation

- `flate test ks` — `network/envoy-gateway` renders clean.
- Post-merge check: the `https-quic` config-rejection warnings disappear from envoy proxy logs and `alt-svc` disappears from responses.
- Browser note: Chrome may hold the cached h3 entry briefly (it self-heals after marking the alternate broken, or on cache purge).