### PR TITLE
fix(rook-ceph): disable csi readAffinity, right-size csi plugins

### DIFF
--- a/kubernetes/apps/base/rook-ceph/ceph-csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/base/rook-ceph/ceph-csi-drivers/helmrelease.yaml
@@ -11,13 +11,70 @@ spec:
   interval: 15m
   dependsOn: []
   values:
+    operatorConfig:
+      driverSpecDefaults:
+        controllerPlugin:
+          resources:
+            attacher:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+            omapGenerator:
+              requests:
+                cpu: 250m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+            plugin:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+            provisioner:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+            resizer:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+            snapshotter:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+        nodePlugin:
+          resources:
+            plugin:
+              requests:
+                cpu: 250m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+            registrar:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
     drivers:
       cephfs:
         enabled: true
         name: rook-ceph.cephfs.csi.ceph.com
+        grpcTimeout: 150
         snapshotPolicy: volumeSnapshot
         kernelMountOptions:
           ms_mode: prefer-crc
+        controllerPlugin:
+          replicas: 2
         nodePlugin:
           tolerations: &pluginTolerations
             - key: llm-workload
@@ -30,6 +87,9 @@ spec:
       rbd:
         enabled: true
         name: rook-ceph.rbd.csi.ceph.com
+        grpcTimeout: 150
         snapshotPolicy: volumeSnapshot
+        controllerPlugin:
+          replicas: 2
         nodePlugin:
           tolerations: *pluginTolerations

--- a/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/base/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -59,7 +59,7 @@ spec:
         disable: false
       csi:
         readAffinity:
-          enabled: true
+          enabled: false # https://github.com/ceph/ceph-csi/issues/5772
       dashboard:
         enabled: true
         urlPrefix: /


### PR DESCRIPTION
Disables CSI `readAffinity`, which is a data-loss path for CephFS on Tentacle (`ceph-csi#5772`) and was live in `ceph-csi-config` on both cluster IDs. Also adds resource requests to the CSI plugins — the v1.20 chart ships `resources: {}`, so every plugin pod was BestEffort, including the nodePlugins that run on skirk — and restores `grpcTimeout: 150` plus two controllerPlugin replicas, both of which the chart migration silently dropped.