### PR TITLE
feat(llm): self-hosted TTS via Lemonade OpenMOSS on the Strix iGPU

### DIFF
--- a/kubernetes/apps/base/llm/lemonade-tts/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/lemonade-tts/app/helmrelease.yaml
@@ -1,0 +1,113 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: lemonade-tts
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: lemonade-tts
+  interval: 15m
+  values:
+    controllers:
+      lemonade-tts:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # config.json is a sparse override file; only the keys set here differ
+          # from Lemonade's built-in defaults. Written by an init container
+          # rather than mounted from a ConfigMap because the same directory is a
+          # persistent volume that Lemonade also writes its own state into.
+          config:
+            image:
+              repository: ghcr.io/lemonade-sdk/lemonade-server
+              tag: latest@sha256:3873d3ec672eaebdf4484cf1592daae1ae0f73d0f6377a03f38f931f972ca122
+            command:
+              - sh
+              - -c
+              - |
+                set -eu
+                mkdir -p /opt/lemonade/.config/lemonade
+                cat > /opt/lemonade/.config/lemonade/config.json <<'JSON'
+                {
+                  "openmoss": {
+                    "backend": "vulkan"
+                  }
+                }
+                JSON
+                cat /opt/lemonade/.config/lemonade/config.json
+        containers:
+          app:
+            image:
+              repository: ghcr.io/lemonade-sdk/lemonade-server
+              tag: latest@sha256:3873d3ec672eaebdf4484cf1592daae1ae0f73d0f6377a03f38f931f972ca122
+            # Vulkan on the Strix Halo iGPU needs /dev/kfd and /dev/dri; this is
+            # the same access pattern the whisper deployment on this node uses.
+            securityContext:
+              privileged: true
+            command:
+              - ./lemond
+            args:
+              - --host
+              - 0.0.0.0
+              - --port
+              - "13305"
+            resources:
+              requests:
+                cpu: 500m
+                # GTT is not charged to any cgroup on this node, so the request
+                # is the only signal the scheduler has for what this consumes.
+                memory: 8Gi
+              limits:
+                memory: 16Gi
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /api/v1/health, port: 13305 }
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /api/v1/health, port: 13305 }
+                  initialDelaySeconds: 20
+                  periodSeconds: 10
+                  failureThreshold: 12
+    defaultPodOptions:
+      nodeSelector:
+        topology.kubernetes.io/gpus: amd
+      tolerations:
+        - key: llm-workload
+          operator: Exists
+          effect: NoSchedule
+      securityContext:
+        fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: 13305
+    persistence:
+      cache:
+        existingClaim: lemonade-tts-cache
+        advancedMounts:
+          lemonade-tts:
+            config:
+              - path: /opt/lemonade/.config/lemonade
+                subPath: config
+            app:
+              - path: /opt/lemonade/.cache/huggingface
+                subPath: huggingface
+              - path: /opt/lemonade/.cache/lemonade
+                subPath: lemonade
+              - path: /opt/lemonade/.config/lemonade
+                subPath: config
+              - path: /opt/lemonade/llama
+                subPath: llama

--- a/kubernetes/apps/base/llm/lemonade-tts/app/kustomization.yaml
+++ b/kubernetes/apps/base/llm/lemonade-tts/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./persistentvolumeclaim.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/llm/lemonade-tts/app/ocirepository.yaml
+++ b/kubernetes/apps/base/llm/lemonade-tts/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: lemonade-tts
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/base/llm/lemonade-tts/app/persistentvolumeclaim.yaml
+++ b/kubernetes/apps/base/llm/lemonade-tts/app/persistentvolumeclaim.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lemonade-tts-cache
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: local-hostpath
+  resources:
+    requests:
+      storage: 40Gi

--- a/kubernetes/apps/main/llm/kustomization.yaml
+++ b/kubernetes/apps/main/llm/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ./litellm-operator.yaml
   - ./litellm.yaml
   - ./llmkube.yaml
+  - ./lemonade-tts.yaml
   - ./memini.yaml
   - ./open-webui.yaml
   - ./openclaw.yaml

--- a/kubernetes/apps/main/llm/lemonade-tts.yaml
+++ b/kubernetes/apps/main/llm/lemonade-tts.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app lemonade-tts
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/base/llm/lemonade-tts/app
+  postBuild:
+    substitute:
+      APP: *app
+  wait: false
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system


### PR DESCRIPTION
Lemonade exposes an OpenAI-compatible `POST /v1/audio/speech` so this plugs into OpenClaw's `tts.providers.openai.baseUrl` with no plugin or custom skill, and its `openmoss` backend supports vulkan on amd_gpu which is the same path whisper already uses on this node, whereas `kokoro` is cpu/metal only and cannot use this GPU; OpenMOSS is preferred because `voice` is a free-text style instruction and `voice_design_description` invents a voice from a description and uses it as the reference, which answers the requirement that a fixed voice catalogue could not without cloning anyone or paying per character. Wiring OpenClaw afterwards needs `responseFormat: wav` since OpenMOSS v0.3 encodes only wav or pcm, with the ffmpeg now mounted into the OpenClaw pod handling conversion for Discord voice notes, and memory is requested explicitly because GTT is not charged to any cgroup on this node so the request is the scheduler's only signal.