### PR TITLE
fix(memini): stop turn captures graduating into permanent facts

### DIFF
--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -41,6 +41,7 @@ spec:
               MEMINI_RERANK_MODEL: rerank
               MEMINI_RERANK_MAX_CONCURRENCY: 2
               MEMINI_RERANK_TIMEOUT: 45s
+              MEMINI_PROMOTE_MIN_ACCESS: "10"
               MEMINI_RERANK_POOL: "5"
               MEMINI_RERANK_MAX_DOC_CHARS: "1024"
               MEMINI_TIMEOUT_MS: "55000"

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -529,6 +529,8 @@ data:
               fallback_on_error: true,
               timeout_ms: 60000,
               recall_limit: 3,
+              recall_min_score: 0.9,
+              min_capture_chars: 200,
               expose_tools: true,
             },
           },


### PR DESCRIPTION
Miso's namespace holds 2454 memories, 2146 durable, 1271 of them promotion-produced rather than deliberately written — the promoter retiers anything recalled 3 times and recall runs every turn, so a week on one topic makes that topic permanent. Raises `MEMINI_PROMOTE_MIN_ACCESS` to 10, sets `recall_min_score` to 0.9 (the 0.5 default filters nothing on this store — measured: floors of 0 and 0.5 both return all 20 candidates, only 0.95 cuts any), and sets `min_capture_chars` to 200 so throwaway turns never enter the pipeline. Nothing here touches the memories already promoted; that needs a separate prune.