### PR TITLE
feat(openclaw): make llama-vision the primary vision model, at 32k context

### DIFF
--- a/kubernetes/apps/base/llm/litellm/llama-vision.yaml
+++ b/kubernetes/apps/base/llm/litellm/llama-vision.yaml
@@ -38,13 +38,13 @@ spec:
       labelSelector:
         matchLabels:
           app: llama-vision
-  contextSize: 8192
+  contextSize: 32768
   parallelSlots: 1
   batchSize: 2048
   uBatchSize: 512
   resources:
     cpu: "4"
-    memory: 12Gi
+    memory: 16Gi
   extraArgs:
     - --alias
     - llama-vision

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -30,8 +30,9 @@ data:
             ]
           },
           imageModel: {
-            primary: "litellm/llama-nvidia-chat",
+            primary: "litellm/llama-vision",
             fallbacks: [
+              "litellm/llama-nvidia-chat",
               "litellm/llama-strix-chat",
               "litellm/glm-5.3-flash",
               "minimax/MiniMax-M3",
@@ -253,6 +254,7 @@ data:
             models: [
               { id: "kimi-k2.7", name: "Kimi K2.7 Code", reasoning: true, input: ["text", "image"], cost: { input: 0.95, output: 4, cacheRead: 0.19, cacheWrite: 0.95 }, contextWindow: 262144, maxTokens: 32768, compat: { supportsUsageInStreaming: true } },
               { id: "kimi-k3", name: "Kimi K3", reasoning: true, input: ["text", "image"], cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3 }, contextWindow: 262144, maxTokens: 131072, compat: { supportsUsageInStreaming: true } },
+              { id: "llama-vision", name: "Gemma-4-E4B-it abliterated (CPU)", reasoning: false, input: ["text", "image"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 32768, maxTokens: 8192, compat: { supportsUsageInStreaming: true } },
               { id: "llama-strix", name: "Qwen3.6-35B-A3B UD-Q4_K_XL (ROCm)", reasoning: true, input: ["text", "image"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 16384, compat: { supportsUsageInStreaming: true } },
               { id: "llama-strix-chat", name: "Qwen3.6-35B-A3B non-thinking (ROCm)", reasoning: false, input: ["text", "image"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 16384, compat: { supportsUsageInStreaming: true } },
               { id: "llama-reviewer", name: "Gemma-4-12B-it-QAT (9070XT)", reasoning: true, input: ["text", "image"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 262144, maxTokens: 16384, compat: { supportsUsageInStreaming: true } },


### PR DESCRIPTION
Sets `imageModel.primary` to `litellm/llama-vision` and demotes the previous primary `llama-nvidia-chat` to the head of the fallback chain, declares `llama-vision` on the litellm provider as accepting images so OpenClaw knows the model exists, and raises the service context from the 8192 it shipped with to 32768 because OpenClaw needs at least 16k; Gemma 4 E4B is natively 131072 with a 512-token sliding window so most layers retain only 512 tokens and the extra context costs little KV, with memory raised to 16Gi to cover it against a measured 8.4 GiB RSS at 8k on a node with over 60 GiB free.