### PR TITLE
feat(talos): update siderolabs/talos (v1.13.9 -> v1.14.0) and migrate to multi-document config

### DIFF
--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -33,7 +33,7 @@ tasks:
             exit 0
           fi
           node_file="$(find "${TALOS_DIR}" -name "${NODE}.yaml" -print -quit)"
-          yq --exit-status '.machine.nodeLabels."topology.kubernetes.io" == "egpu"' "$node_file" >/dev/null 2>&1 \
+          yq --exit-status 'select(.kind == "KubeNodeConfig") | .labels."topology.kubernetes.io" == "egpu"' "$node_file" >/dev/null 2>&1 \
             && echo true || echo false
       GPU_PATCH:
         sh: dirname "$(find "${TALOS_DIR}" -name "${NODE}.yaml" -exec dirname {} \;)/${NODE}.yaml" | xargs -I{} echo "{}/eGPU.yaml"
@@ -74,7 +74,7 @@ tasks:
       rendered_ca="$(
         CLUSTER={{.CLUSTER}} MACHINE_TYPE={{.MACHINE_TYPE}} SCHEMATIC={{.SCHEMATIC}} minijinja-cli {{.TALOS_DIR}}/machineconfig.yaml.j2 \
           | op inject \
-          | yq --exit-status --no-doc '.machine.ca.crt'
+          | yq eval-all --exit-status --no-doc '[select(.machine.ca.crt != null) | .machine.ca.crt] | .[0]'
       )"
       live_ca="$(
         talosctl --talosconfig {{.TALOS_DIR}}/talosconfig --nodes {{.CONTROL_PLANE}} get machineconfig --output yaml \
@@ -95,7 +95,7 @@ tasks:
             exit 0
           fi
           node_file="$(find "${TALOS_DIR}" -name "${NODE}.yaml" -print -quit)"
-          yq --exit-status '.machine.nodeLabels."topology.kubernetes.io" == "egpu"' "$node_file" >/dev/null 2>&1 \
+          yq --exit-status 'select(.kind == "KubeNodeConfig") | .labels."topology.kubernetes.io" == "egpu"' "$node_file" >/dev/null 2>&1 \
             && echo true || echo false
       MACHINE_TYPE:
         sh: |-
@@ -192,7 +192,7 @@ tasks:
       TALOS_IMAGE:
         sh: |-
           talosctl --talosconfig {{.TALOS_DIR}}/talosconfig --nodes {{.NODE}} get machineconfig --output=jsonpath='{.spec}' \
-            | yq eval-all --exit-status --no-doc '[select(.machine.install.image != null) | .machine.install.image] | .[0]'
+            | yq eval-all --exit-status --no-doc '[select(.kind == "UnattendedInstallConfig") | .installer.image] | .[0]'
     requires:
       vars: [CLUSTER, NODE]
     preconditions:
@@ -320,7 +320,7 @@ tasks:
             exit 0
           fi
           node_file="$(find "${TALOS_DIR}" -name "${NODE}.yaml" -print -quit)"
-          yq --exit-status '.machine.nodeLabels."topology.kubernetes.io" == "egpu"' "$node_file" >/dev/null 2>&1 \
+          yq --exit-status 'select(.kind == "KubeNodeConfig") | .labels."topology.kubernetes.io" == "egpu"' "$node_file" >/dev/null 2>&1 \
             && echo true || echo false
     requires:
       vars: [VERSION, CLUSTER, NODE]
@@ -342,7 +342,7 @@ tasks:
             exit 0
           fi
           node_file="$(find "${TALOS_DIR}" -name "${NODE}.yaml" -print -quit)"
-          yq --exit-status '.machine.nodeLabels."topology.kubernetes.io" == "egpu"' "$node_file" >/dev/null 2>&1 \
+          yq --exit-status 'select(.kind == "KubeNodeConfig") | .labels."topology.kubernetes.io" == "egpu"' "$node_file" >/dev/null 2>&1 \
             && echo true || echo false
       MACHINE_TYPE:
         sh: basename "$(find "${TALOS_DIR}" -name "${NODE}.yaml" -exec dirname {} \;)"

--- a/kubernetes/apps/main/kube-tools/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/main/kube-tools/upgrades/talosupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-    version: v1.13.9
+    version: v1.14.0
   policy:
     timeout: 30m
     debug: true

--- a/kubernetes/apps/test/kube-tools/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/test/kube-tools/upgrades/talosupgrade.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   talos:
     # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-    version: v1.13.9
+    version: v1.14.0

--- a/kubernetes/apps/utility/kube-tools/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/utility/kube-tools/upgrades/talosupgrade.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   talos:
     # renovate: datasource=custom.talos-factory depName=siderolabs/talos
-    version: v1.13.9
+    version: v1.14.0

--- a/talos/main/controlplane/ayaka.yaml
+++ b/talos/main/controlplane/ayaka.yaml
@@ -1,9 +1,10 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.12/website/content/v1.12/schemas/config.schema.json
-machine:
-  install:
-    diskSelector:
-      serial: "S665NE0R500552" # m.2 PM9A3 960GB
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.14/website/content/v1.14/schemas/config.schema.json
+apiVersion: v1alpha1
+kind: UnattendedInstallConfig
+provisioning:
+  diskSelector:
+    match: disk.serial == "S665NE0R500552" # m.2 PM9A3 960GB
 ---
 apiVersion: v1alpha1
 kind: HostnameConfig

--- a/talos/main/controlplane/eGPU.yaml
+++ b/talos/main/controlplane/eGPU.yaml
@@ -1,17 +1,25 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.13/website/content/v1.13/schemas/config.schema.json
-machine:
-  kernel:
-    modules:
-      - name: nbd
-      - name: thunderbolt
-      - name: thunderbolt_net
-      - name: nvidia
-      - name: nvidia_uvm
-      - name: nvidia_drm
-      - name: nvidia_modeset
-  nodeLabels:
-    topology.kubernetes.io: egpu
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.14/website/content/v1.14/schemas/config.schema.json
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_uvm
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_drm
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nvidia_modeset
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+labels:
+  topology.kubernetes.io: egpu
 ---
 # OCuLink eGPU shifts the MS-01 PCI topology, which renames onboard NICs.
 apiVersion: v1alpha1

--- a/talos/main/controlplane/eula.yaml
+++ b/talos/main/controlplane/eula.yaml
@@ -1,9 +1,10 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.12/website/content/v1.12/schemas/config.schema.json
-machine:
-  install:
-    diskSelector:
-      serial: "S665NE0R500722" # m.2 PM9A3 960GB
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.14/website/content/v1.14/schemas/config.schema.json
+apiVersion: v1alpha1
+kind: UnattendedInstallConfig
+provisioning:
+  diskSelector:
+    match: disk.serial == "S665NE0R500722" # m.2 PM9A3 960GB
 ---
 apiVersion: v1alpha1
 kind: HostnameConfig

--- a/talos/main/controlplane/ganyu.yaml
+++ b/talos/main/controlplane/ganyu.yaml
@@ -1,11 +1,15 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.12/website/content/v1.12/schemas/config.schema.json
-machine:
-  install:
-    diskSelector:
-      serial: "S665NE0R500520" # m.2 PM9A3 960GB
-  nodeLabels:
-    topology.kubernetes.io: egpu
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.14/website/content/v1.14/schemas/config.schema.json
+apiVersion: v1alpha1
+kind: UnattendedInstallConfig
+provisioning:
+  diskSelector:
+    match: disk.serial == "S665NE0R500520" # m.2 PM9A3 960GB
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+labels:
+  topology.kubernetes.io: egpu
 ---
 apiVersion: v1alpha1
 kind: HostnameConfig

--- a/talos/main/machineconfig.yaml.j2
+++ b/talos/main/machineconfig.yaml.j2
@@ -40,7 +40,7 @@ machine:
         nconnect=16
         noatime=True
   install:
-    image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.13.9
+    image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.14.0
   kernel:
     modules:
       - name: nbd

--- a/talos/main/machineconfig.yaml.j2
+++ b/talos/main/machineconfig.yaml.j2
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.13/website/content/v1.13/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.14/website/content/v1.14/schemas/config.schema.json
 version: v1alpha1
 machine:
   ca:
@@ -9,114 +9,8 @@ machine:
     {% endif %}
   features:
     diskQuotaSupport: true
-    hostDNS:
-      enabled: true
-      forwardKubeDNSToHost: true
-      resolveMemberNames: true
-    kubePrism:
-      enabled: true
-      port: 7445
-    {% if ENV.MACHINE_TYPE == 'controlplane' %}
-    kubernetesTalosAPIAccess:
-      enabled: true
-      allowedRoles: ["os:admin", "os:reader"]
-      allowedKubernetesNamespaces: ["actions-runner-system", "kube-tools", "llm"]
-    {% endif %}
-  files:
-    - op: create
-      path: /etc/cri/conf.d/20-customization.part
-      content: |
-        [plugins."io.containerd.cri.v1.images"]
-          discard_unpacked_layers = false
-        [plugins."io.containerd.cri.v1.runtime"]
-          device_ownership_from_security_context = true
-    - op: overwrite
-      path: /etc/nfsmount.conf
-      permissions: 0o644
-      content: |
-        [ NFSMount_Global_Options ]
-        nfsvers=4.2
-        hard=True
-        nconnect=16
-        noatime=True
-  install:
-    image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.14.0
-  kernel:
-    modules:
-      - name: nbd
-      {% if ENV.MACHINE_TYPE == 'controlplane' %}
-      - name: thunderbolt
-      - name: thunderbolt_net
-      {% endif %}
-  kubelet:
-    defaultRuntimeSeccompProfileEnabled: true
-    disableManifestsDirectory: true
-    extraArgs:
-      max-pods: "200"
-    extraConfig:
-      serializeImagePulls: false
-      imageMaximumGCAge: 24h
-      {% if ENV.MACHINE_TYPE == 'controlplane' %}
-      systemReserved:
-        cpu: 500m
-        memory: 1Gi
-        ephemeral-storage: 2Gi
-      kubeReserved:
-        cpu: 500m
-        memory: 1Gi
-        ephemeral-storage: 2Gi
-      evictionHard:
-        memory.available: 512Mi
-        nodefs.available: 10%
-        imagefs.available: 15%
-      evictionSoft:
-        memory.available: 1Gi
-      evictionSoftGracePeriod:
-        memory.available: 1m
-      evictionPressureTransitionPeriod: 30s
-      {% endif %}
-    image: ghcr.io/siderolabs/kubelet:v1.36.2
-    nodeIP:
-      validSubnets: ["10.69.1.0/24"]
-  nodeLabels:
-    topology.kubernetes.io/region: k8s
-    topology.kubernetes.io/zone: {{ 'm' if ENV.MACHINE_TYPE == 'controlplane' else 'w' }}
-  sysfs:
-    devices.system.cpu.cpufreq.policy0.scaling_governor: powersave
-    devices.system.cpu.cpufreq.policy0.energy_performance_preference: balance_power
-  sysctls:
-    fs.inotify.max_user_watches: "1048576"     # Watchdog
-    fs.inotify.max_user_instances: "8192"      # Watchdog
-    net.core.default_qdisc: fq                 # 10Gb/s
-    net.core.somaxconn: "8192"                # Raise listen backlog for burst handling
-    net.core.netdev_max_backlog: "16384"      # Raise kernel ingress queue depth
-    net.core.rmem_max: "67108864"              # 10Gb/s | Cloudflared / QUIC
-    net.core.wmem_max: "67108864"              # 10Gb/s | Cloudflared / QUIC
-    net.ipv4.neigh.default.gc_thresh1: "4096"  # Prevent ARP cache overflows
-    net.ipv4.neigh.default.gc_thresh2: "8192"  # Prevent ARP cache overflows
-    net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
-    net.ipv4.ping_group_range: 0 2147483647    # Allow Ping
-    net.ipv4.tcp_congestion_control: bbr       # 10Gb/s
-    net.ipv4.tcp_fastopen: "3"                 # Send and accept data in the opening SYN packet
-    net.ipv4.tcp_max_syn_backlog: "8192"       # Larger SYN queue for bursty connection rates
-    net.ipv4.tcp_mtu_probing: "1"              # 10Gb/s | Jumbo frames
-    net.ipv4.tcp_notsent_lowat: "131072"       # Allow Ping
-    net.ipv4.tcp_rmem: 4096 87380 33554432     # 10Gb/s
-    net.ipv4.tcp_wmem: 4096 65536 33554432     # 10Gb/s
-    net.ipv4.tcp_slow_start_after_idle: "0"    # Allow Ping
-    net.ipv4.tcp_window_scaling: "1"           # 10Gb/s
-    sunrpc.tcp_slot_table_entries: "128"       # 10Gb/s | NFS
-    sunrpc.tcp_max_slot_table_entries: "128"   # 10Gb/s | NFS
-    user.max_user_namespaces: "11255"          # User Namespaces
-    vm.dirty_background_bytes: "268435456"     # 256MiB | Byte-based writeback start; protect etcd fdatasync on shared NVMe
-    vm.dirty_bytes: "536870912"                # 512MiB | Cap dirty buildup (ratio 5%/20% on 134GB RAM allowed multi-GB flush storms)
-    vm.dirty_expire_centisecs: "3000"         # Expire dirty data after 30s
-    vm.dirty_writeback_centisecs: "500"       # Flush dirty pages every 5s
   token: op://Kubernetes/talos-{{ ENV.CLUSTER }}/MACHINE_TOKEN
   type: {{ ENV.MACHINE_TYPE }}
-  time:
-    disabled: false
-    servers: ["time.cloudflare.com"]
 cluster:
   ca:
     crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_CA_CRT
@@ -126,39 +20,11 @@ cluster:
   clusterName: main
   controlPlane:
     endpoint: https://k8s.main.internal:6443
-  discovery:
-    enabled: true
-    registries:
-      kubernetes:
-        disabled: true
-      service:
-        disabled: false
-  id: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ID
-  network:
-    cni:
-      name: none
-    dnsDomain: cluster.local
-    podSubnets: ["10.42.0.0/16"]
-    serviceSubnets: ["10.43.0.0/16"]
-  secret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRET
   token: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_TOKEN
   {% if ENV.MACHINE_TYPE == 'controlplane' %}
   aggregatorCA:
     crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_AGGREGATORCA_CRT
     key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_AGGREGATORCA_KEY
-  allowSchedulingOnControlPlanes: true
-  apiServer:
-    certSANs: ["k8s.main.internal", "127.0.0.1"]
-    extraArgs:
-      enable-aggregator-routing: true
-      feature-gates: HPAScaleToZero=true
-    image: registry.k8s.io/kube-apiserver:v1.36.2
-  controllerManager:
-    extraArgs:
-      bind-address: 0.0.0.0
-    image: registry.k8s.io/kube-controller-manager:v1.36.2
-  coreDNS:
-    disabled: true
   etcd:
     advertisedSubnets: ["10.69.1.0/24"]
     ca:
@@ -166,31 +32,237 @@ cluster:
       key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ETCD_CA_KEY
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
-  proxy:
-    disabled: true
-    image: registry.k8s.io/kube-proxy:v1.36.2
-  secretboxEncryptionSecret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRETBOXENCRYPTIONSECRET
-  scheduler:
-    config:
-      apiVersion: kubescheduler.config.k8s.io/v1
-      kind: KubeSchedulerConfiguration
-      profiles:
-        - schedulerName: default-scheduler
-          plugins:
-            score:
-              disabled:
-                - name: ImageLocality
-          pluginConfig:
-            - name: PodTopologySpread
-              args:
-                defaultingType: List
-                defaultConstraints:
-                  - maxSkew: 1
-                    topologyKey: kubernetes.io/hostname
-                    whenUnsatisfiable: ScheduleAnyway
-    image: registry.k8s.io/kube-scheduler:v1.36.2
-    extraArgs:
-      bind-address: 0.0.0.0
   serviceAccount:
     key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SERVICEACCOUNT_KEY
   {% endif %}
+---
+apiVersion: v1alpha1
+kind: ResolverConfig
+searchDomains:
+  domains: []
+hostDNS:
+  enabled: true
+  forwardKubeDNSToHost: true
+  resolveMemberNames: true
+---
+apiVersion: v1alpha1
+kind: DiscoveryServiceConfig
+name: default
+endpoint: https://discovery.talos.dev/
+---
+apiVersion: v1alpha1
+kind: DiscoveryIdentityConfig
+clusterID: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ID
+clusterSecret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRET
+---
+apiVersion: v1alpha1
+kind: TimeSyncConfig
+enabled: true
+ntp:
+  servers: ["time.cloudflare.com"]
+---
+apiVersion: v1alpha1
+kind: UnattendedInstallConfig
+installer:
+  image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.14.0
+provisioning:
+  wipe: false
+---
+apiVersion: v1alpha1
+kind: FilesystemTrimConfig
+interval: 168h0m0s
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nbd
+{% if ENV.MACHINE_TYPE == 'controlplane' %}
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: thunderbolt
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: thunderbolt_net
+{% endif %}
+---
+apiVersion: v1alpha1
+kind: SysfsConfig
+params:
+  devices.system.cpu.cpufreq.policy0.scaling_governor: powersave
+  devices.system.cpu.cpufreq.policy0.energy_performance_preference: balance_power
+---
+apiVersion: v1alpha1
+kind: SysctlConfig
+params:
+  fs.inotify.max_user_watches: "1048576"     # Watchdog
+  fs.inotify.max_user_instances: "8192"      # Watchdog
+  net.core.default_qdisc: fq                 # 10Gb/s
+  net.core.somaxconn: "8192"                # Raise listen backlog for burst handling
+  net.core.netdev_max_backlog: "16384"      # Raise kernel ingress queue depth
+  net.core.rmem_max: "67108864"              # 10Gb/s | Cloudflared / QUIC
+  net.core.wmem_max: "67108864"              # 10Gb/s | Cloudflared / QUIC
+  net.ipv4.neigh.default.gc_thresh1: "4096"  # Prevent ARP cache overflows
+  net.ipv4.neigh.default.gc_thresh2: "8192"  # Prevent ARP cache overflows
+  net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
+  net.ipv4.ping_group_range: 0 2147483647    # Allow Ping
+  net.ipv4.tcp_congestion_control: bbr       # 10Gb/s
+  net.ipv4.tcp_fastopen: "3"                 # Send and accept data in the opening SYN packet
+  net.ipv4.tcp_max_syn_backlog: "8192"       # Larger SYN queue for bursty connection rates
+  net.ipv4.tcp_mtu_probing: "1"              # 10Gb/s | Jumbo frames
+  net.ipv4.tcp_notsent_lowat: "131072"       # Allow Ping
+  net.ipv4.tcp_rmem: 4096 87380 33554432     # 10Gb/s
+  net.ipv4.tcp_wmem: 4096 65536 33554432     # 10Gb/s
+  net.ipv4.tcp_slow_start_after_idle: "0"    # Allow Ping
+  net.ipv4.tcp_window_scaling: "1"           # 10Gb/s
+  sunrpc.tcp_slot_table_entries: "128"       # 10Gb/s | NFS
+  sunrpc.tcp_max_slot_table_entries: "128"   # 10Gb/s | NFS
+  user.max_user_namespaces: "11255"          # User Namespaces
+  vm.dirty_background_bytes: "268435456"     # 256MiB | Byte-based writeback start; protect etcd fdatasync on shared NVMe
+  vm.dirty_bytes: "536870912"                # 512MiB | Cap dirty buildup (ratio 5%/20% on 134GB RAM allowed multi-GB flush storms)
+  vm.dirty_expire_centisecs: "3000"         # Expire dirty data after 30s
+  vm.dirty_writeback_centisecs: "500"       # Flush dirty pages every 5s
+---
+apiVersion: v1alpha1
+kind: EtcFileConfig
+name: nfsmount.conf
+mode: 0o644
+contents: |
+  [ NFSMount_Global_Options ]
+  nfsvers=4.2
+  hard=True
+  nconnect=16
+  noatime=True
+---
+apiVersion: v1alpha1
+kind: CRICustomizationConfig
+name: containerd
+content: |
+  [plugins."io.containerd.cri.v1.images"]
+    discard_unpacked_layers = false
+  [plugins."io.containerd.cri.v1.runtime"]
+    device_ownership_from_security_context = true
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+nodeIP:
+  validSubnets: ["10.69.1.0/24"]
+labels:
+  topology.kubernetes.io/region: k8s
+  topology.kubernetes.io/zone: {{ 'm' if ENV.MACHINE_TYPE == 'controlplane' else 'w' }}
+  {% if ENV.MACHINE_TYPE == 'controlplane' %}
+  node-role.kubernetes.io/control-plane: ""
+  {% endif %}
+---
+apiVersion: v1alpha1
+kind: KubeletConfig
+image: ghcr.io/siderolabs/kubelet:v1.36.2
+defaultRuntimeSeccompProfileEnabled: true
+extraArgs:
+  max-pods: "200"
+config:
+  serializeImagePulls: false
+  imageMaximumGCAge: 24h
+  {% if ENV.MACHINE_TYPE == 'controlplane' %}
+  systemReserved:
+    cpu: 500m
+    memory: 1Gi
+    ephemeral-storage: 2Gi
+  kubeReserved:
+    cpu: 500m
+    memory: 1Gi
+    ephemeral-storage: 2Gi
+  evictionHard:
+    memory.available: 512Mi
+    nodefs.available: 10%
+    imagefs.available: 15%
+  evictionSoft:
+    memory.available: 1Gi
+  evictionSoftGracePeriod:
+    memory.available: 1m
+  evictionPressureTransitionPeriod: 30s
+  {% endif %}
+---
+apiVersion: v1alpha1
+kind: KubeNetworkConfig
+dnsDomain: cluster.local
+podSubnets: ["10.42.0.0/16"]
+serviceSubnets: ["10.43.0.0/16"]
+---
+apiVersion: v1alpha1
+kind: KubePrismConfig
+port: 7445
+{% if ENV.MACHINE_TYPE == 'controlplane' %}
+---
+apiVersion: v1alpha1
+kind: KubeTalosAPIAccessConfig
+allowedRoles: ["os:admin", "os:reader"]
+allowedKubernetesNamespaces: ["actions-runner-system", "kube-tools", "llm"]
+---
+apiVersion: v1alpha1
+kind: KubeAPIServerConfig
+image: registry.k8s.io/kube-apiserver:v1.36.2
+certExtraSANs: ["k8s.main.internal", "127.0.0.1"]
+extraArgs:
+  enable-aggregator-routing: "true"
+  feature-gates: HPAScaleToZero=true
+---
+apiVersion: v1alpha1
+kind: KubeAuthorizerConfig
+name: node
+type: Node
+---
+apiVersion: v1alpha1
+kind: KubeAuthorizerConfig
+name: rbac
+type: RBAC
+---
+apiVersion: v1alpha1
+kind: KubeControllerManagerConfig
+image: registry.k8s.io/kube-controller-manager:v1.36.2
+extraArgs:
+  bind-address: 0.0.0.0
+---
+apiVersion: v1alpha1
+kind: KubeSchedulerConfig
+image: registry.k8s.io/kube-scheduler:v1.36.2
+extraArgs:
+  bind-address: 0.0.0.0
+config:
+  profiles:
+    - schedulerName: default-scheduler
+      plugins:
+        score:
+          disabled:
+            - name: ImageLocality
+      pluginConfig:
+        - name: PodTopologySpread
+          args:
+            defaultingType: List
+            defaultConstraints:
+              - maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: ScheduleAnyway
+---
+apiVersion: v1alpha1
+kind: KubeProxyConfig
+enabled: false
+image: registry.k8s.io/kube-proxy:v1.36.2
+---
+apiVersion: v1alpha1
+kind: KubeCoreDNSConfig
+enabled: false
+---
+apiVersion: v1alpha1
+kind: KubeEtcdEncryptionConfig
+config:
+  resources:
+    - providers:
+        - secretbox:
+            keys:
+              - name: key2
+                secret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRETBOXENCRYPTIONSECRET
+        - identity: {}
+      resources:
+        - secrets
+{% endif %}

--- a/talos/main/worker/skirk.yaml
+++ b/talos/main/worker/skirk.yaml
@@ -1,19 +1,25 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.12/website/content/v1.12/schemas/config.schema.json
-machine:
-  install:
-    diskSelector:
-      model: "WDS500G3X0C-00SJG0"
-  nodeLabels:
-    topology.kubernetes.io/gpus: amd
-    node-role.kubernetes.io/rocm-worker: "true"
-  kubelet:
-    extraArgs:
-      max-pods: "50"
-    extraConfig:
-      registerWithTaints:
-        - key: llm-workload
-          value: "true"
-          effect: NoSchedule
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.14/website/content/v1.14/schemas/config.schema.json
+apiVersion: v1alpha1
+kind: UnattendedInstallConfig
+provisioning:
+  diskSelector:
+    match: disk.model == "WDS500G3X0C-00SJG0"
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+labels:
+  topology.kubernetes.io/gpus: amd
+  node-role.kubernetes.io/rocm-worker: "true"
+---
+apiVersion: v1alpha1
+kind: KubeletConfig
+extraArgs:
+  max-pods: "50"
+config:
+  registerWithTaints:
+    - key: llm-workload
+      value: "true"
+      effect: NoSchedule
 ---
 # OS disk - 500GB WD Black
 apiVersion: v1alpha1

--- a/talos/test/controlplane/citlali.yaml
+++ b/talos/test/controlplane/citlali.yaml
@@ -1,9 +1,10 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.12/website/content/v1.12/schemas/config.schema.json
-machine:
-  install:
-    diskSelector:
-      model: "Timetec MS07"
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.14/website/content/v1.14/schemas/config.schema.json
+apiVersion: v1alpha1
+kind: UnattendedInstallConfig
+provisioning:
+  diskSelector:
+    match: disk.model == "Timetec MS07"
 ---
 apiVersion: v1alpha1
 kind: HostnameConfig

--- a/talos/test/machineconfig.yaml.j2
+++ b/talos/test/machineconfig.yaml.j2
@@ -40,7 +40,7 @@ machine:
         nconnect=16
         noatime=True
   install:
-    image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.13.9
+    image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.14.0
   kernel:
     modules:
       - name: nbd

--- a/talos/test/machineconfig.yaml.j2
+++ b/talos/test/machineconfig.yaml.j2
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.13/website/content/v1.13/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.14/website/content/v1.14/schemas/config.schema.json
 version: v1alpha1
 machine:
   ca:
@@ -9,86 +9,6 @@ machine:
     {% endif %}
   features:
     diskQuotaSupport: true
-    hostDNS:
-      enabled: true
-      forwardKubeDNSToHost: true
-      resolveMemberNames: true
-    kubePrism:
-      enabled: true
-      port: 7445
-    {% if ENV.MACHINE_TYPE == 'controlplane' %}
-    kubernetesTalosAPIAccess:
-      enabled: true
-      allowedRoles: ["os:admin"]
-      allowedKubernetesNamespaces: ["actions-runner-system", "kube-tools"]
-    {% endif %}
-  files:
-    - op: create
-      path: /etc/cri/conf.d/20-customization.part
-      content: |
-        [plugins."io.containerd.cri.v1.images"]
-          discard_unpacked_layers = false
-        [plugins."io.containerd.cri.v1.runtime"]
-          device_ownership_from_security_context = true
-    - op: overwrite
-      path: /etc/nfsmount.conf
-      permissions: 0o644
-      content: |
-        [ NFSMount_Global_Options ]
-        nfsvers=4.2
-        hard=True
-        nconnect=16
-        noatime=True
-  install:
-    image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.14.0
-  kernel:
-    modules:
-      - name: nbd
-  kubelet:
-    defaultRuntimeSeccompProfileEnabled: true
-    disableManifestsDirectory: true
-    extraArgs:
-      max-pods: "200"
-    extraConfig:
-      serializeImagePulls: false
-      imageMaximumGCAge: 24h
-    image: ghcr.io/siderolabs/kubelet:v1.36.2
-    nodeIP:
-      validSubnets: ["10.69.1.0/24"]
-  nodeLabels:
-    topology.kubernetes.io/region: k8s
-    topology.kubernetes.io/zone: {{ 'm' if ENV.MACHINE_TYPE == 'controlplane' else 'w' }}
-  sysfs:
-    devices.system.cpu.cpufreq.policy0.scaling_governor: powersave
-    devices.system.cpu.cpufreq.policy0.energy_performance_preference: balance_power
-  sysctls:
-    fs.inotify.max_user_watches: "1048576"     # Watchdog
-    fs.inotify.max_user_instances: "8192"      # Watchdog
-    net.core.default_qdisc: fq                 # 10Gb/s
-    net.core.somaxconn: "8192"                # Raise listen backlog for burst handling
-    net.core.netdev_max_backlog: "16384"      # Raise kernel ingress queue depth
-    net.core.rmem_max: "67108864"              # 10Gb/s | Cloudflared / QUIC
-    net.core.wmem_max: "67108864"              # 10Gb/s | Cloudflared / QUIC
-    net.ipv4.neigh.default.gc_thresh1: "4096"  # Prevent ARP cache overflows
-    net.ipv4.neigh.default.gc_thresh2: "8192"  # Prevent ARP cache overflows
-    net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
-    net.ipv4.ping_group_range: 0 2147483647    # Allow Ping
-    net.ipv4.tcp_congestion_control: bbr       # 10Gb/s
-    net.ipv4.tcp_fastopen: "3"                 # Send and accept data in the opening SYN packet
-    net.ipv4.tcp_mtu_probing: "1"              # 10Gb/s | Jumbo frames
-    net.ipv4.tcp_notsent_lowat: "131072"       # Allow Ping
-    net.ipv4.tcp_rmem: 4096 87380 33554432     # 10Gb/s
-    net.ipv4.tcp_wmem: 4096 65536 33554432     # 10Gb/s
-    net.ipv4.tcp_slow_start_after_idle: "0"    # Allow Ping
-    net.ipv4.tcp_window_scaling: "1"           # 10Gb/s
-    net.ipv4.tcp_max_syn_backlog: "8192"       # Larger SYN queue for bursty connection rates
-    sunrpc.tcp_slot_table_entries: "128"       # 10Gb/s | NFS
-    sunrpc.tcp_max_slot_table_entries: "128"   # 10Gb/s | NFS
-    user.max_user_namespaces: "11255"          # User Namespaces
-    vm.dirty_background_ratio: "5"            # Start writeback earlier
-    vm.dirty_ratio: "20"                      # Cap dirty page buildup
-    vm.dirty_expire_centisecs: "3000"         # Expire dirty data after 30s
-    vm.dirty_writeback_centisecs: "500"       # Flush dirty pages every 5s
   token: op://Kubernetes/talos-{{ ENV.CLUSTER }}/MACHINE_TOKEN
   type: {{ ENV.MACHINE_TYPE }}
 cluster:
@@ -100,39 +20,11 @@ cluster:
   clusterName: test
   controlPlane:
     endpoint: https://k8s.test.internal:6443
-  discovery:
-    enabled: true
-    registries:
-      kubernetes:
-        disabled: true
-      service:
-        disabled: false
-  id: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ID
-  network:
-    cni:
-      name: none
-    dnsDomain: cluster.local
-    podSubnets: ["10.42.0.0/16"]
-    serviceSubnets: ["10.43.0.0/16"]
-  secret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRET
   token: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_TOKEN
   {% if ENV.MACHINE_TYPE == 'controlplane' %}
   aggregatorCA:
     crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_AGGREGATORCA_CRT
     key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_AGGREGATORCA_KEY
-  allowSchedulingOnControlPlanes: true
-  apiServer:
-    certSANs: ["k8s.test.internal", "127.0.0.1"]
-    extraArgs:
-      enable-aggregator-routing: true
-      feature-gates: HPAScaleToZero=true
-    image: registry.k8s.io/kube-apiserver:v1.36.2
-  controllerManager:
-    extraArgs:
-      bind-address: 0.0.0.0
-    image: registry.k8s.io/kube-controller-manager:v1.36.2
-  coreDNS:
-    disabled: true
   etcd:
     advertisedSubnets: ["10.69.1.0/24"]
     ca:
@@ -140,35 +32,205 @@ cluster:
       key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ETCD_CA_KEY
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
-  proxy:
-    disabled: true
-    image: registry.k8s.io/kube-proxy:v1.36.2
-  secretboxEncryptionSecret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRETBOXENCRYPTIONSECRET
-  scheduler:
-    config:
-      apiVersion: kubescheduler.config.k8s.io/v1
-      kind: KubeSchedulerConfiguration
-      profiles:
-        - schedulerName: default-scheduler
-          plugins:
-            score:
-              disabled:
-                - name: ImageLocality
-          pluginConfig:
-            - name: PodTopologySpread
-              args:
-                defaultingType: List
-                defaultConstraints:
-                  - maxSkew: 1
-                    topologyKey: kubernetes.io/hostname
-                    whenUnsatisfiable: ScheduleAnyway
-    image: registry.k8s.io/kube-scheduler:v1.36.2
-    extraArgs:
-      bind-address: 0.0.0.0
   serviceAccount:
     key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SERVICEACCOUNT_KEY
   {% endif %}
-
+---
+apiVersion: v1alpha1
+kind: ResolverConfig
+searchDomains:
+  domains: []
+hostDNS:
+  enabled: true
+  forwardKubeDNSToHost: true
+  resolveMemberNames: true
+---
+apiVersion: v1alpha1
+kind: DiscoveryServiceConfig
+name: default
+endpoint: https://discovery.talos.dev/
+---
+apiVersion: v1alpha1
+kind: DiscoveryIdentityConfig
+clusterID: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ID
+clusterSecret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRET
+---
+apiVersion: v1alpha1
+kind: UnattendedInstallConfig
+installer:
+  image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.14.0
+provisioning:
+  wipe: false
+---
+apiVersion: v1alpha1
+kind: FilesystemTrimConfig
+interval: 168h0m0s
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nbd
+---
+apiVersion: v1alpha1
+kind: SysfsConfig
+params:
+  devices.system.cpu.cpufreq.policy0.scaling_governor: powersave
+  devices.system.cpu.cpufreq.policy0.energy_performance_preference: balance_power
+---
+apiVersion: v1alpha1
+kind: SysctlConfig
+params:
+  fs.inotify.max_user_watches: "1048576"     # Watchdog
+  fs.inotify.max_user_instances: "8192"      # Watchdog
+  net.core.default_qdisc: fq                 # 10Gb/s
+  net.core.somaxconn: "8192"                # Raise listen backlog for burst handling
+  net.core.netdev_max_backlog: "16384"      # Raise kernel ingress queue depth
+  net.core.rmem_max: "67108864"              # 10Gb/s | Cloudflared / QUIC
+  net.core.wmem_max: "67108864"              # 10Gb/s | Cloudflared / QUIC
+  net.ipv4.neigh.default.gc_thresh1: "4096"  # Prevent ARP cache overflows
+  net.ipv4.neigh.default.gc_thresh2: "8192"  # Prevent ARP cache overflows
+  net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
+  net.ipv4.ping_group_range: 0 2147483647    # Allow Ping
+  net.ipv4.tcp_congestion_control: bbr       # 10Gb/s
+  net.ipv4.tcp_fastopen: "3"                 # Send and accept data in the opening SYN packet
+  net.ipv4.tcp_mtu_probing: "1"              # 10Gb/s | Jumbo frames
+  net.ipv4.tcp_notsent_lowat: "131072"       # Allow Ping
+  net.ipv4.tcp_rmem: 4096 87380 33554432     # 10Gb/s
+  net.ipv4.tcp_wmem: 4096 65536 33554432     # 10Gb/s
+  net.ipv4.tcp_slow_start_after_idle: "0"    # Allow Ping
+  net.ipv4.tcp_window_scaling: "1"           # 10Gb/s
+  net.ipv4.tcp_max_syn_backlog: "8192"       # Larger SYN queue for bursty connection rates
+  sunrpc.tcp_slot_table_entries: "128"       # 10Gb/s | NFS
+  sunrpc.tcp_max_slot_table_entries: "128"   # 10Gb/s | NFS
+  user.max_user_namespaces: "11255"          # User Namespaces
+  vm.dirty_background_ratio: "5"            # Start writeback earlier
+  vm.dirty_ratio: "20"                      # Cap dirty page buildup
+  vm.dirty_expire_centisecs: "3000"         # Expire dirty data after 30s
+  vm.dirty_writeback_centisecs: "500"       # Flush dirty pages every 5s
+---
+apiVersion: v1alpha1
+kind: EtcFileConfig
+name: nfsmount.conf
+mode: 0o644
+contents: |
+  [ NFSMount_Global_Options ]
+  nfsvers=4.2
+  hard=True
+  nconnect=16
+  noatime=True
+---
+apiVersion: v1alpha1
+kind: CRICustomizationConfig
+name: containerd
+content: |
+  [plugins."io.containerd.cri.v1.images"]
+    discard_unpacked_layers = false
+  [plugins."io.containerd.cri.v1.runtime"]
+    device_ownership_from_security_context = true
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+nodeIP:
+  validSubnets: ["10.69.1.0/24"]
+labels:
+  topology.kubernetes.io/region: k8s
+  topology.kubernetes.io/zone: {{ 'm' if ENV.MACHINE_TYPE == 'controlplane' else 'w' }}
+  {% if ENV.MACHINE_TYPE == 'controlplane' %}
+  node-role.kubernetes.io/control-plane: ""
+  {% endif %}
+---
+apiVersion: v1alpha1
+kind: KubeletConfig
+image: ghcr.io/siderolabs/kubelet:v1.36.2
+defaultRuntimeSeccompProfileEnabled: true
+extraArgs:
+  max-pods: "200"
+config:
+  serializeImagePulls: false
+  imageMaximumGCAge: 24h
+---
+apiVersion: v1alpha1
+kind: KubeNetworkConfig
+dnsDomain: cluster.local
+podSubnets: ["10.42.0.0/16"]
+serviceSubnets: ["10.43.0.0/16"]
+---
+apiVersion: v1alpha1
+kind: KubePrismConfig
+port: 7445
+{% if ENV.MACHINE_TYPE == 'controlplane' %}
+---
+apiVersion: v1alpha1
+kind: KubeTalosAPIAccessConfig
+allowedRoles: ["os:admin"]
+allowedKubernetesNamespaces: ["actions-runner-system", "kube-tools"]
+---
+apiVersion: v1alpha1
+kind: KubeAPIServerConfig
+image: registry.k8s.io/kube-apiserver:v1.36.2
+certExtraSANs: ["k8s.test.internal", "127.0.0.1"]
+extraArgs:
+  enable-aggregator-routing: "true"
+  feature-gates: HPAScaleToZero=true
+---
+apiVersion: v1alpha1
+kind: KubeAuthorizerConfig
+name: node
+type: Node
+---
+apiVersion: v1alpha1
+kind: KubeAuthorizerConfig
+name: rbac
+type: RBAC
+---
+apiVersion: v1alpha1
+kind: KubeControllerManagerConfig
+image: registry.k8s.io/kube-controller-manager:v1.36.2
+extraArgs:
+  bind-address: 0.0.0.0
+---
+apiVersion: v1alpha1
+kind: KubeSchedulerConfig
+image: registry.k8s.io/kube-scheduler:v1.36.2
+extraArgs:
+  bind-address: 0.0.0.0
+config:
+  profiles:
+    - schedulerName: default-scheduler
+      plugins:
+        score:
+          disabled:
+            - name: ImageLocality
+      pluginConfig:
+        - name: PodTopologySpread
+          args:
+            defaultingType: List
+            defaultConstraints:
+              - maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: ScheduleAnyway
+---
+apiVersion: v1alpha1
+kind: KubeProxyConfig
+enabled: false
+image: registry.k8s.io/kube-proxy:v1.36.2
+---
+apiVersion: v1alpha1
+kind: KubeCoreDNSConfig
+enabled: false
+---
+apiVersion: v1alpha1
+kind: KubeEtcdEncryptionConfig
+config:
+  resources:
+    - providers:
+        - secretbox:
+            keys:
+              - name: key2
+                secret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRETBOXENCRYPTIONSECRET
+        - identity: {}
+      resources:
+        - secrets
+{% endif %}
 ---
 apiVersion: v1alpha1
 kind: BondConfig

--- a/talos/utility/controlplane/celestia.yaml
+++ b/talos/utility/controlplane/celestia.yaml
@@ -1,10 +1,15 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.12/website/content/v1.12/schemas/config.schema.json
-machine:
-  install:
-    disk: /dev/sda
-  nodeLabels:
-    topology.kubernetes.io/gpus: amd
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.14/website/content/v1.14/schemas/config.schema.json
+apiVersion: v1alpha1
+kind: UnattendedInstallConfig
+provisioning:
+  diskSelector:
+    match: disk.dev_path == "/dev/sda"
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+labels:
+  topology.kubernetes.io/gpus: amd
 ---
 apiVersion: v1alpha1
 kind: HostnameConfig

--- a/talos/utility/machineconfig.yaml.j2
+++ b/talos/utility/machineconfig.yaml.j2
@@ -40,7 +40,7 @@ machine:
         nconnect=16
         noatime=True
   install:
-    image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.13.9
+    image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.14.0
   kernel:
     modules:
       - name: nbd

--- a/talos/utility/machineconfig.yaml.j2
+++ b/talos/utility/machineconfig.yaml.j2
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.13/website/content/v1.13/schemas/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siderolabs/talos/refs/heads/release-1.14/website/content/v1.14/schemas/config.schema.json
 version: v1alpha1
 machine:
   ca:
@@ -9,93 +9,8 @@ machine:
     {% endif %}
   features:
     diskQuotaSupport: true
-    hostDNS:
-      enabled: true
-      forwardKubeDNSToHost: true
-      resolveMemberNames: true
-    kubePrism:
-      enabled: true
-      port: 7445
-    {% if ENV.MACHINE_TYPE == 'controlplane' %}
-    kubernetesTalosAPIAccess:
-      enabled: true
-      allowedRoles: ["os:admin"]
-      allowedKubernetesNamespaces: ["actions-runner-system", "kube-tools"]
-    {% endif %}
-  files:
-    - op: create
-      path: /etc/cri/conf.d/20-customization.part
-      content: |
-        [plugins."io.containerd.cri.v1.images"]
-          discard_unpacked_layers = false
-        [plugins."io.containerd.cri.v1.runtime"]
-          device_ownership_from_security_context = true
-    - op: overwrite
-      path: /etc/nfsmount.conf
-      permissions: 0o644
-      content: |
-        [ NFSMount_Global_Options ]
-        nfsvers=4.2
-        hard=True
-        nconnect=16
-        noatime=True
-  install:
-    image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.14.0
-  kernel:
-    modules:
-      - name: nbd
-  kubelet:
-    defaultRuntimeSeccompProfileEnabled: true
-    disableManifestsDirectory: true
-    extraArgs:
-      max-pods: "200"
-    extraConfig:
-      serializeImagePulls: false
-      imageMaximumGCAge: 24h
-      allowedUnsafeSysctls:
-        - net.ipv6.conf.net1.accept_ra_rt_info_max_plen
-    image: ghcr.io/siderolabs/kubelet:v1.36.2
-    nodeIP:
-      validSubnets: ["10.69.1.0/24"]
-  nodeLabels:
-    topology.kubernetes.io/region: k8s
-    topology.kubernetes.io/zone: {{ 'm' if ENV.MACHINE_TYPE == 'controlplane' else 'w' }}
-  sysctls:
-    fs.inotify.max_user_watches: "1048576"     # Watchdog
-    fs.inotify.max_user_instances: "8192"      # Watchdog
-    net.core.default_qdisc: fq                 # 10Gb/s
-    net.core.somaxconn: "8192"                # Raise listen backlog for burst handling
-    net.core.netdev_max_backlog: "16384"      # Raise kernel ingress queue depth
-    net.core.rmem_max: "67108864"              # 10Gb/s | Cloudflared / QUIC
-    net.core.wmem_max: "67108864"              # 10Gb/s | Cloudflared / QUIC
-    net.ipv4.neigh.default.gc_thresh1: "4096"  # Prevent ARP cache overflows
-    net.ipv4.neigh.default.gc_thresh2: "8192"  # Prevent ARP cache overflows
-    net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
-    net.ipv4.ping_group_range: 0 2147483647    # Allow Ping
-    net.ipv4.tcp_congestion_control: bbr       # 10Gb/s
-    net.ipv4.tcp_fastopen: "3"                 # Send and accept data in the opening SYN packet
-    net.ipv4.tcp_mtu_probing: "1"              # 10Gb/s | Jumbo frames
-    net.ipv4.tcp_notsent_lowat: "131072"       # Allow Ping
-    net.ipv4.tcp_rmem: 4096 87380 33554432     # 10Gb/s
-    net.ipv4.tcp_wmem: 4096 65536 33554432     # 10Gb/s
-    net.ipv4.tcp_slow_start_after_idle: "0"    # Allow Ping
-    net.ipv4.tcp_window_scaling: "1"           # 10Gb/s
-    net.ipv4.tcp_max_syn_backlog: "8192"       # Larger SYN queue for bursty connection rates
-    sunrpc.tcp_slot_table_entries: "128"       # 10Gb/s | NFS
-    sunrpc.tcp_max_slot_table_entries: "128"   # 10Gb/s | NFS
-    user.max_user_namespaces: "11255"          # User Namespaces
-    vm.dirty_background_ratio: "5"            # Start writeback earlier
-    vm.dirty_ratio: "20"                      # Cap dirty page buildup
-    vm.dirty_expire_centisecs: "3000"         # Expire dirty data after 30s
-    vm.dirty_writeback_centisecs: "500"       # Flush dirty pages every 5s
   token: op://Kubernetes/talos-{{ ENV.CLUSTER }}/MACHINE_TOKEN
   type: {{ ENV.MACHINE_TYPE }}
-  sysfs:
-    devices.system.cpu.cpufreq.policy0.scaling_governor: powersave
-    devices.system.cpu.cpufreq.policy0.energy_performance_preference: balance_power
-  time:
-    disabled: false
-    servers: ["time.cloudflare.com"]
 cluster:
   ca:
     crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_CA_CRT
@@ -105,39 +20,11 @@ cluster:
   clusterName: utility
   controlPlane:
     endpoint: https://k8s.utility.internal:6443
-  discovery:
-    enabled: true
-    registries:
-      kubernetes:
-        disabled: true
-      service:
-        disabled: false
-  id: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ID
-  network:
-    cni:
-      name: none
-    dnsDomain: cluster.local
-    podSubnets: ["10.42.0.0/16"]
-    serviceSubnets: ["10.43.0.0/16"]
-  secret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRET
   token: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_TOKEN
   {% if ENV.MACHINE_TYPE == 'controlplane' %}
   aggregatorCA:
     crt: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_AGGREGATORCA_CRT
     key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_AGGREGATORCA_KEY
-  allowSchedulingOnControlPlanes: true
-  apiServer:
-    certSANs: ["k8s.utility.internal", "127.0.0.1"]
-    extraArgs:
-      enable-aggregator-routing: true
-      feature-gates: HPAScaleToZero=true
-    image: registry.k8s.io/kube-apiserver:v1.36.2
-  controllerManager:
-    extraArgs:
-      bind-address: 0.0.0.0
-    image: registry.k8s.io/kube-controller-manager:v1.36.2
-  coreDNS:
-    disabled: true
   etcd:
     advertisedSubnets: ["10.69.1.0/24"]
     ca:
@@ -145,34 +32,213 @@ cluster:
       key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ETCD_CA_KEY
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
-  proxy:
-    disabled: true
-    image: registry.k8s.io/kube-proxy:v1.36.2
-  secretboxEncryptionSecret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRETBOXENCRYPTIONSECRET
-  scheduler:
-    config:
-      apiVersion: kubescheduler.config.k8s.io/v1
-      kind: KubeSchedulerConfiguration
-      profiles:
-        - schedulerName: default-scheduler
-          plugins:
-            score:
-              disabled:
-                - name: ImageLocality
-          pluginConfig:
-            - name: PodTopologySpread
-              args:
-                defaultingType: List
-                defaultConstraints:
-                  - maxSkew: 1
-                    topologyKey: kubernetes.io/hostname
-                    whenUnsatisfiable: ScheduleAnyway
-    image: registry.k8s.io/kube-scheduler:v1.36.2
-    extraArgs:
-      bind-address: 0.0.0.0
   serviceAccount:
     key: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SERVICEACCOUNT_KEY
   {% endif %}
+---
+apiVersion: v1alpha1
+kind: ResolverConfig
+searchDomains:
+  domains: []
+hostDNS:
+  enabled: true
+  forwardKubeDNSToHost: true
+  resolveMemberNames: true
+---
+apiVersion: v1alpha1
+kind: DiscoveryServiceConfig
+name: default
+endpoint: https://discovery.talos.dev/
+---
+apiVersion: v1alpha1
+kind: DiscoveryIdentityConfig
+clusterID: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_ID
+clusterSecret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRET
+---
+apiVersion: v1alpha1
+kind: TimeSyncConfig
+enabled: true
+ntp:
+  servers: ["time.cloudflare.com"]
+---
+apiVersion: v1alpha1
+kind: UnattendedInstallConfig
+installer:
+  image: factory.talos.dev/metal-installer/{{ ENV.SCHEMATIC }}:v1.14.0
+provisioning:
+  wipe: false
+---
+apiVersion: v1alpha1
+kind: FilesystemTrimConfig
+interval: 168h0m0s
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: nbd
+---
+apiVersion: v1alpha1
+kind: SysfsConfig
+params:
+  devices.system.cpu.cpufreq.policy0.scaling_governor: powersave
+  devices.system.cpu.cpufreq.policy0.energy_performance_preference: balance_power
+---
+apiVersion: v1alpha1
+kind: SysctlConfig
+params:
+  fs.inotify.max_user_watches: "1048576"     # Watchdog
+  fs.inotify.max_user_instances: "8192"      # Watchdog
+  net.core.default_qdisc: fq                 # 10Gb/s
+  net.core.somaxconn: "8192"                # Raise listen backlog for burst handling
+  net.core.netdev_max_backlog: "16384"      # Raise kernel ingress queue depth
+  net.core.rmem_max: "67108864"              # 10Gb/s | Cloudflared / QUIC
+  net.core.wmem_max: "67108864"              # 10Gb/s | Cloudflared / QUIC
+  net.ipv4.neigh.default.gc_thresh1: "4096"  # Prevent ARP cache overflows
+  net.ipv4.neigh.default.gc_thresh2: "8192"  # Prevent ARP cache overflows
+  net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
+  net.ipv4.ping_group_range: 0 2147483647    # Allow Ping
+  net.ipv4.tcp_congestion_control: bbr       # 10Gb/s
+  net.ipv4.tcp_fastopen: "3"                 # Send and accept data in the opening SYN packet
+  net.ipv4.tcp_mtu_probing: "1"              # 10Gb/s | Jumbo frames
+  net.ipv4.tcp_notsent_lowat: "131072"       # Allow Ping
+  net.ipv4.tcp_rmem: 4096 87380 33554432     # 10Gb/s
+  net.ipv4.tcp_wmem: 4096 65536 33554432     # 10Gb/s
+  net.ipv4.tcp_slow_start_after_idle: "0"    # Allow Ping
+  net.ipv4.tcp_window_scaling: "1"           # 10Gb/s
+  net.ipv4.tcp_max_syn_backlog: "8192"       # Larger SYN queue for bursty connection rates
+  sunrpc.tcp_slot_table_entries: "128"       # 10Gb/s | NFS
+  sunrpc.tcp_max_slot_table_entries: "128"   # 10Gb/s | NFS
+  user.max_user_namespaces: "11255"          # User Namespaces
+  vm.dirty_background_ratio: "5"            # Start writeback earlier
+  vm.dirty_ratio: "20"                      # Cap dirty page buildup
+  vm.dirty_expire_centisecs: "3000"         # Expire dirty data after 30s
+  vm.dirty_writeback_centisecs: "500"       # Flush dirty pages every 5s
+---
+apiVersion: v1alpha1
+kind: EtcFileConfig
+name: nfsmount.conf
+mode: 0o644
+contents: |
+  [ NFSMount_Global_Options ]
+  nfsvers=4.2
+  hard=True
+  nconnect=16
+  noatime=True
+---
+apiVersion: v1alpha1
+kind: CRICustomizationConfig
+name: containerd
+content: |
+  [plugins."io.containerd.cri.v1.images"]
+    discard_unpacked_layers = false
+  [plugins."io.containerd.cri.v1.runtime"]
+    device_ownership_from_security_context = true
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+nodeIP:
+  validSubnets: ["10.69.1.0/24"]
+labels:
+  topology.kubernetes.io/region: k8s
+  topology.kubernetes.io/zone: {{ 'm' if ENV.MACHINE_TYPE == 'controlplane' else 'w' }}
+  {% if ENV.MACHINE_TYPE == 'controlplane' %}
+  node-role.kubernetes.io/control-plane: ""
+  {% endif %}
+---
+apiVersion: v1alpha1
+kind: KubeletConfig
+image: ghcr.io/siderolabs/kubelet:v1.36.2
+defaultRuntimeSeccompProfileEnabled: true
+extraArgs:
+  max-pods: "200"
+config:
+  serializeImagePulls: false
+  imageMaximumGCAge: 24h
+  allowedUnsafeSysctls:
+    - net.ipv6.conf.net1.accept_ra_rt_info_max_plen
+---
+apiVersion: v1alpha1
+kind: KubeNetworkConfig
+dnsDomain: cluster.local
+podSubnets: ["10.42.0.0/16"]
+serviceSubnets: ["10.43.0.0/16"]
+---
+apiVersion: v1alpha1
+kind: KubePrismConfig
+port: 7445
+{% if ENV.MACHINE_TYPE == 'controlplane' %}
+---
+apiVersion: v1alpha1
+kind: KubeTalosAPIAccessConfig
+allowedRoles: ["os:admin"]
+allowedKubernetesNamespaces: ["actions-runner-system", "kube-tools"]
+---
+apiVersion: v1alpha1
+kind: KubeAPIServerConfig
+image: registry.k8s.io/kube-apiserver:v1.36.2
+certExtraSANs: ["k8s.utility.internal", "127.0.0.1"]
+extraArgs:
+  enable-aggregator-routing: "true"
+  feature-gates: HPAScaleToZero=true
+---
+apiVersion: v1alpha1
+kind: KubeAuthorizerConfig
+name: node
+type: Node
+---
+apiVersion: v1alpha1
+kind: KubeAuthorizerConfig
+name: rbac
+type: RBAC
+---
+apiVersion: v1alpha1
+kind: KubeControllerManagerConfig
+image: registry.k8s.io/kube-controller-manager:v1.36.2
+extraArgs:
+  bind-address: 0.0.0.0
+---
+apiVersion: v1alpha1
+kind: KubeSchedulerConfig
+image: registry.k8s.io/kube-scheduler:v1.36.2
+extraArgs:
+  bind-address: 0.0.0.0
+config:
+  profiles:
+    - schedulerName: default-scheduler
+      plugins:
+        score:
+          disabled:
+            - name: ImageLocality
+      pluginConfig:
+        - name: PodTopologySpread
+          args:
+            defaultingType: List
+            defaultConstraints:
+              - maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: ScheduleAnyway
+---
+apiVersion: v1alpha1
+kind: KubeProxyConfig
+enabled: false
+image: registry.k8s.io/kube-proxy:v1.36.2
+---
+apiVersion: v1alpha1
+kind: KubeCoreDNSConfig
+enabled: false
+---
+apiVersion: v1alpha1
+kind: KubeEtcdEncryptionConfig
+config:
+  resources:
+    - providers:
+        - secretbox:
+            keys:
+              - name: key2
+                secret: op://Kubernetes/talos-{{ ENV.CLUSTER }}/CLUSTER_SECRETBOXENCRYPTIONSECRET
+        - identity: {}
+      resources:
+        - secrets
+{% endif %}
 ---
 apiVersion: v1alpha1
 kind: BondConfig


### PR DESCRIPTION
Bumps the installer image and the tuppr TalosUpgrade version across main/utility/test, then migrates the machine config to the 1.14 multi-document kinds the way upstream now generates it. Parked, not for merge — tuppr rolls the nodes the moment it lands. The migration is voluntary: every v1alpha1 field in use still works on 1.14 (I validated the pre-migration config under talosctl v1.14.0 and it passes with one warning, for `.machine.files`), so this is about not writing new config into deprecated fields rather than about being forced. Four parts are not mechanical and are worth a look: adding `KubeAPIServerConfig` stops Talos injecting the Node and RBAC authorizers (`InjectDefaultAuthorizers()` is false on the document, true on the v1alpha1 shim), so both are now declared explicitly; `KubeEtcdEncryptionConfig` has to reuse the `key2` key name the legacy field generated or existing encrypted secrets stop decrypting; `allowSchedulingOnControlPlanes` is replaced by omitting the taint from `KubeNodeConfig`, which also means the control-plane label must be listed explicitly; and 1.14 started applying DHCPv4 search domains to the resolver, so `ResolverConfig` pins `searchDomains.domains` to empty. skirk's taint stays in `registerWithTaints` because NodeRestriction won't let a worker set its own taints. Node labels left `machine.nodeLabels`, so the eGPU detection in `.taskfiles/talos` and `upgrade-node`'s installer-image lookup were updated to match. `FilesystemTrimConfig` is included since upgraded clusters don't get it automatically; `SecurityProfileConfig.workloadIsolation` (sandboxd) is deliberately left out. All six node configs, composed as template + type patch + node patch, validate for metal mode under talosctl v1.14.0 with no warnings.