### PR TITLE
fix(memini): stop recall silently degrading to an ungated fallback

### DIFF
--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -40,8 +40,9 @@ spec:
               MEMINI_RERANK: http://litellm.llm:4000/v1
               MEMINI_RERANK_MODEL: rerank
               MEMINI_RERANK_MAX_CONCURRENCY: 2
-              MEMINI_RERANK_TIMEOUT: 25s
+              MEMINI_RERANK_TIMEOUT: 45s
               MEMINI_RERANK_POOL: "8"
+              MEMINI_TIMEOUT_MS: "55000"
             envFrom:
               - secretRef:
                   name: memini

--- a/kubernetes/apps/base/llm/memini/memini-rerank.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-rerank.yaml
@@ -4,7 +4,7 @@ kind: Model
 metadata:
   name: memini-rerank
 spec:
-  source: https://huggingface.co/ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/resolve/main/qwen3-reranker-0.6b-q8_0.gguf
+  source: https://huggingface.co/gpustack/jina-reranker-v2-base-multilingual-GGUF/resolve/main/jina-reranker-v2-base-multilingual-Q8_0.gguf
   format: gguf
   quantization: Q8_0
   hardware:
@@ -23,7 +23,7 @@ spec:
   rolloutPolicy:
     waitForIdle: true
     idleTimeoutSeconds: 86400
-  replicas: 1
+  replicas: 3
   priority: normal
   podLabels:
     cpu-inference: "true"
@@ -33,9 +33,9 @@ spec:
       whenUnsatisfiable: ScheduleAnyway
       labelSelector:
         matchLabels:
-          cpu-inference: "true"
+          app: memini-rerank
   contextSize: 8096
-  parallelSlots: 2
+  parallelSlots: 1
   batchSize: 8192
   uBatchSize: 8192
   env:

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -524,7 +524,7 @@ data:
               skip_without_agent: true,
               skip_system_turns: true,
               fallback_on_error: true,
-              timeout_ms: 15000,
+              timeout_ms: 60000,
               recall_limit: 3,
               expose_tools: true,
             },


### PR DESCRIPTION
Recall was serving three memories per prompt chosen without a reranker roughly 40% of the time (145 rerank fallbacks against 217 successes, plus 66 recalls degraded to keyword-only), and memini's own docs describe that fallback as returning the least-irrelevant noise ranked confidently, which is what made Miso appear to be fed nonsense; injection volume was never the problem, since every recall served exactly the configured three with budgets enforced and cooldown excluding up to twenty already-seen ids. The cause was latency: a cross-encoder rerank is CPU-bound and serialises, so with five memini clients the tail passed the 15s client timeout, OpenClaw hung up, and memini recorded a rerank failure, measured at 3.4s for one concurrent request and 18.6s for five on a single replica. Three benchmarked changes follow: the reranker becomes jina-reranker-v2-base-multilingual, which ties Qwen3-0.6B on top-3 accuracy at 12/12 (the metric `recall_limit: 3` actually consumes) while being 3.8x faster and weaker only on P@1 ordering at 9/12 against 11/12, with Qwen3 at Q4_K_M rejected because it collapses to 7/12 top-3 since rerankers emit calibrated scores that quantisation damages far more than a generative model's distribution, and bge-reranker-base rejected as strictly worse than jina at the same size; three replicas with one slot each so a queued caller reaches an idle pod, verified to spread across all three despite litellm's connection pooling; and the topology spread constraint now selects this app rather than the shared `cpu-inference` label, which balanced the whole cohort and let two replicas stack on one node while another sat with 7.76 CPU free. Timeouts are raised so the failure mode is slowness rather than silent wrongness, client 60s above memini total 55s above rerank 45s above embed 15s, since `MEMINI_TIMEOUT_MS` defaults to 30s and would cancel a slow rerank regardless of the rerank timeout.