### PR TITLE
feat(openclaw): give Miso a Discord voice channel using whisper and MiniMax

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -203,7 +203,13 @@ data:
         },
       },
       tools: {
-        media: { image: { timeoutSeconds: 180 } },
+        media: {
+          image: { timeoutSeconds: 180 },
+          audio: { enabled: true },
+          models: [
+            { type: "cli", command: "whisper-stt", args: ["{{AttachmentPath}}"], capabilities: ["audio"], timeoutSeconds: 120 },
+          ],
+        },
         sessions: { visibility: "all" },
         agentToAgent: { enabled: true },
         exec: { mode: "full", strictInlineEval: false },
@@ -295,6 +301,10 @@ data:
             moderation: false,
             emojiUploads: false,
             stickerUploads: false,
+          },
+          voice: {
+            enabled: true,
+            mode: "stt-tts",
           },
           streaming: { block: { enabled: false } },
           groupPolicy: "allowlist",


### PR DESCRIPTION
Enables `channels.discord.voice` in `stt-tts` mode so the whole loop stays on hardware you own plus the flat MiniMax sub, with whisper listening and the existing tts block speaking, rather than the default `agent-proxy` mode which needs a metered OpenAI GA realtime model; STT in that mode comes from `tools.media.audio` rather than any voice-specific key, and because whisper.cpp serves only `/inference` and 404s the OpenAI transcription route, it goes through a `tools.media.models[]` CLI entry pointing at a small wrapper that converts to 16 kHz mono and posts to the in-cluster service, measured at about 330 ms for a 20 second clip across mp3, wav and the ogg/opus Discord actually sends; the wrapper lives on the PVC alongside ffmpeg so it is not in this diff, and the remaining setup is Discord-side, namely invite scopes plus Connect and Speak on the target channel before `/vc join`.