### PR TITLE
feat(openclaw): give Miso a voice via MiniMax, with ElevenLabs configured as an alternative

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -195,7 +195,7 @@ data:
         providers: {
           elevenlabs: {
             apiKey: "$${ELEVENLABS_API_KEY}",
-            voiceId: "pFZP5JQG7iQjIQuC4Bku",
+            voiceId: "cgSgspJ2msm6clMCkdW9",
             modelId: "eleven_multilingual_v2",
           },
           minimax: {

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -191,8 +191,13 @@ data:
         ownership: "explicit",
       },
       tts: {
-        provider: "minimax",
+        provider: "elevenlabs",
         providers: {
+          elevenlabs: {
+            apiKey: "$${ELEVENLABS_API_KEY}",
+            voiceId: "tQ4MEZFJOzsahSEEZtHK",
+            modelId: "eleven_multilingual_v2",
+          },
           minimax: {
             baseUrl: "https://api.minimax.io",
             apiKey: "$${MINIMAX_TTS_API_KEY}",

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -195,7 +195,7 @@ data:
         providers: {
           elevenlabs: {
             apiKey: "$${ELEVENLABS_API_KEY}",
-            voiceId: "tQ4MEZFJOzsahSEEZtHK",
+            voiceId: "pFZP5JQG7iQjIQuC4Bku",
             modelId: "eleven_multilingual_v2",
           },
           minimax: {

--- a/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/externalsecret.yaml
@@ -34,6 +34,7 @@ spec:
         CONTEXT7_API_KEY: "{{ .OPENCLAW_API_KEY }}"
         MEMINI_API_KEY: "{{ .MEMINI_API_KEY }}"
         MINIMAX_TTS_API_KEY: "{{ .MINIMAX_API_KEY }}"
+        ELEVENLABS_API_KEY: "{{ .ELEVENLABS_API_KEY }}"
         WAYPOINT_API_KEY: "{{ .WAYPOINT_API_KEY }}"
         FORGEJO_USER: "{{ .FORGEJO_USER }}"
         FORGEJO_PASSWORD: "{{ .FORGEJO_PASSWORD }}"
@@ -42,6 +43,8 @@ spec:
         key: openclaw
     - extract:
         key: composio
+    - extract:
+        key: elevenlabs
     - extract:
         key: minimax
     - extract:


### PR DESCRIPTION
Keeps MiniMax as the speech provider using `English_radiant_girl`, a bright warm young adult American voice, which is the MiniMax analogue of the ElevenLabs Jessica picked by ear and costs nothing under the flat subscription with no character ceiling; ElevenLabs' free tier is 10,000 credits a month at one credit per character, roughly ten voice notes, and the voice originally wanted (Ivanna) is a library voice that returns `402 paid_plan_required` on free regardless of being added to the workspace, so the ElevenLabs provider block and its key are left configured to make switching a one-line change if the $6 Starter plan is ever worth it. The speed override is dropped so the voice runs at its natural rate, since the slowdown existed to push a narrator voice toward a sultry register that is no longer the target, and MiniMax continues to serve chat through litellm under a separately named key after the earlier collision.