### PR TITLE
fix(llm): cloud fallback for llamacpp jinja template rejects

### DIFF
--- a/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
+++ b/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
@@ -96,10 +96,22 @@ spec:
     cooldown_time: 30
     enable_pre_call_checks: true
     fallbacks:
+    # The local llama.cpp servers run --jinja with the Qwen3.8 chat template,
+    # which hard-rejects system messages that are not first (llama.cpp returns
+    # "Jinja Exception: System message must be at the beginning"). Clients that
+    # send quiet/auxiliary prompts with a trailing system message — SillyTavern's
+    # SD prompt-text generation — 500 on both locals, so these groups fall back
+    # to the cloud chat door. Matches the existing auto-group pattern.
     - llama-strix:
       - llama-nvidia
+      - MiniMax-M3-chat
     - llama-nvidia:
       - llama-strix
+      - MiniMax-M3-chat
+    - local-pool:
+      - MiniMax-M3-chat
+    - local-pool-chat:
+      - MiniMax-M3-chat
     - llama-reviewer:
       - MiniMax-M3-chat
     - auto:


### PR DESCRIPTION
## Root cause

SillyTavern's interactive image generation sends its SD prompt-expansion request as a quiet chat-completion call with a **trailing system message**. The local llama.cpp servers (`llama-nvidia`, `llama-strix`) run `--jinja` with the Qwen3.8 chat template, which hard-raises on any system message that isn't first:

```
litellm.InternalServerError: OpenAIException — Jinja Exception:
System message must be at the beginning
Model Group=llama-strix → fallback llama-nvidia → same rejection
```

litellm 500s, ST toasts "SD prompt text generation failed", and ComfyUI never receives a request (verified: zero prompt submissions in comfy logs while ST logged repeated failures).

## Fix

Extend the existing `fallbacks` in `routerSettings` so the local groups end with the cloud chat door (`MiniMax-M3-chat`), matching the pattern already used by the `auto` group:

- `llama-strix` / `llama-nvidia`: cross-fallback as today, then `MiniMax-M3-chat`
- `local-pool` / `local-pool-chat`: → `MiniMax-M3-chat`

Regular chats are unaffected (they succeed on the locals and never hit the fallback). Auxiliary calls that the locals structurally reject — ST's image prompt expansion — now succeed via MiniMax-M3, and the image itself still renders locally in ComfyUI. Note the trade-off: any other failure on these groups will also land on MiniMax-M3-chat; spend is attributable via the litellm Prometheus counters.

## Deeper fix (not in this PR)

The durable fix is relaxing the served template itself (e.g. `--chat-template-file` with a patched Qwen3.8 template in the llmkube model args) so the locals tolerate trailing system messages. Deferred as it touches shared serving config for all consumers.

## Validation

`flate test ks` — `llm/litellm` renders clean. Post-merge: ST interactive image generation completes; litellm logs show the fallback hop for the expansion call.