### PR TITLE
feat(llm): bring back llama-vision as Gemma 4 E4B on CPU

### DIFF
--- a/kubernetes/apps/base/llm/litellm/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
   - ./llama-flash-next.yaml
   # - ./llama-strix.yaml
   # - ./llama-reviewer.yaml
-  # - ./llama-vision.yaml
+  - ./llama-vision.yaml
   - ./prometheusrule.yaml
   - ./llmkube-skirk-cache.yaml
   - ./llama-strix-prompt-cache.yaml

--- a/kubernetes/apps/base/llm/litellm/llama-vision.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-vision.yaml
@@ -4,22 +4,15 @@ kind: Model
 metadata:
   name: llama-vision
 spec:
-  source: hf://huihui-ai/Huihui-MiniCPM-V-4_5-abliterated
+  source: hf://llmfan46/gemma-4-E4B-it-ultra-uncensored-heretic-GGUF
   files:
-    - GGUF/ggml-model-Q4_K_M.gguf
-    - GGUF/mmproj-model-f16.gguf
-  mmproj: GGUF/mmproj-model-f16.gguf
+    - gemma-4-E4B-it-ultra-uncensored-heretic-Q4_K_M.gguf
+    - gemma-4-E4B-it-mmproj-BF16.gguf
+  mmproj: gemma-4-E4B-it-mmproj-BF16.gguf
   format: gguf
   quantization: Q4_K_M
   hardware:
-    accelerator: rocm
-    gpu:
-      enabled: true
-      vendor: amd
-      layers: 99
-      resourceClaims:
-        - name: gpu
-          resourceClaimTemplateName: llama-strix-gpu
+    accelerator: cpu
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
@@ -29,80 +22,39 @@ metadata:
     krr/ignore: "true"
 spec:
   modelRef: llama-vision
-  modelCache:
-    claimName: llmkube-skirk-cache
   runtime: llamacpp
-  image: docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:1c655ca0443655f2e7603d054770b07cd8c79267145728b3261295f005053947
+  image: ghcr.io/ggml-org/llama.cpp:server@sha256:7fa75431b8a78f9528cab4aaf65e8ae3e13da546a3cc7221247ca81bab864d84
   rolloutPolicy:
     waitForIdle: true
     idleTimeoutSeconds: 86400
-  command:
-    - llama-server
   replicas: 1
-  priority: high
-  nodeSelector:
-    topology.kubernetes.io/gpus: amd
-  tolerations:
-    - key: llm-workload
-      operator: Exists
-      effect: NoSchedule
-  contextSize: 16384
-  parallelSlots: 2
-  flashAttention: true
-  jinja: true
-  cacheTypeK: q8_0
-  cacheTypeV: q8_0
-  batchSize: 4096
-  uBatchSize: 1024
+  priority: normal
+  podLabels:
+    cpu-inference: "true"
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app: llama-vision
+  contextSize: 8192
+  parallelSlots: 1
+  batchSize: 2048
+  uBatchSize: 512
   resources:
-    cpu: "500m"
+    cpu: "4"
     memory: 12Gi
-  endpoint:
-    port: 8080
-    type: ClusterIP
   extraArgs:
     - --alias
     - llama-vision
-    - --cont-batching
-    - --cache-ram
-    - "0"
-    - --kv-unified
-    # MiniCPM-V 4.5 uses its model-defined 448px slicing and 64-token
-    # resampler; --image-min/max-tokens target other vision families.
-    - --reasoning
-    - "off"
-    - --temp
-    - "0.6"
-    - --top-p
-    - "0.95"
-    - --top-k
-    - "20"
-    - --repeat-penalty
-    - "1.05"
+    - --chat-template-kwargs
+    - '{"enable_thinking": false}'
     - --threads
-    - "8"
+    - "12"
     - --threads-batch
     - "16"
-    - --load-mode
-    - none
-  probeOverrides:
-    startup:
-      httpGet:
-        path: /health
-        port: 8080
-      periodSeconds: 10
-      failureThreshold: 360
-    liveness:
-      httpGet:
-        path: /health
-        port: 8080
-      initialDelaySeconds: 30
-      periodSeconds: 30
-      failureThreshold: 6
-    readiness:
-      httpGet:
-        path: /health
-        port: 8080
-      initialDelaySeconds: 20
-      periodSeconds: 10
-      failureThreshold: 6
+    - --mmap
+  endpoint:
+    port: 8080
+    type: ClusterIP


### PR DESCRIPTION
The previous `llama-vision` (MiniCPM-V-4.5-abliterated on the Strix iGPU) was commented out of the kustomization and not deployed, leaving vision to the general models, each of which has a problem: the 27B on the 3090 has poor general knowledge and its projector is CPU-offloaded to save VRAM, while Flash-Next on Strix is a single parallel slot occupying most of that node so any vision request contends with normal chat. Gemma 4 E4B is built for edge and CPU, so this runs on a CPU node and takes nothing from either GPU, and it was measured on both real workloads: OCR of a rendered invoice with currency, SKUs and a lot number came back 100% correct in 19.8s against Flash-Next's identical result in 8.3s, so equal accuracy off the contended slot; anime character identification it simply cannot do, describing outfit and pose accurately every time but lacking the world knowledge for the name, where Flash-Next identifies correctly in 12.9s and the 27B got character and series both wrong. Thinking is disabled at the server through `chat-template-kwargs` because with thinking on it spent 143s and 1079 tokens to reach a worse answer than the 15s non-thinking run, and because `reasoning_effort: none` (the other way to suppress it) makes the model fabricate a confident wrong name where `enable_thinking: false` admits it does not know. The model is abliterated to match the previous one, the projector is listed in both `files` and `mmproj` without which llmkube never downloads it and vision fails silently, the memory request is sized from a measured 8.4 GiB RSS, and the topology spread selects this app rather than the shared `cpu-inference` label.