### PR TITLE
feat(openclaw): give Miso a voice via MiniMax text-to-speech

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -190,6 +190,19 @@ data:
         },
         ownership: "explicit",
       },
+      tts: {
+        provider: "minimax",
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimax.io",
+            apiKey: "$${MINIMAX_API_KEY}",
+            model: "speech-2.8-hd",
+            voiceId: "Korean_SoothingLady",
+            speed: 0.94,
+            pitch: -1,
+          },
+        },
+      },
       tools: {
         media: { image: { timeoutSeconds: 180 } },
         sessions: { visibility: "all" },

--- a/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
@@ -33,6 +33,7 @@ spec:
         WEATHER_UNDERGROUND_API_KEY: "{{ .WEATHER_UNDERGROUND_API_KEY }}"
         CONTEXT7_API_KEY: "{{ .OPENCLAW_API_KEY }}"
         MEMINI_API_KEY: "{{ .MEMINI_API_KEY }}"
+        MINIMAX_API_KEY: "{{ .MINIMAX_API_KEY }}"
         WAYPOINT_API_KEY: "{{ .WAYPOINT_API_KEY }}"
         FORGEJO_USER: "{{ .FORGEJO_USER }}"
         FORGEJO_PASSWORD: "{{ .FORGEJO_PASSWORD }}"
@@ -41,6 +42,8 @@ spec:
         key: openclaw
     - extract:
         key: composio
+    - extract:
+        key: minimax
     - extract:
         key: context7
     - extract:


### PR DESCRIPTION
Registers MiniMax T2A as the speech provider so Miso can send Discord voice messages, talking to api.minimax.io directly with the existing 1Password minimax item because the MiniMax chat provider points at litellm and T2A is not proxied there, which means it bills against the flat subscription rather than adding a resident model or any GPU; the voice is `English_compelling_lady1` at 0.92 speed with no pitch shift, chosen by ear from the 332-voice library against an elegant and seductive brief, after finding that only 45 of those voices are English, that pitch shifts beyond a semitone read as male, and that cross-language voices reading English sound uncanny, and note that OpenClaw's MiniMax provider exposes only baseUrl, model, voiceId, speed, vol and pitch so emotion and language_boost are not reachable from config, while the ffmpeg/ffprobe needed on PATH for Discord's OGG/Opus waveform format are already symlinked into the PVC and so are not part of this diff.