### PR TITLE
fix(llm): grant sillytavern key the chat-tuned local doors

### DIFF
--- a/kubernetes/apps/base/llm/litellm/virtualkeys/sillytavern.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/sillytavern.yaml
@@ -10,9 +10,11 @@ spec:
   secretKey: api-key
   models:
   - local-pool
+  - local-pool-chat
   - llama-strix
   - llama-nvidia
   - MiniMax-M3-chat
+  - muse
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret

--- a/kubernetes/apps/base/llm/litellm/virtualkeys/sillytavern.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/sillytavern.yaml
@@ -14,7 +14,6 @@ spec:
   - llama-strix
   - llama-nvidia
   - MiniMax-M3-chat
-  - muse
 ---
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret


### PR DESCRIPTION
## Root cause

SillyTavern's virtual key only granted the thinking doors. `local-pool` resolves to `llama-nvidia` (Qwen3.8-27B), which serves with `--reasoning-preserve --reasoning-budget 32768` at server-default sampling `temp 1.0 / top_p 0.95 / min_p 0`. Through the OpenAI-compatible path the `<think>` block lands in message content, thinking burns the response budget (perceived cut-offs), and hot sampling derails into repetition garbage mid-reply.

## Fix

Grant **`local-pool-chat`** — the same servers via the non-thinking door: `reasoning_effort: none`, `temp 0.7 / top_p 0.8 / presence_penalty 1.5`. Use Chat Completion API mode in SillyTavern; Text Completion mode bypasses these door-level overrides.

(muse was in an earlier revision of this branch but points at a retired server — dropped.)

## Post-merge

In SillyTavern pick `local-pool-chat`, set Context Size 131072, raise **Response Length** (the per-reply max-tokens slider, defaults low — the usual cause of mid-sentence cut-offs), Streaming on.