### PR TITLE
fix(observability): point alertmanager triage receiver at the real secret

### DIFF
--- a/kubernetes/apps/base/observability/kube-prometheus-stack/alertmanagerconfig.yaml
+++ b/kubernetes/apps/base/observability/kube-prometheus-stack/alertmanagerconfig.yaml
@@ -53,7 +53,7 @@ spec:
           httpConfig:
             authorization:
               credentials:
-                name: alert-triage-secret
+                name: alert-triage
                 key: WEBHOOK_TOKEN
     - name: blackhole
     - name: heartbeat


### PR DESCRIPTION
The triage webhook receiver in the base Alertmanager config referenced credentials from a secret named `alert-triage-secret`, but the `alert-triage` ExternalSecret targets a secret named `alert-triage` (holding the `WEBHOOK_TOKEN` key). No secret ever existed under the `-secret` name, so prometheus-operator failed to provision the Alertmanager configuration on every sync — surfacing as `PrometheusOperatorSyncFailed`. Points the receiver at the `alert-triage` secret that actually exists. Verified the `WEBHOOK_TOKEN` key is present in that secret on main.
