### PR TITLE
refactor(dispatch): resolve bridge lanes by role, not by id

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -39,14 +39,10 @@ spec:
               # Two-tier flow: everything grooms into local; the bridge escalates
               # exhausted issues into frontier (cloud lane retired — no distinct
               # executor backed it, and upfront complexity triage was asking too
-              # much of the 4B groomer).
-              DISPATCH_LANES: local,frontier
-              # Bridge 0.4.0+: instead of tombstoning after RETRY_MAX_ATTEMPTS,
-              # re-lane the issue to frontier + unclaim; the next tick claims it
-              # there and builds the Workload with the coder-frontier Agent
-              # (cloud-proxy -> litellm -> MiniMax-M3). Ignored by older bridges.
-              ESCALATION_LANE: frontier
-              LANE_CODER_AGENTS: '{"*":["coder"],"frontier":["coder-frontier"]}'
+              # much of the 4B groomer). DISPATCH_LANES and ESCALATION_LANE are
+              # unset so the bridge reads both from Dispatch's own lane config
+              # (DISPATCH_LANE_CONFIG_JSON) instead of restating it here.
+              LANE_CODER_AGENTS: '{"*":["coder"],"escalation":["coder-frontier"]}'
               # coder is 1, not 2, deliberately. llama-nvidia runs
               # parallelSlots: 2, and admitting two local coders fills both,
               # so everything else on that backend queues behind runs that


### PR DESCRIPTION
Drops `DISPATCH_LANES` and `ESCALATION_LANE` and rekeys `LANE_CODER_AGENTS` from the lane id `frontier` to the role `escalation`, so the bridge reads the lane topology from Dispatch (`DISPATCH_LANE_CONFIG_JSON`) rather than restating it. Exercises the role resolution shipped in bridge 0.8.0 (misospace/foreman-dispatch-bridge#293), now live in cluster.

No behaviour change. Resolved against the live lane config:

| | before | after |
|---|---|---|
| polled lanes | `local,frontier` | `["local","frontier"]` |
| escalation | `frontier` | `frontier` |
| coder for `local` | `coder` | `coder` |
| coder for `frontier` | `coder-frontier` | `coder-frontier` |

`/api/lanes` is confirmed served by the deployed Dispatch (401 with auth required, vs 404 on a bogus route) and the last tick logged no `lanes:unavailable`. If it ever is down, the bridge falls back to `local,cloud,frontier`; `cloud` aliases to `local`, so that degrades to a duplicate poll, not a miss.

`PR_FIX_LANE_AGENTS` is untouched — those are PR-fix lanes (`NORMAL`/`ESCALATED`), a separate enum from execution lanes.

https://claude.ai/code/session_01YSuDvZq9ncvyX85Uzx3cQh