### PR TITLE
feat(openclaw): mount ffmpeg and ffprobe into a trusted system path

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -171,6 +171,23 @@ spec:
         path: /mnt/daena/comfyui/output
         globalMounts:
           - path: /home/node/.openclaw/workspace/images
+      # OpenClaw resolves ffmpeg/ffprobe only from /usr/bin, /bin, /usr/sbin, /sbin
+      # and /usr/local/bin (src/infra/resolve-system-bin.ts) and never consults PATH,
+      # so the static builds already on the volume are invisible to it. Mount them as
+      # individual files: mounting over /usr/local/bin itself would shadow node and the
+      # openclaw entrypoint that live there. Needed for Discord voice-message OGG/Opus
+      # plus waveform generation; TTS itself does not use ffmpeg.
+      ffmpeg:
+        existingClaim: "{{ .Release.Name }}"
+        advancedMounts:
+          openclaw:
+            app:
+              - path: /usr/local/bin/ffmpeg
+                subPath: .openclaw/workspace/bin/ffmpeg
+                readOnly: true
+              - path: /usr/local/bin/ffprobe
+                subPath: .openclaw/workspace/bin/ffprobe
+                readOnly: true
       configmap:
         type: configMap
         name: "{{ .Release.Name }}-config"


### PR DESCRIPTION
OpenClaw resolves media binaries through `resolveSystemBin`, which by design only looks in `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin` and `/usr/local/bin` and never consults PATH, and since the official images do not bundle ffmpeg while the container runs as uid 1000 with no capabilities against root-owned system directories, nothing installed at runtime can satisfy it and `OPENCLAW_IMAGE_APT_PACKAGES` is only a build ARG; this mounts the static builds already present on the volume as two individual files rather than mounting over `/usr/local/bin`, which would shadow the `node` binary and the `openclaw` entrypoint that live there, and it is needed only for the Discord voice-message format with its OGG/Opus plus generated waveform, since TTS itself never touches ffmpeg and plain MP3 attachments already worked.