### PR TITLE
fix(openclaw): put Miso's voice back on MiniMax

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -191,7 +191,7 @@ data:
         ownership: "explicit",
       },
       tts: {
-        provider: "elevenlabs",
+        provider: "minimax",
         providers: {
           elevenlabs: {
             apiKey: "$${ELEVENLABS_API_KEY}",
@@ -202,8 +202,7 @@ data:
             baseUrl: "https://api.minimax.io",
             apiKey: "$${MINIMAX_TTS_API_KEY}",
             model: "speech-2.8-hd",
-            voiceId: "English_compelling_lady1",
-            speed: 0.92,
+            voiceId: "English_radiant_girl",
           },
         },
       },


### PR DESCRIPTION
ElevenLabs' free tier is 10,000 credits a month at one credit per character, so a single six-voice audition cost 909 of them, making it roughly ten voice notes a month, and the voice actually wanted is a library voice requiring the paid plan regardless; `English_radiant_girl` is the MiniMax analogue of the ElevenLabs Jessica chosen by ear, bright and warm and young adult American, costing nothing under the flat subscription with no character ceiling, and the speed override is dropped so it runs at its natural rate since the slowdown existed to push a narrator voice toward a sultry register that is no longer the target, while the ElevenLabs provider block and key stay configured so switching back is a one-line change.