### PR TITLE
fix(observability): gate kube-state-metrics foreman CRS to main only

### DIFF
--- a/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/helmrelease.yaml
@@ -147,9 +147,11 @@ spec:
             resources: ["agentictasks", "workloads", "fleetnodes"]
             verbs: ["list", "watch"]
       customResourceState:
-        enabled: true
-        # The foreman chart renders this ConfigMap into observability
-        # (foreman.crs.namespace); definitions update on foreman chart bumps.
+        # Only main runs foreman, which renders the foreman-crs ConfigMap into
+        # observability (foreman.crs.namespace); other clusters have no such
+        # ConfigMap, so gating keeps their kube-state-metrics from wedging on a
+        # missing mount. definitions update on foreman chart bumps.
+        enabled: ${KSM_FOREMAN_CRS:=false}
         create: false
         name: foreman-crs
         key: foreman-crs.yaml

--- a/kubernetes/apps/main/observability/kube-prometheus-stack.yaml
+++ b/kubernetes/apps/main/observability/kube-prometheus-stack.yaml
@@ -10,6 +10,7 @@ spec:
   postBuild:
     substitute:
       ALERTMANAGER_SUBDOMAIN: alertmanager
+      KSM_FOREMAN_CRS: "true"
       PVC_CAPACITY: "75"
       SUBDOMAIN: prometheus
   wait: false


### PR DESCRIPTION
The base kube-prometheus-stack hardcodes a kube-state-metrics `customResourceState` that references the `foreman-crs` ConfigMap with `create: false`. That ConfigMap is rendered by the foreman chart, which only runs on main, so on utility (and any other cluster) kube-state-metrics mounts a ConfigMap that never exists and wedges in ContainerCreating — it surfaced when the pod was recreated during tonight's Talos work. This gates `customResourceState.enabled` behind `${KSM_FOREMAN_CRS:=false}` and sets it true only in the main overlay, matching the existing per-cluster substitute pattern; clusters without foreman drop the CRS config and its mount entirely. Verified by rendering the base through kustomize + envsubst: main resolves to `enabled: true`, utility/test default to `enabled: false`.
