### PR TITLE
fix(observability): correct gatus conditions for opencode/openclaw/mcp-gateway

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -252,9 +252,6 @@ spec:
               - name: "{{ .Release.Name }}"
                 port: &codeserverPort 12321
       imageui:
-        annotations:
-          gatus.home-operations.com/endpoint: |
-            conditions: ["[STATUS] == 302"]
         hostnames: ["generate.jory.dev"]
         parentRefs:
           - name: envoy-external

--- a/kubernetes/apps/base/llm/opencode/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/opencode/helmrelease.yaml
@@ -67,9 +67,6 @@ spec:
             port: *port
     route:
       app:
-        annotations:
-          gatus.home-operations.com/endpoint: |
-            conditions: ["[STATUS] == 302"]
         hostnames: ["opencode.jory.dev"]
         parentRefs:
           - name: envoy-external

--- a/kubernetes/apps/base/llm/opencode/httproute.yaml
+++ b/kubernetes/apps/base/llm/opencode/httproute.yaml
@@ -6,7 +6,7 @@ metadata:
   name: opencode-api
   annotations:
     gatus.home-operations.com/endpoint: |
-      conditions: ["[STATUS] == 401"]
+      conditions: ["len([BODY]) == 0"]
 spec:
   hostnames:
     - opencode-api.jory.dev

--- a/kubernetes/apps/base/llm/toolhive/config/httproute.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/httproute.yaml
@@ -4,6 +4,9 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: mcp-gateway
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      conditions: ["[STATUS] == 401"]
 spec:
   hostnames:
     - mcp.jory.dev


### PR DESCRIPTION
These gatus checks asserted the wrong responses, firing `GatusEndpointDown` and `GatusEndpointExposed` while the services were actually healthy — confirmed against the live gatus endpoint statuses (`/api/v1/endpoints/statuses`), where each check's expected vs actual status was: opencode `302`/**200**, openclaw-imageui `302`/**200**, mcp-gateway `200`/**401**, opencode-api `401`/**0**.

- **opencode**, **openclaw-imageui** return 200, not 302 — drop the endpoint annotation so they fall back to the default 200 check.
- **mcp-gateway** sits behind apikey auth and returns 401, but had no endpoint annotation so it inherited the default 200 check — add a `401` condition.
- **opencode-api** is a guarded internal endpoint; it asserted a `401` status and got no response (status 0), tripping `GatusEndpointExposed`. Switch it to the empty-body check the other guarded endpoints already use (`len([BODY]) == 0`).
