### PR TITLE
docs(llm): reconcile strategy doc with the model rename + current state

### DIFF
--- a/.agents/instructions/foreman.instructions.md
+++ b/.agents/instructions/foreman.instructions.md
@@ -12,15 +12,15 @@ dispatch (Next.js)  --groom/claim-->  foreman-dispatch-bridge (Python CronJob)  
 
 - **dispatch** — hosted-LLM groomer labels issues `status/ready` and assigns a
   `currentLane` (`local` | `frontier`). Exposes a per-agent queue the bridge polls.
-- **foreman-dispatch-bridge** — every 30 min claims ready issues for
+- **foreman-dispatch-bridge** — every 15 min claims ready issues for
   `foreman-coder`, builds a Foreman `Workload` per issue, handles escalation,
   revision, and PR-fix. Pure glue; owns no execution.
 - **Foreman** — the LLMKube operator decomposes each `Workload` into
-  `AgenticTask`s (code → review; **gateless** since 2026-07-29 via
-  `VERIFY_ENABLED=false` — no deterministic verify gate Jobs run), schedules
-  them onto `FleetNode`s, and runs the coder/reviewer agents (the
-  deterministic `gate` agent still exists but is idle in gateless mode). It
-  commits, DCO-signs, and opens the PR.
+  `AgenticTask`s (**code → review**, no verify gate: the `gate` agent and the
+  `VERIFY_ENABLED` flag are both gone — verification is the coder's own in-loop
+  self-test plus the repo's real CI on the opened PR), schedules them onto
+  `FleetNode`s, and runs the coder/reviewer agents. It commits, DCO-signs, and
+  opens the PR.
 
 Everything here is GitOps-managed in this repo **except ad-hoc `llmkube foreman
 dispatch` runs**, which are intentionally off-git (see below).
@@ -32,7 +32,7 @@ dispatch` runs**, which are intentionally off-git (see below).
 | Agents, fleet HelmRelease | `kubernetes/apps/base/llm/foreman/` (this repo) |
 | Bridge deploy + all routing env | `kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml` |
 | dispatch app | `kubernetes/apps/base/llm/dispatch/` (this repo); code repo `misospace/dispatch` |
-| Bridge code | `misospace/foreman-dispatch-bridge` (Python, pytest; tag-driven releases `v0.6.x`) |
+| Bridge code | `misospace/foreman-dispatch-bridge` (Python, pytest; release-please tags `v0.9.x`) |
 | Coder toolchain images | `misospace/llmkube-images` |
 | Upstream Foreman + CLI | `defilantech/LLMKube` |
 
@@ -41,115 +41,119 @@ dispatch` runs**, which are intentionally off-git (see below).
 
 ## Agents and images
 
-Two orthogonal axes: **model** (`providerConfig.model` or `inferenceServiceRef`,
-served via litellm) and **toolchain** (InProcess = the fleet pod image; Job =
-per-Agent `execution.image`).
+Two orthogonal axes: **model** (`providerConfig.model`, served via litellm) and
+**execution** (InProcess = runs inside the fleet pod; Job = an ephemeral
+per-task pod on the Agent's `execution.image`). All three coders run **Job**;
+both reviewers run **InProcess**. The per-language coder split
+(`coder-python`/`node`/`go`) and the deterministic `gate` agent are both gone —
+one polyglot `llmkube-coder` image serves every coder.
 
-| Agent | Model | Cost | Execution | Image / toolchain |
+| Agent | Model | Cost | Execution | Toolchain |
 | --- | --- | --- | --- | --- |
-| `coder` | `nvidia` (local) | free | InProcess (fleet) | polyglot `llmkube-coder` (Py+Node); generic/`*` + pr-fix fallback |
-| `coder-python` | `nvidia` (local) | free | **Job** | `ghcr.io/joryirving/llmkube-coder-python` |
-| `coder-node` | `nvidia` (local) | free | **Job** | `ghcr.io/joryirving/llmkube-coder-node` |
-| `coder-go` | `qwen3.8-27b` (local) | free | **Job** | `ghcr.io/defilantech/llmkube-foreman-agent-coder` |
-| `coder-frontier` | `MiniMax-M3-chat` (cloud) | **$ — the only cloud spend** | InProcess (fleet) | polyglot |
-| `coder-revision` | `nvidia` (local) | free | InProcess (fleet) | polyglot (pr-fix / revision) |
-| `gate` | none (deterministic) | free | Job (per-task) | **idle in gateless mode** (`VERIFY_ENABLED=false`); was `GATEPROFILE_MAP.image` per language |
-| `reviewer` | `self-hosted` (local) | free | InProcess (fleet) | — |
+| `coder` | `qwen3.8-27b` (local) | free | **Job** | polyglot `llmkube-coder`; base lane + generic `*` + pr-fix fallback |
+| `coder-frontier` | `MiniMax-M3-chat` (cloud) | **$** | **Job** | polyglot; escalation lane + pr-fix |
+| `coder-revision` | `MiniMax-M3-chat` (cloud) | **$** | **Job** | polyglot; reviewer-requested revisions |
+| `reviewer` | `gemma-4-12b-it-qat` (local) | free | InProcess (fleet) | — |
+| `reviewer-fork` | `gemma-4-12b-it-qat` (local) | free | InProcess (fork fleet) | — |
 
 Every LLM agent (all coders + both reviewers) has `spec.mcp` enabled with the
 hosted context7 server (`resolve-library-id`, `query-docs`) for up-to-date
 library docs mid-task; auth rides the `CONTEXT7_API_KEY` header from the
 `foreman-agent` Secret (1Password `context7` item, `OPENCODE_API_KEY`
-field). `gate`/`gate-fork` have no MCP (deterministic, no LLM loop). Adding
-another MCP server = add a `servers` entry per agent + any header secret.
+field). Adding another MCP server = add a `servers` entry per agent + any
+header secret.
 
-**Cost model.** Everything runs on **local** models (nvidia / self-hosted) except
-`coder-frontier` (**MiniMax, cloud**), which is the escalation tier only. The
-groomer defaults ready work to the `local` lane; `frontier` is reached only by
-bridge escalation or a deliberately-hard grooming decision, so cloud spend is
-bounded to genuinely-hard work. Reviews run on the local `self-hosted` model
-(they used to be cloud `dsv4f`) — reviews are now free regardless of volume.
+**Cost model.** Only the base `coder` (`qwen3.8-27b`, local) is free. Escalation
+(`coder-frontier`), reviewer-requested revisions (`coder-revision`), and the
+**entire pr-fix loop** run on **MiniMax-M3-chat (cloud)** — the only cloud spend.
+The groomer defaults ready work to the `local` lane; `frontier` is reached only
+by bridge escalation or a deliberately-hard grooming decision, so cloud spend is
+bounded to genuinely-hard work plus fixes. Reviews run on the local
+`gemma-4-12b-it-qat` — free regardless of volume, and a deliberate family split
+from the Qwen coder so the reviewer does not inherit the coder's blind spots.
 
-**Coder tuning** (all coder Agents): `maxTurns: 160`,
-`stuckLoopDetection.editFreeTurnsLimit: 100`, and context caps sized to the model
-— nvidia (131k window): soft 100k / hard 120k; `coder-frontier` (MiniMax ~1M):
-soft 500k / hard 800k. These let a coder explore a multi-file change *and*
-implement it before the turn/edit/context budget trips (the old 80-turn / 24-edit
-defaults were force-concluding coders mid-exploration with no diff).
+**Coder tuning.** `coder` (qwen3.8-27b, 80k window): `maxTurns: 160`,
+`editFreeTurnsLimit: 90`, `repeatedToolThreshold: 5`, context soft 85k / hard
+98k, `contextStrategy: session`. `coder-frontier` / `coder-revision`
+(MiniMax ~1M, 480k window): same turn/edit budgets, context soft 500k / hard
+800k. Wall-clock is a backstop, not the limit that bites — the turn/edit/context
+caps bound the loop semantically.
 
-**Fork fleet.** A second deployment `foreman-llmkube-agent` runs `reviewer-fork` +
-`gate-fork` (roles pinned so they only take fork work) for PRs into
-`defilantech/LLMKube` opened from the `joryirving/LLMKube` fork.
+**The fleet.** The `foreman` HelmRelease runs two `native`-mode deployments off
+`ghcr.io/misospace/llmkube-coder`: **`foreman-default-agent`** (`replicaCount: 2`,
+roles worker/coder/verifier) for misospace work, and **`foreman-llmkube-agent`**
+(the fork fleet, below). Reviewers run **InProcess** on these pods; coders run as
+**Job**-mode pods that select a node without reserving it (LLMKube#1496), so
+coder concurrency is capped by the bridge's `CODER_AGENT_SLOTS`, not by replicas
+— one FleetNode was observed carrying two Job coders and a review at once.
 
-**The fleet pods stay polyglot on purpose.** The `foreman-agent` Deployment
-(`replicaCount: 2`, `mode: native`) runs `ghcr.io/joryirving/llmkube-coder`. Those
-pods (a) run the InProcess tiers (`coder`/`coder-frontier`/`coder-revision`/`reviewer`)
-and (b) **orchestrate** the Job-mode agents — when a `coder-python`/`node`/`go`
-task is claimed, a fleet pod spawns an ephemeral Job on that Agent's
-`execution.image`. Minimal per-language images only ever appear as short-lived
-Job pods, never on the fleet. Do not "upgrade" the fleet pods to a per-language
-image.
+**Fork fleet.** `foreman-llmkube-agent` (`replicaCount: 1`) is role-pinned to
+`coder-fork` / `verifier-fork` / `reviewer-fork` so the whole pipeline for a PR
+into `defilantech/LLMKube` runs there, clones+pushes the `joryirving/LLMKube`
+fork, and opens a cross-repo PR upstream. It commits as Jory
+(`jory@jory.dev`); the default fleet commits as Saffron. misospace work
+(roles worker/coder/verifier) never lands here.
 
-Agent version alignment: image `VERSION` is Renovate-tracked to
-`defilantech/LLMKube` releases; the fleet chart image tag rides the chart
-AppVersion. Keep coder images and the deployed operator on the same LLMKube
-release.
+Agent version alignment: coder images are Renovate-tracked to `defilantech/LLMKube`
+releases; the fleet chart image tag rides the chart AppVersion. Keep coder images
+and the deployed operator on the same LLMKube release (both `0.9.25` as of this
+snapshot).
 
 ## Routing (all in the bridge HelmRelease `env`)
 
 - `DISPATCH_AGENT_NAME: foreman-coder` — the dispatch-side identity the bridge
   claims as (dash, not slash — a `/` breaks the queue URL).
-- `DISPATCH_LANES: local,frontier` · `ESCALATION_LANE: frontier` — base work
-  grooms into `local`; exhausted issues get re-laned to `frontier`.
-- `MAX_IN_PROGRESS: "10"` — cap on concurrent non-terminal Workloads.
-- `VERIFY_ENABLED: "false"` — **gateless mode** (bridge 0.6.10+, #58; operator
-  ≥0.9.9 via LLMKube#1166). Workloads decompose `code → review` with no verify
-  gate Job. Verification = the coder's own in-loop test run + the repo's real
-  CI on the opened PR + the pr-fix loop. This ended the gate-failure class
-  outright (imageless-generic GATE-ERRORs, the 63-char gate-Job-name
-  truncation bug on long repo names).
-- `LANE_CODER_AGENTS: {"*":"coder","frontier":"coder-frontier"}` — explicit
-  per-lane coder; **wins outright** and is language-agnostic (keeps escalation on
-  polyglot `coder-frontier`).
-- `BASE_CODER_AGENTS: {"python":"coder-python","node":"coder-node","go":"coder-go","*":"coder"}`
-  — base-lane routing by the repo's language. Resolution order in
-  `coder_agent_for`: explicit lane match → base map by language → base map `*` →
-  lane wildcard → default `coder`. Empty map = legacy behavior.
-- `GATEPROFILE_MAP` — repo → `{language, commands{...}, sourceExtensions, image}`.
-  With gateless mode no verify gate Job ever runs, but the map still matters:
-  - `language` drives BASE_CODER_AGENTS routing.
-  - `commands` feed the **coder self-gate** (the coder runs them in-loop before
-    concluding); keep them mirroring the repo's CI.
-  - `sourceExtensions` (e.g. `[".gd"]` for windowstead) tells the reviewer's
-    scope-overlap check which files count as the repo's source (LLMKube #1120).
-  - `image` is **dead config in gateless mode** (it only ever ran the gate Job);
-    the `*` pass-through wildcard entry is likewise inert legacy from the
-    pre-gateless interim. Both can be slimmed at leisure.
-  Onboarding a repo = add `{language, commands, sourceExtensions}` here.
-- `REVISION_CODER_AGENTS: {"*":"coder-revision"}` — reviewer-requested revisions.
-- `PRUNE_COMPLETED_AFTER_HOURS: "6"`, `PRUNE_FAILED_AFTER_HOURS: "48"` (defaults;
-  unset = these values) — terminal-Workload GC (bridge 0.6.7+). Each tick, after
-  reconcile, the bridge deletes Completed Workloads older than 6h (the PR already
-  lives on GitHub) and Failed ones older than 48h (longer for triage). `0` disables
-  a phase. Covers issue + pr-fix Workloads. This is why terminal Workloads no
-  longer need manual `kubectl delete`.
-- `PR_FIX_ENABLED: "true"`, `PR_FIX_MAX_ATTEMPTS: "3"`,
-  `PR_FIX_LANE_AGENTS: {"NORMAL":"coder","ESCALATED":"coder-frontier"}` — PR-fix
-  loop: when an open PR fails CI or gets `CHANGES_REQUESTED`, it re-pushes a fix.
-  dispatch (0.5.26+) routes an AI-reviewer (Saffron) `CHANGES_REQUESTED` into this
-  loop by parsing its structured `ai-pr-reviewer` findings, instead of dead-ending
-  at `needs-human`; a prose-only review with no parseable findings still escalates
-  to a human.
-  **Escalation ladder (bridge 0.6.6+):** a fix exhausts `max_attempts` on the
-  base coder (`NORMAL`) → auto-escalates to `ESCALATED` (`coder-frontier`) with a
-  fresh budget → only marks `NEEDS_HUMAN` when *every* coder tier is exhausted. A
-  human is the last resort, not the first, for a fix a coder couldn't do.
+- **Lanes are discovered, not hardcoded.** `DISPATCH_LANES` / `ESCALATION_LANE`
+  are gone: the bridge reads the lane set from dispatch's `GET /api/lanes` and
+  resolves the escalation lane by **role**. Base work grooms into the
+  `default`-role lane (`local`); exhausted issues re-lane to the
+  `escalation`-role lane (`frontier`). Explicit config still wins if set; unset =
+  discovered.
+- `LANE_CODER_AGENTS: {"*":["coder"],"escalation":["coder-frontier"]}` —
+  **role-keyed** (not lane-id-keyed) coder routing; the value is a list.
+  Precedence in `lanes.lookup`: exact lane id → lane's role → `*` wildcard. Keeps
+  escalation on cloud `coder-frontier` however the lane is named.
+- `CODER_AGENT_SLOTS: {"coder":1,"coder-frontier":4}` — per-coder concurrency
+  cap. Job-mode coders are not capped by fleet replicas, so this is the real
+  limit: a lane's work goes to the coder with the most idle slots, and when every
+  candidate is full the lane does not claim that tick. Empty = legacy
+  issue-number hash split.
+- `MAX_IN_PROGRESS: "14"` — cap on concurrent non-terminal Workloads. Each lane
+  drains up to the remaining headroom, so a backlog fills capacity in one tick.
+- `VERDICT_SELF_GO: "code-fix,docs,packaging,config,ci-policy"` — work classes
+  stamped onto every Workload's `spec.verdictPolicy.selfGO`, letting the coder
+  self-GO (skip the separate review stage) for those change classes. Widen only
+  for fleets whose PRs run the changed workflow, get an AI review, and are merged
+  by hand; empty leaves Foreman's default policy untouched.
+- `GATEPROFILE_MAP` — repo → `{testLayout, sourceExtensions}`. Gates never run,
+  so the old `language` / `commands` / `image` keys are gone; what survives:
+  - `testLayout` (`{testRoot, sourceRoot}`) tells the coder self-gate where the
+    repo's tests and source live.
+  - `sourceExtensions` (e.g. `[".gd"]` for windowstead, `[".ex",".exs",".heex"]`
+    for pinchflat) tells the reviewer's scope-overlap check which files count as
+    the repo's source (LLMKube#1120). The `*` entry carries the Go/HCL default.
+  Onboarding a repo = add `{testLayout, sourceExtensions}` here.
+- `REVISION_CODER_AGENTS: {"*":"coder-revision"}` — reviewer-requested revisions
+  (cloud MiniMax).
+- `PR_FIX_ENABLED: "true"`, `PR_FIX_MAX_ATTEMPTS: "4"`,
+  `PR_FIX_LANE_AGENTS: {"NORMAL":"coder-frontier","ESCALATED":"coder-frontier"}` —
+  PR-fix loop: when an open PR fails CI or gets `CHANGES_REQUESTED`, it re-pushes
+  a fix (both tiers on cloud `coder-frontier`). dispatch routes an AI-reviewer
+  (Saffron) `CHANGES_REQUESTED` into this loop by parsing its structured
+  `ai-pr-reviewer` findings instead of dead-ending at `needs-human`; a prose-only
+  review with no parseable findings still escalates to a human.
+  **Escalation ladder:** a fix exhausts `max_attempts` on `NORMAL` →
+  auto-escalates to `ESCALATED` with a fresh budget → only marks `NEEDS_HUMAN`
+  when every coder tier is exhausted. A human is the last resort.
 
-To onboard a new language coder: build a minimal image in `containers`
-(`apps/llmkube-coder/` is the pattern — one runtime + git + that language's
-linters), add a Job-mode Agent here, and map the language in `BASE_CODER_AGENTS`.
-Requires a bridge release (`v0.6.x`) only if you change routing *code*; config
-changes are HelmRelease-only.
+Terminal-Workload GC is on by default (`PRUNE_COMPLETED_AFTER_HOURS`,
+`PRUNE_FAILED_AFTER_HOURS` unset = 6h / 48h): each tick after reconcile the
+bridge deletes Completed Workloads older than 6h (the PR already lives on GitHub)
+and Failed ones older than 48h, so terminal Workloads no longer need manual
+`kubectl delete`.
+
+Onboarding a repo is config-only (`GATEPROFILE_MAP` + labels); a bridge release
+(`v0.9.x`) is needed only when you change routing *code*.
 
 ## Ad-hoc dispatch (off-git, bypasses dispatch + bridge)
 
@@ -161,16 +165,16 @@ only the Agent definitions are GitOps config.
 ```bash
 export GITHUB_TOKEN=<token>            # reads issue title/body from GitHub
 
-# Dogfood LLMKube issue 892 on the Go coder — dry-run first to preview the task:
-llmkube foreman dispatch --repo defilantech/LLMKube --agents coder-go -n llm --dry-run 892
+# Dogfood LLMKube issue 892 on the coder — dry-run first to preview the task:
+llmkube foreman dispatch --repo defilantech/LLMKube --agents coder -n llm --dry-run 892
 # then run it for real:
-llmkube foreman dispatch --repo defilantech/LLMKube --agents coder-go -n llm 892
+llmkube foreman dispatch --repo defilantech/LLMKube --agents coder -n llm 892
 
 # Fan several issues across coders (round-robins the --agents list):
-llmkube foreman dispatch --repo defilantech/LLMKube --agents coder-go -n llm 892 901 905
+llmkube foreman dispatch --repo defilantech/LLMKube --agents coder,coder-frontier -n llm 892 901 905
 
-# Force a misospace issue onto a specific coder, custom base branch, no wait:
-llmkube foreman dispatch --repo misospace/KubeTix --agents coder-python -n llm \
+# Force a misospace issue onto the cloud coder, custom base branch, no wait:
+llmkube foreman dispatch --repo misospace/KubeTix --agents coder-frontier -n llm \
   --base-branch main --no-wait 153
 ```
 
@@ -186,7 +190,7 @@ self-reviewed run go through dispatch/bridge instead.
 
 ```bash
 # Fleet + agents + operator health
-kubectl -n llm get pods | grep -E 'foreman|agent' | grep -v gate
+kubectl -n llm get pods | grep -E 'foreman|agent'
 kubectl -n llm get agents
 kubectl -n llm get fleetnodes
 
@@ -194,7 +198,7 @@ kubectl -n llm get fleetnodes
 kubectl -n llm get workloads -o custom-columns=\
 'NAME:.metadata.name,CODER:.spec.coderAgentRef.name,PHASE:.status.phase'
 
-# Bridge: it's a CronJob (schedule "30 */1 * * *"), not a Deployment
+# Bridge: it's a CronJob (schedule "*/15 * * * *"), not a Deployment
 kubectl -n llm get cronjob foreman-dispatch-bridge \
   -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].image}{"\n"}'
 # Force a bridge tick now (same as the :30 run); inspect its log:
@@ -222,54 +226,62 @@ The correct re-run flow:
 2. Delete the Workload CR. The bridge rebuilds it with **current** routing/
    config (a re-rendered old Workload would reuse its baked `coderAgentRef`).
 
-Bridge `#68` (merged, ships in the next tag > 0.6.10) automates the recovery:
-a per-tick reconcile resets issues that are in-progress with no live Workload
-and no open PR, and the Failed-workload GC unclaims at prune time — so manual
-strands self-heal within a tick once that release is deployed.
+Most of this now self-heals: a per-tick reconcile resets issues that are
+in-progress with no live Workload and no open PR, and the Failed-workload GC
+unclaims at prune time, so manual strands recover within a tick. And when a coder
+judges an issue **already resolved** on the base branch (`NO-GO` +
+`extra.modelExtra.outcome: ALREADY-RESOLVED`), the bridge now closes the GitHub
+issue with the coder's evidence instead of stranding it — no hand-reconcile
+needed. A NO-GO is still a *model claim*, so the close comment carries the
+evidence for a human to reopen if it was wrong.
 
-Dispatch MCP tools for this surgery (dispatch 0.5.27+): `unclaim_issue`,
+Dispatch MCP tools for manual surgery when you do need it: `unclaim_issue`,
 `get_queue`, `list_issues`, `list_pr_fixes`, `mark_pr_fix`, `run_groomer`
-(groom now instead of waiting out the 10-min cron).
+(groom now instead of waiting out the cron).
 
 ### Apply an Agent prompt/config change
 
-InProcess agents (`reviewer`, `coder*`, and the fork `reviewer-fork`/`gate-fork`)
-load their Agent CR `spec.systemPrompt` **at pod startup and cache it**. Editing
-the Agent CR — even committed, Flux-reconciled, and confirmed live via
+The **InProcess** agents — `reviewer` and the fork `reviewer-fork` — load their
+Agent CR `spec.systemPrompt` **at pod startup and cache it**. Editing the Agent
+CR — even committed, Flux-reconciled, and confirmed live via
 `kubectl -n llm get agent <name> -o jsonpath='{.spec.systemPrompt}'` — does
-**not** touch the running pods. You must restart the fleet:
+**not** touch the running fleet pods. You must restart the fleet:
 
 ```bash
-kubectl -n llm rollout restart deployment/foreman-agent deployment/foreman-llmkube-agent
-kubectl -n llm rollout status deployment/foreman-agent
+kubectl -n llm rollout restart deployment/foreman-default-agent deployment/foreman-llmkube-agent
+kubectl -n llm rollout status deployment/foreman-default-agent
 ```
 
-- Symptom when forgotten: PRs opened *hours after* a prompt change still show the
-  old behavior. Diagnose by comparing the PR `createdAt` to the fix commit time
-  and the agent pod age (`kubectl -n llm get pods | grep foreman-agent`) — a pod
+- Symptom when forgotten: reviews *hours after* a reviewer-prompt change still
+  show the old behavior. Diagnose by comparing the review time to the fix commit
+  and the agent pod age (`kubectl -n llm get pods | grep foreman.*agent`) — a pod
   older than the fix has the stale prompt.
-- Coders run as Job-mode pods (separate), so the restart doesn't kill in-flight
-  coder Jobs. Time it while Workloads are pre-review to avoid interrupting
-  InProcess review/gate tasks (they requeue, but it wastes a run).
+- **Coders do not need this.** They run as Job-mode pods that load the Agent CR
+  fresh at task start, so a coder `systemPrompt` / `model` / `maxTurns` /
+  `stuckLoopDetection` change takes effect on the **next** coder task with no
+  restart. The restart only re-reads the InProcess reviewers, and it doesn't kill
+  in-flight coder Jobs — time it while Workloads are pre-review so you don't
+  interrupt a running review (it requeues, but wastes a run).
 
 ## Gotchas
 
-- **Agent CR changes need a fleet restart** — see "Apply an Agent prompt/config
-  change" above. Editing `systemPrompt` / `providerConfig.model` / `maxTurns` /
-  `stuckLoopDetection` silently no-ops on the running pods until a
-  `rollout restart`. This is the #1 way a change appears applied but isn't.
+- **Reviewer CR changes need a fleet restart** — see "Apply an Agent prompt/config
+  change" above. Editing an InProcess reviewer's `systemPrompt` /
+  `providerConfig.model` silently no-ops on the running pods until a
+  `rollout restart`. (Job-mode coders reload per task and do *not* need this.)
+  This is the #1 way a reviewer change appears applied but isn't.
 - **Reviewer prompt must keep "Step 1: navigate to the branch."** Foreman does
   NOT check out the PR branch for the reviewer or inject a diff — it hands over
   the branch name and relies on the reviewer system prompt to
   `git fetch origin <branch> && git checkout origin/<branch>` first. Drop that
   step (easy to do when trimming the prompt) and every review diffs `main` →
   phantom diffs → false NO-GOs. `reviewer.yaml` / `reviewer-fork.yaml` carry it.
-- **InProcess throughput ceiling.** All reviews + frontier coding + prfix
-  revisions run InProcess on the 2 `foreman-agent` replicas, so a grooming flood
-  queues tasks (`Pending`) behind that cap and workloads sit in `Dispatched` until
-  a replica frees. It self-drains and reviews are local/free, so it's latency not
-  cost. Levers if it matters: raise replicas (more local concurrency) or lower
-  `MAX_IN_PROGRESS`.
+- **Review throughput ceiling.** Reviews run InProcess on the 2
+  `foreman-default-agent` replicas (and the reviewer backend runs `--parallel 2`),
+  so a flood of review-ready Workloads queues behind that cap. It self-drains and
+  reviews are local/free, so it's latency not cost. Coders are unaffected — they
+  are Job-mode and capped separately by `CODER_AGENT_SLOTS`. Levers if review
+  latency matters: raise `foreman-default-agent` replicas or lower `MAX_IN_PROGRESS`.
 - **Long runs can hit the wall-clock budget.** With `maxTurns: 160`, a genuinely
   large change can exhaust the loop's wall-clock timeout before finishing
   (`loop wall-clock budget exhausted`) — surfaces as a Failed Workload the
@@ -281,37 +293,25 @@ kubectl -n llm rollout status deployment/foreman-agent
 
 ## Open items
 
-- **NO-GO "already-resolved" surfacing (not yet automated).** When a coder judges
-  an issue already fixed, its `*-code-*` task returns `result.verdict: NO-GO` /
-  `result.extra.outcome: MODEL-DECIDED` with a summary and no diff; verify/review
-  cascade to `INCOMPLETE` and the Workload rolls up `Failed`. These are currently
-  reconciled **by hand**: read the code task's summary, confirm the claim against
-  the actual code, then `status/done` + close the issue — or re-dispatch if the
-  claim is wrong. A NO-GO is a *model claim*, not a guarantee (a coder once matched
-  unrelated code and falsely claimed "fixed"), so confirm before closing.
-  Auto-handling (surface-first, opt-in auto-close) is not built.
-- **Agent-config hot-reload (upstream nice-to-have).** The "Agent CR changes need
-  a fleet restart" gotcha is a papercut worth an upstream request (agent should
-  watch/reload its CR, or foreman should signal a restart is required).
-- **Cut bridge v0.6.11.** Merged-but-unreleased on the bridge: #68 (stranded-
-  issue reconcile + GC-time unclaim), #70 (HTTP retry/backoff to dispatch),
-  #69, #71. Tag `v0.6.11` → CI publishes → bump the digest here.
-- **Coder images lag the operator.** Operator `0.9.13` vs coder images `0.9.6`
-  (`misospace/llmkube-images` hasn't cut a 0.9.13 build). Violates the
-  "coders match the operator release" rule above — resolve when llmkube-images
-  ships the bump.
-- **dispatch hygiene (filed, unfixed).** dispatch#691 (pr-followup sync
-  silently degrades under GitHub rate limiting — "complete" with most repo
-  fetches swallowed) and dispatch#692 (queue items never reaped when their PR
-  merges — stale BLOCKED entries linger).
+- **Agent-config hot-reload (upstream nice-to-have).** The "Reviewer CR changes
+  need a fleet restart" gotcha is a papercut worth an upstream request (the
+  InProcess reviewer should watch/reload its CR, or foreman should signal a
+  restart is required). Coders already reload per Job.
+- **FleetNode orphaning (upstream LLMKube#1778).** FleetNode CRs carry no
+  `ownerReferences`, so a pod replacement (node reboot, rollout, eviction)
+  strands the old CR — its heartbeat freezes and `ForemanFleetNodeHeartbeatStale`
+  fires forever. Restarting does not clear it; `kubectl delete fleetnode <orphan>`
+  does. Check with: for each FleetNode, `kubectl -n llm get pod <name>` — a
+  NotFound is an orphan. The stale-alert annotation is also wrong (`$labels.node`
+  vs the metric's `name`): LLMKube#1779.
 
 ## Change conventions
 
 - **Config** (Agents, HelmRelease env, `GATEPROFILE_MAP`): edit YAML in this repo,
   PR → Flux reconciles. **Remember the fleet restart** for Agent CR changes.
-- **Bridge code** (`misospace/foreman-dispatch-bridge`, Python/pytest): PR → tag
-  `v0.6.x` (patch-bump) → CI publishes the image → bump the tag+digest in the
-  bridge HelmRelease here.
+- **Bridge code** (`misospace/foreman-dispatch-bridge`, Python/pytest): PR →
+  release-please cuts `v0.9.x` → CI publishes the image → Renovate bumps the
+  tag+digest in the bridge HelmRelease here.
 - **dispatch** (`misospace/dispatch`, Next.js) is **chart-managed**: the
   `manual-release` workflow opens a version-bump release PR (auto-merge) →
   `publish-release` tags + publishes an OCI chart
@@ -326,10 +326,12 @@ kubectl -n llm rollout status deployment/foreman-agent
 - Ad-hoc runs (`llmkube foreman dispatch`, or the `task foreman:dispatch` /
   `foreman:revise` helpers in `.taskfiles/foreman/`) are never committed.
 
-## Current versions (snapshot, 2026-07-30)
+## Current versions (snapshot, 2026-09-08)
 
-Bridge `0.6.10` (v0.6.11 pending — see open items) · dispatch chart `0.5.28` ·
-Foreman operator `0.9.13` / coder images `0.9.6` (lagging — see open items).
-Gateless (`VERIFY_ENABLED=false`) since 2026-07-29. nvidia local base coders,
-MiniMax `coder-frontier`, self-hosted `reviewer`. Update this line when you cut
-a release so the next operator has a baseline.
+Bridge `0.9.0` · dispatch chart `0.5.57` · Foreman operator `0.9.25` / coder
+images `0.9.25` (aligned). No verify gate (gateless is permanent — `gate` agent
+and `VERIFY_ENABLED` both removed). Local base coder `qwen3.8-27b`; cloud
+`MiniMax-M3-chat` for `coder-frontier` / `coder-revision` / pr-fix; local reviewer
+`gemma-4-12b-it-qat`. Lanes discovered from dispatch, coders route by role +
+`CODER_AGENT_SLOTS`. Update this line when you cut a release so the next operator
+has a baseline.

--- a/.agents/instructions/foreman.instructions.md
+++ b/.agents/instructions/foreman.instructions.md
@@ -50,7 +50,7 @@ per-Agent `execution.image`).
 | `coder` | `nvidia` (local) | free | InProcess (fleet) | polyglot `llmkube-coder` (Py+Node); generic/`*` + pr-fix fallback |
 | `coder-python` | `nvidia` (local) | free | **Job** | `ghcr.io/joryirving/llmkube-coder-python` |
 | `coder-node` | `nvidia` (local) | free | **Job** | `ghcr.io/joryirving/llmkube-coder-node` |
-| `coder-go` | `llama-nvidia` (local) | free | **Job** | `ghcr.io/defilantech/llmkube-foreman-agent-coder` |
+| `coder-go` | `qwen3.8-27b` (local) | free | **Job** | `ghcr.io/defilantech/llmkube-foreman-agent-coder` |
 | `coder-frontier` | `MiniMax-M3-chat` (cloud) | **$ — the only cloud spend** | InProcess (fleet) | polyglot |
 | `coder-revision` | `nvidia` (local) | free | InProcess (fleet) | polyglot (pr-fix / revision) |
 | `gate` | none (deterministic) | free | Job (per-task) | **idle in gateless mode** (`VERIFY_ENABLED=false`); was `GATEPROFILE_MAP.image` per language |

--- a/docs/src/notes/coding-loop.md
+++ b/docs/src/notes/coding-loop.md
@@ -20,7 +20,7 @@ Workload (this bridge) ──► AgenticTasks (foreman-operator)
     │
     ├─ code    coder Agent (Job, polyglot image) — clone, fix, SELF-GATE, push branch
     │          issues split deterministically: coder (nvidia) / coder-strix (self-hosted)
-    └─ review  reviewer Agent (Nemotron 3.5 Lightning, read-only) — diff review, verdict
+    └─ review  reviewer Agent (Gemma 4 12B-it QAT, read-only) — diff review, verdict
     │
     ▼ review GO
 foreman opens the PR (summary grounded against the diff)
@@ -52,7 +52,7 @@ survives retries (bridge 0.6.20; losing it once collided every third attempt ont
 **4. Execute.** The operator decomposes into `code → review` (verify Jobs are off:
 `VERIFY_ENABLED=false`, repo CI is the verifier). The coder runs as its own Job on the
 polyglot image, runs the `gateProfile` commands as a **self-gate** before submitting, and
-pushes `foreman/<workload>/issue-<n>`. The reviewer (Nemotron 3.5 Lightning via `llama-reviewer`)
+pushes `foreman/<workload>/issue-<n>`. The reviewer (Gemma 4 12B-it QAT via `gemma-4-12b-it-qat`)
 reads the diff and issues a verdict; deterministic rails ground its claims (filesTouched,
 issueAsk, findings, and — since 0.9.15 — the PR-body summary against the diff).
 

--- a/docs/src/notes/coding-loop.md
+++ b/docs/src/notes/coding-loop.md
@@ -13,14 +13,14 @@ under `kubernetes/apps/base/llm/foreman/agents/`.
 GitHub issue
     │  dispatch scheduled sync (15m)
     ▼
-Dispatch cache ──► Groomer (self-hosted 35B, json_schema-constrained) ──► lane: local / backlog
+Dispatch cache ──► Groomer (qwen3.8-flash-next, json_schema-constrained) ──► lane: local / backlog
     │  bridge CronJob (*/15)
     ▼
 Workload (this bridge) ──► AgenticTasks (foreman-operator)
     │
     ├─ code    coder Agent (Job, polyglot image) — clone, fix, SELF-GATE, push branch
-    │          issues split deterministically: coder (nvidia) / coder-strix (self-hosted)
-    └─ review  reviewer Agent (Gemma 4 12B-it QAT, read-only) — diff review, verdict
+    │          base lane: coder (qwen3.8-27b, local); escalation: coder-frontier (MiniMax, cloud)
+    └─ review  reviewer Agent (gemma-4-12b-it-qat, read-only) — diff review, verdict
     │
     ▼ review GO
 foreman opens the PR (summary grounded against the diff)
@@ -35,12 +35,12 @@ foreman opens the PR (summary grounded against the diff)
 **1. Sync.** Dispatch's in-app scheduler syncs tracked repos every 15m. Closed issues are
 forced to `status/done` on GitHub itself; `renovate`-labeled issues are excluded.
 
-**2. Groom.** The hosted groomer runs on `self-hosted` (the strix/mac litellm pool). It
-sends a `json_schema` response_format — grammar-constrained decoding, with
-`validateGroomerOutput` as the net. Grooming is binary: ready → `local`, not → `backlog`.
-It never routes to `frontier`; tiering is decided by *failure*, not prediction. Both pool
-members must honour `response_format` — a member that strips it returns prose and the
-groomer fails validation (that was `additional_drop_params` on the mac, removed in #8898).
+**2. Groom.** The hosted groomer runs on `qwen3.8-flash-next` (Flash-Next 180B on the
+Strix box, 262k window). It sends a `json_schema` response_format — grammar-constrained
+decoding, with `validateGroomerOutput` as the net. Grooming is binary: ready → `local`,
+not → `backlog`. It never routes to `frontier`; tiering is decided by *failure*, not
+prediction. The backend must honour `response_format` — one that strips it returns prose
+and the groomer fails validation.
 
 **3. Claim → Workload.** This CronJob (`*/15`) retries failed Workloads first, then claims
 one `status/ready` issue per lane. The Workload carries the coder Agent (picked from the

--- a/docs/src/notes/llm-strategy.md
+++ b/docs/src/notes/llm-strategy.md
@@ -7,8 +7,16 @@ Everything funnels through **LiteLLM** (`kubernetes/apps/base/llm/litellm/litell
 aliases; LiteLLM forwards to the upstream a given subscription or local server expects. This doc is the
 reference for keeping those aliases meaningful and for designing intent-based routing on top of them.
 
-**Last reconciled against the cluster: 2026-08-25.** That pass retired Opencode Go and Moonshot,
-removed `glm-5.2`, renamed `llama-strix-nemotron` to `llama-reviewer`, moved the local models to
+**Local models partially reconciled 2026-09-08.** That pass renamed the local aliases to
+model-specific names (`llama-nvidia`→`qwen3.8-27b`, `llama-strix`→`qwen3.8-flash-next`,
+`llama-reviewer`→`gemma-4-12b-it-qat`, plus `-chat` twins), swapped the Strix box from
+Qwen3.6-35B-A3B to Qwen3.8-Flash-Next, moved the reviewer lane to Gemma 4 12B-it QAT on the 9070XT
+(LM Studio `gemma-wake`), removed the short-lived `llama-vision`, and swapped the reranker to jina on
+CPU. The **Model inventory** and current-routing sections below reflect this; the **capability
+ranking** and **v2 bench** sections still measure the pre-swap models (see the note there).
+
+The prior pass (2026-08-25) retired Opencode Go and Moonshot, removed `glm-5.2`, renamed
+`llama-strix-nemotron` to `llama-reviewer` (now `gemma-4-12b-it-qat`), moved the local models to
 unsloth builds, and added a non-thinking `-chat` door beside each one.
 
 This is a strategy snapshot, not a live quota ledger. Provider pricing, rolling allowances, and
@@ -60,21 +68,25 @@ weights, KV cache and slots, so the second door costs no memory.
 
 ### Local (self-hosted, $0 marginal)
 
-| Alias                   | Backend              | Model                                          | Ctx (in) | Role                                  |
-| ----------------------- | -------------------- | ---------------------------------------------- | -------- | ------------------------------------- |
-| `llama-strix`           | Strix ROCm (2 slots) | Qwen3.6-35B-A3B unsloth UD-Q4_K_XL, native MTP | 262k     | General local brain; vision + tools   |
-| `llama-strix-chat`      | same server          | —                                              | 262k     | Non-thinking door; memini scoring     |
-| `llama-nvidia`          | 3090 (2 slots)       | Qwen3.8-27B unsloth UD-Q4_K_XL                 | 131k     | Coding lane; vision                   |
-| `llama-nvidia-chat`     | same server          | —                                              | 131k     | Non-thinking door                     |
-| `llama-reviewer`        | Strix ROCm (2 slots) | Nemotron 3.5 Lightning 30B-A3B UD-Q4_K_XL, MTP | 200k     | Foreman code review                   |
-| `llama-reviewer-chat`   | same server          | —                                              | 200k     | Non-thinking door                     |
-| `llama-vision`          | Strix ROCm (2 slots) | MiniCPM-V 4.5 abliterated Q4_K_M               | 16k      | Image analysis; will not refuse       |
-| `memini-embed`          | Intel iGPU           | Qwen3-Embedding-0.6B                           | —        | Embeddings (1024-dim)                 |
-| `memini-rerank`         | Strix ROCm           | Qwen3-Reranker-0.6B                            | —        | Reranking                             |
-| `toolhive-embed`        | Intel iGPU           | Qwen3-Embedding-0.6B                           | —        | Embeddings for toolhive vMCP          |
+| Alias                       | Backend                     | Model                                             | Ctx (in) | Role                                  |
+| --------------------------- | --------------------------- | ------------------------------------------------- | -------- | ------------------------------------- |
+| `qwen3.8-flash-next`        | Strix Vulkan (1 slot)       | Qwen3.8-Flash-Next 180B-e51B-A6B UD-IQ4_XS, MTP   | 262k     | General local brain; vision + tools   |
+| `qwen3.8-flash-next-chat`   | same server                 | —                                                 | 262k     | Non-thinking door; memini scoring     |
+| `qwen3.8-27b`               | 3090 (time-sliced)          | Qwen3.8-27B unsloth UD-Q4_K_XL                    | 131k     | Coding lane; vision (CPU-offloaded)   |
+| `qwen3.8-27b-chat`          | same server                 | —                                                 | 131k     | Non-thinking door                     |
+| `gemma-4-12b-it-qat`        | 9070XT (Windows, LM Studio) | Gemma 4 12B-it QAT                                | —        | Foreman code review (`gemma-wake`)    |
+| `gemma-4-12b-it-qat-chat`   | same server                 | —                                                 | —        | Non-thinking door                     |
+| `memini-embed`              | Intel iGPU                  | Qwen3-Embedding-0.6B                              | —        | Embeddings (1024-dim)                 |
+| `memini-rerank`             | CPU (3 replicas)            | jina-reranker-v2-base-multilingual Q8_0           | —        | Reranking                             |
+| `toolhive-embed`            | Intel iGPU                  | Qwen3-Embedding-0.6B                              | —        | Embeddings for toolhive vMCP          |
 
-`llama-strix-dsv4f` (DeepSeek-V4-Flash UD-IQ2_M) and `llama-strix-fp8` exist in git but are commented
-out of the kustomization — they need most of the box to themselves.
+Vision no longer has a dedicated abliterated model — the old `llama-vision` (CPU Gemma 4 E4B, briefly)
+was removed; image analysis now goes through `qwen3.8-flash-next-chat` (falling back to `qwen3.8-27b-chat`).
+The dead Qwen3.6-35B-A3B and Nemotron manifests are kept commented out as named fallback references
+(`qwen3.6-35b-a3b`, `nemotron-3.5-lightning-30b-a3b`) in case Flash-Next disappoints.
+
+`dsv4f-local` (DeepSeek-V4-Flash UD-IQ2_M) exists in git but is commented out of the kustomization — it
+needs most of the box to itself. The FP8 variant was deleted (FP8 doesn't work on gfx1151).
 
 ### Cloud (flat-rate subscriptions)
 
@@ -126,8 +138,8 @@ Retired 2026-08-25 when the plan capped out, ahead of its 08-28 lapse. It had su
 
 | Pool | Order | Members | Policy |
 | ---- | ----- | ------- | ------ |
-| `reasoning-pool` | 1 -> 4 | GPT-5.6 Terra -> GLM-5.3-Flash (Z.AI) -> MiniMax-M3 -> llama-strix | Planning lane; M3 is the flat-plan floor, strix the local one |
-| `implementation-pool` | 1 -> 3 | GPT-5.6 Luna (effort high) -> MiniMax-M2.7 -> llama-nvidia | Implementation lane, deliberately below the planning lane |
+| `reasoning-pool` | 1 -> 4 | GPT-5.6 Terra -> GLM-5.3-Flash (Z.AI) -> MiniMax-M3 -> qwen3.8-flash-next | Planning lane; M3 is the flat-plan floor, strix the local one |
+| `implementation-pool` | 1 -> 3 | GPT-5.6 Luna (effort high) -> MiniMax-M2.7 -> qwen3.8-27b | Implementation lane, deliberately below the planning lane |
 | `frontier-pool` | 1 -> 4 | GPT-6 Astra -> Kimi K3 (Kimi Coding) -> GLM-5.3 (Z.AI) -> DSV4F (Neuralwatt) | Frontier escalation, subscriptions before PAYG |
 
 The three pools are a capability ladder, not three copies of the same idea: `frontier-pool` for
@@ -143,8 +155,8 @@ Reasoning effort is **passed through**, not pinned, on every ChatGPT rung except
 for `xhigh` does not get it. Every other ChatGPT rung takes the caller's effort.
 
 `implementation-pool` declares 131072 rather than Luna's 1.05M: a group's usable window is the smallest
-rung it can land on, and rung 3 is llama-nvidia. Raise it only if truncation on fall-through is
-acceptable. `reasoning-pool` keeps its 1.05M declaration because llama-strix sits at rung 4, reached
+rung it can land on, and rung 3 is qwen3.8-27b. Raise it only if truncation on fall-through is
+acceptable. `reasoning-pool` keeps its 1.05M declaration because qwen3.8-flash-next sits at rung 4, reached
 only once ChatGPT, Z.AI and MiniMax have all failed.
 
 **Provider failover** (LiteLLM `order:`, transparent to callers) reacts when an upstream rejects a
@@ -162,6 +174,8 @@ ceiling even though Kimi K3 is a 1M model standalone. It remains available via t
 
 ## Model capability ranking
 
+> **Stale as of the 2026-09-08 rename.** The scores and analysis below were measured against the previous local models — Qwen3.6-35B-A3B on the Strix box (now Qwen3.8-Flash-Next) and Nemotron 3.5 Lightning as the reviewer (now Gemma 4 12B-it QAT). The aliases have been renamed to match the current names, but the numbers have **not** been re-run; treat them as historical until re-benchmarked.
+
 Benchmark snapshot as of **2026-08-23** — perishable. Numbers remain largely **vendor
 self-reported on non-overlapping harnesses** (SWE-bench Pro ≠ Verified; Terminal-Bench
 2.0 ≠ 2.1 ≠ 3.0; vendor SWE-Pro runs 15–30pts above standardized scaffolding), so treat deltas as
@@ -170,7 +184,8 @@ table as a statement about pricing, cache behaviour, or quota consumption.
 
 Rows for `dsv4p`, `glm-5.2`, `mimo-v2.5` and `mimo-v2.5-pro` are kept for reference only — those
 aliases were retired on 2026-08-25 and are no longer served. The Mellum2 row is likewise
-historical: `llama-reviewer` now serves Nemotron 3.5 Lightning 30B-A3B.
+historical: the reviewer lane (`gemma-4-12b-it-qat`) served Nemotron 3.5 Lightning 30B-A3B in that
+snapshot but now runs Gemma 4 12B-it QAT on the 9070XT (LM Studio `gemma-wake`).
 
 Rows are ordered by **AA-II**, the [Artificial Analysis Intelligence Index](https://artificialanalysis.ai/leaderboards/models)
 (v4.1.1) — the only axis in this table measured on one harness across every model here, and therefore
@@ -187,13 +202,13 @@ harnesses. Cells marked ⁱ are **independently run**; everything else is vendor
 | DeepSeek-V4-Pro     | `dsv4p`                 | MoE 1.6T/49A        | 1M    | 53ⁱ   | 96.4ⁱ | n/p ⁷   | n/p ⁷     | 87.9       | n/p ⁷ | n/p   |
 | GLM-5.2             | `glm-5.2`               | MoE ~753B/40A       | 1M    | 53ⁱ   | n/p   | 62.1    | n/p       | 78ⁱ ⁴      | 89ⁱ   | 99.2  |
 | DeepSeek-V4-Flash   | `dsv4f`                 | MoE 284B/13A        | 1M    | 52ⁱ   | n/p ⁷ | n/p ⁷   | n/p ⁷     | 79ⁱ ⁷      | 91ⁱ   | n/p   |
-| Qwen3.8-27B dense   | `llama-nvidia`                | dense 27.8B         | 145k⁸ | 52ⁱ   | n/p ⁸ | 61.7    | 90.3      | 73.0       | 89.2  | n/p   |
+| Qwen3.8-27B dense   | `qwen3.8-27b`                | dense 27.8B         | 145k⁸ | 52ⁱ   | n/p ⁸ | 61.7    | 90.3      | 73.0       | 89.2  | n/p   |
 | GPT-5.6 Luna        | `chatgpt/gpt-5.6-luna`  | proprietary         | 1.05M | 51ⁱ   | n/p   | 62.7    | n/p       | 84.7       | n/p ² | n/p   |
 | MiniMax-M3          | `MiniMax`               | MoE ~428B/23A ¹     | 1M    | 45ⁱ   | 80.5  | 59.0    | n/p       | 66.0       | 93ⁱ   | n/p   |
 | MiMo-V2.5-Pro       | `mimo-v2.5-pro`         | MoE 1.02T/42A       | 1M    | 43ⁱ   | 78.9  | 57.2    | n/p ⁹     | n/p ⁹      | n/p ⁹ | n/p ⁹ |
 | MiniMax-M2.7        | `MiniMax-M2.7`          | MoE ~230B/10A       | 205k  | 39ⁱ   | n/p   | 56.2    | n/p       | n/p ⁹      | 89.8  | 94.2  |
 | MiMo-V2.5           | `mimo-v2.5`             | MoE 310B/15A        | 1M    | 38ⁱ   | n/p   | 56.1    | n/p       | n/p ⁹      | n/p   | n/p   |
-| Qwen3.6-35B-A3B     | `llama-strix`           | MoE 35B/3A          | 262k  | 32ⁱ   | 73.4  | 49.5    | 80.4      | n/p ⁹      | 86.0  | 92.7  |
+| Qwen3.6-35B-A3B     | `qwen3.8-flash-next`           | MoE 35B/3A          | 262k  | 32ⁱ   | 73.4  | 49.5    | 80.4      | n/p ⁹      | 86.0  | 92.7  |
 | Mellum2-12B-A2.5B   | — (retired)                   | MoE 12B/2.5A        | 131k  | n/p   | n/p   | n/p     | 37.2      | n/p        | 40.9  | 41.7  |
 
 ¹ MiniMax-M3 is **~428B total / ~23B active** — the ~229B/9.8B figure the previous snapshot carried is
@@ -266,7 +281,7 @@ measured — Flash Terminal-Bench 2.1 61.8 → 82.7, DeepSWE 7.3 → 54.4 — an
 the direction, lifting Flash from index 40 to 52. Note also that Flash's old 56.9 was Terminal-Bench
 **2.0**; the 2.1 retro-score for the same build is 61.8.
 
-⁸ `llama-nvidia` has run **Qwen3.8-27B** since 2026-08-14, not the Qwen3.6-27B the previous snapshot listed —
+⁸ `qwen3.8-27b` has run **Qwen3.8-27B** since 2026-08-14, not the Qwen3.6-27B the previous snapshot listed —
 that row was wrong on the model name irrespective of benchmarks. Qwen publishes no SWE-bench Verified
 for it (the nearest vendor substitute, QwenSWEBench 79.0, is Qwen's own harness) and no AIME, so the
 generational SWE-V and AIME comparisons against Qwen3.6-27B cannot be made. Terminal-Bench also
@@ -282,14 +297,13 @@ automated HF metadata PR flattened into the card alongside post-trained numbers.
 comparable to any other row here and have been removed rather than corrected — Xiaomi publishes no
 post-trained equivalents.
 
-`llama-strix` runs the stock unsloth Qwen3.6-35B-A3B (UD-Q4_K_XL, native MTP) with its
-mmproj loaded. The abliterated HauhauCS build it previously ran — and Ornith-1.0-35B before
-that, a post-tune of the *same* Qwen3.6-35B-A3B — were dropped in the 2026-08-25 move to
-unsloth builds, so the box keeps the architecture without a post-tune. Uncensored image
-analysis now lives on `llama-vision` (abliterated MiniCPM-V 4.5); the Mac LM Studio member
-is gone, so there is no second `llama-strix` upstream to reason about.
+`qwen3.8-flash-next` now runs Qwen3.8-Flash-Next (180B-e51B-A6B, UD-IQ4_XS, native MTP, Vulkan) with
+its mmproj loaded — swapped in on 2026-09-08, replacing the Qwen3.6-35B-A3B this section's scores were
+measured against (which had itself replaced the HauhauCS and Ornith-1.0-35B post-tunes of the same
+Qwen3.6 in the 2026-08-25 unsloth move). Image analysis now goes through the local `-chat` models
+rather than a dedicated `llama-vision`, which was removed.
 
-`llama-reviewer` publishes more than the previous snapshot credited it with — the
+`gemma-4-12b-it-qat` publishes more than the previous snapshot credited it with — the
 [Mellum2 Instruct card](https://huggingface.co/JetBrains/Mellum2-12B-A2.5B-Instruct) carries
 LiveCodeBench v6 37.2, EvalPlus 78.4, MultiPL-E 67.1, GPQA 40.9 and AIME 41.7, all self-reported. What
 it genuinely does not publish is any *agentic* coding bench: no SWE-bench of any slice, no
@@ -334,15 +348,15 @@ Reading it for routing:
 - **Reasoning tier** (`gpt-5.6-luna`, `MiniMax-M3`) — note Luna is the weakest GPT tier here
   at AA-II 51 and its long-context recall collapses (vendor MRCR 41.3 against Sol's 91.5), so the pool's
   nominal 1M context is not usable depth on that rung. Luna is pinned to `xhigh` reasoning effort.
-- **Local** — `llama-nvidia` is now Qwen3.8-27B and the gap to `llama-strix` widened from "trails it
-  everywhere" to a 20-point AA-II spread (52 vs 32). `llama-strix` earns its place on the 262k window
+- **Local** — `qwen3.8-27b` is now Qwen3.8-27B and the gap to `qwen3.8-flash-next` widened from "trails it
+  everywhere" to a 20-point AA-II spread (52 vs 32). `qwen3.8-flash-next` earns its place on the 262k window
   and vision, nothing else. The local box is now competitive with paid cheap-tier cloud, which is the
   single most decision-relevant change in this refresh.
-- **`llama-reviewer` is a deliberate family split, not a quality pick.** Foreman's coder runs
-  Qwen (`llama-nvidia`), so a Qwen reviewer inherits the coder's blind spots — it was Qwen
-  reviewing Qwen while `llama-strix` served review, since Ornith was itself a
-  Qwen3.6-35B-A3B post-tune. The lane went to JetBrains' Mellum2 first and now runs
-  NVIDIA's Nemotron 3.5 Lightning 30B-A3B — still a non-Qwen family, ~3B active, free.
+- **`gemma-4-12b-it-qat` is a deliberate family split, not a quality pick.** Foreman's coder runs
+  Qwen (`qwen3.8-27b`), so a Qwen reviewer inherits the coder's blind spots — it was Qwen
+  reviewing Qwen while `qwen3.8-flash-next` served review, since Ornith was itself a
+  Qwen3.6-35B-A3B post-tune. The lane went to JetBrains' Mellum2, then Nemotron 3.5 Lightning
+  30B-A3B, and now Gemma 4 12B-it QAT on the 9070XT — still a non-Qwen family, free.
   It exists to disagree with the coder, so published coding scores
   matter less here than independence and structured-output reliability.
 - **MiniMax-M2.7 / MiMo** — agentic workhorses with thin published reasoning numbers; rank on
@@ -366,12 +380,14 @@ Sources: [Artificial Analysis](https://artificialanalysis.ai/leaderboards/models
 
 ## v2 bench: the local models are within noise of each other
 
+> **Same caveat as the capability ranking:** measured against the pre-2026-09-08 local models, aliases renamed but scores not re-run.
+
 Four suites from `repo-bench` v2, scored on this repo's own material. Error rows (transport
 failures) are dropped rather than counted as zeros — the `tally` subcommand does this.
 
 | Candidate | Troubleshooting | Reviewing | Agentic | Coding | Mean |
 | --------- | --------------- | --------- | ------- | ------ | ---- |
-| `llama-nvidia` 27B Q4 (3090) | 0.981 | 0.923 | 0.718 | 0.710 | 0.833 |
+| `qwen3.8-27b` 27B Q4 (3090) | 0.981 | 0.923 | 0.718 | 0.710 | 0.833 |
 | Qwen3.8-27B FP8 (Strix) | 0.938 | 0.920 | 0.782 | 0.760 | 0.850 |
 | Flash-Next UD-Q3_K_XL (Strix) | 0.978* | 0.792 | 0.833 | 0.760 | 0.841 |
 | Flash-Next NVFP4 + FP8 engram (borrowed RTX 6000 Pro) | 0.991 | 0.838 | 0.788 | 0.620 | 0.809 |
@@ -382,7 +398,7 @@ failures) are dropped rather than counted as zeros — the `tally` subcommand do
 
 \* n=15; three tasks died on the qwen4exp indexer assert and were dropped.
 
-**Run-to-run noise is ±0.02**, measured from the duplicate `nvidia`/`llama-nvidia` pair (same model,
+**Run-to-run noise is ±0.02**, measured from the duplicate `nvidia`/`qwen3.8-27b` pair (same model,
 different dates: deltas 0.016 / 0.003 / 0.019 / 0.020). So the top three rows are a tie, and a 180B
 at Q3 does not beat a 27B on this bench.
 
@@ -392,7 +408,7 @@ score is broken, which is fine for a review-only lane and disqualifying for a co
 Caveat on luna: it ran at `effort=medium`, and every real consumer reaches it through
 `reasoning-pool` which pins `effort: max`. That row is not evidence about the deployed path.
 
-Methodology trap: candidate names are not stable across time. `llama-strix` meant Ornith in August
+Methodology trap: candidate names are not stable across time. `qwen3.8-flash-next` meant Ornith in August
 and Flash-Next later, and `tally` merges by candidate name — check what the alias pointed at before
 comparing rows.
 
@@ -422,10 +438,10 @@ permits. Wall power: skirk **48.7 W** serving three models plus an image generat
 
 | Consumer               | In repo?                                    | Points at                                                                                    |
 | ---------------------- | ------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| **OpenClaw**           | yes (`.../llm/openclaw/app/configmap.yaml`) | Miso/main `glm-5.3-flash`; Matcha `dsv4f`; Saffron `reasoning-pool`; subagents `MiniMax-M3`; heartbeat `llama-nvidia`; image `llama-vision`; lossless-claw expansion/summary `llama-strix-chat` |
-| **Hermes**             | yes (`.../llm/hermes/configmap.yaml`)       | default `MiniMax-M3`; compression/extract/approval/session-search `llama-strix`; vision `llama-vision` |
-| **Foreman**            | yes (`.../llm/foreman/agents/*.yaml`)       | `coder` → `llama-nvidia`; `coder-revision` + `coder-frontier` → `MiniMax-M3-chat`; `reviewer` + `reviewer-fork` → `llama-reviewer` |
-| **Opencode** (CLI/Zen) | yes (`.../llm/opencode/configmap.yaml`)     | default `auto`; coordinator `reasoning-pool`; role subagents `MiniMax-M3`/`llama-nvidia`/`llama-strix`/`glm-5.3`/`llama-reviewer`, plus the workstation CLI on LiteLLM aliases directly |
+| **OpenClaw**           | yes (`.../llm/openclaw/app/configmap.yaml`) | Miso/main `glm-5.3-flash`; Matcha `dsv4f`; Saffron `reasoning-pool`; subagents `MiniMax-M3`; heartbeat `qwen3.8-27b`; image `llama-vision`; lossless-claw expansion/summary `qwen3.8-flash-next-chat` |
+| **Hermes**             | yes (`.../llm/hermes/configmap.yaml`)       | default `MiniMax-M3`; compression/extract/approval/session-search `qwen3.8-flash-next`; vision `llama-vision` |
+| **Foreman**            | yes (`.../llm/foreman/agents/*.yaml`)       | `coder` → `qwen3.8-27b`; `coder-revision` + `coder-frontier` → `MiniMax-M3-chat`; `reviewer` + `reviewer-fork` → `gemma-4-12b-it-qat` |
+| **Opencode** (CLI/Zen) | yes (`.../llm/opencode/configmap.yaml`)     | default `auto`; coordinator `reasoning-pool`; role subagents `MiniMax-M3`/`qwen3.8-27b`/`qwen3.8-flash-next`/`glm-5.3`/`gemma-4-12b-it-qat`, plus the workstation CLI on LiteLLM aliases directly |
 | **Zed**                | no (workstation)                            | LiteLLM aliases directly                                                                     |
 
 ### OpenClaw cron fleet
@@ -436,25 +452,25 @@ per job already encodes an intent-lane pattern by hand.
 | Job                             | Agent   | Model        | Schedule        | Purpose                                        |
 | ------------------------------- | ------- | ------------ | --------------- | ---------------------------------------------- |
 | Afternoon Email/Finance Check   | Miso    | MiniMax-M2.7 | 4pm daily       | Email + financial anomaly scan                 |
-| Instagram Hourly Image Dispatch | Miso    | llama-strix  | 9am–8pm Mon–Thu | Publish one approved staged IG post per window |
+| Instagram Hourly Image Dispatch | Miso    | qwen3.8-flash-next  | 9am–8pm Mon–Thu | Publish one approved staged IG post per window |
 | Image Category Creation         | Miso    | MiniMax      | every 6h        | Generate new image category + gallery          |
 | Evening Email/Finance Check     | Miso    | MiniMax-M2.7 | 9pm daily       | End-of-day email + finance summary             |
-| Nightly Audit Decomposer        | Saffron | llama-strix  | 2am daily       | Decompose audit umbrellas into child issues    |
+| Nightly Audit Decomposer        | Saffron | qwen3.8-flash-next  | 2am daily       | Decompose audit umbrellas into child issues    |
 | Nightly Tech Sweep              | Saffron | MiniMax-M3-chat    | 6:20am daily    | Overnight health check + low-risk fixes        |
 | Unified Morning Brief           | Miso    | MiniMax-M2.7 | 7:30am daily    | Weather, calendar, inbox, IG pool, news, radon |
-| Daily LLM + HN Digest           | Miso    | llama-strix  | 8:30am daily    | r/LocalLLaMA etc. + HN top stories             |
+| Daily LLM + HN Digest           | Miso    | qwen3.8-flash-next  | 8:30am daily    | r/LocalLLaMA etc. + HN top stories             |
 | Daily Home-Ops Updates          | Saffron | MiniMax-M2.7 | 9am daily       | Commit watch on homelab k8s repos              |
-| Daily Image (Miso)              | Miso    | llama-strix  | 9:15am daily    | Character image generation                     |
+| Daily Image (Miso)              | Miso    | qwen3.8-flash-next  | 9:15am daily    | Character image generation                     |
 | Alertmanager Health Digest      | Saffron | MiniMax-M3-chat    | 9:30am daily    | Firing Prometheus alerts + investigation       |
 | Solar Daily Check               | Miso    | MiniMax-M2.7 | 9:35am daily    | Solar generation + weather + guess tracking    |
-| Daily Image (Saffron)           | Saffron | llama-strix  | 10:15am daily   | Character image generation                     |
+| Daily Image (Saffron)           | Saffron | qwen3.8-flash-next  | 10:15am daily   | Character image generation                     |
 | Weekly IG Posting Times         | Miso    | MiniMax-M3-chat    | 11am Fri        | Research optimal IG posting times              |
 | Weekly Audit                    | Saffron | MiniMax-M2.7 | 1am Wed         | Spawn per-repo audit sub-agents                |
 | Weekly Prompt Hygiene           | Saffron | MiniMax-M3-chat    | 10:45am Wed     | Audit prompt files for bloat/contradictions    |
 
 Issue-worker pipelines (pick up issues and open PRs):
 
-- **MC Normal** → `llama-strix`
+- **MC Normal** → `qwen3.8-flash-next`
 - **MC Escalated** → `gpt-5.6-sol`
 
 ## Current routing + observed usage
@@ -463,20 +479,20 @@ Routing today is `simple-shuffle` with hand-written availability fallbacks
 (`kubernetes/apps/base/llm/litellm/litellmproxy.yaml`). `simple-shuffle` spreads a synchronized fan-out
 evenly across a group's deployments; `least-busy` increments its in-flight
 counter _after_ the routing decision, so a burst reads equal counts and piles
-onto the first deployment — wrong for the 2-instance `llama-strix` group.
+onto the first deployment — wrong for the 2-instance `qwen3.8-flash-next` group.
 
 ```yaml
 routing_strategy: simple-shuffle
 fallbacks:
-    - llama-strix: [llama-nvidia, MiniMax-M3-chat]
-    - llama-nvidia: [llama-strix, MiniMax-M3-chat]
-    - dsv4f: [llama-nvidia]
+    - qwen3.8-flash-next: [qwen3.8-27b, MiniMax-M3-chat]
+    - qwen3.8-27b: [qwen3.8-flash-next, MiniMax-M3-chat]
+    - dsv4f: [qwen3.8-27b]
     - kimi-k2.7: [MiniMax-M3-chat]
     - kimi-k3: [MiniMax-M3-chat]
     - auto: [dsv4f, MiniMax-M3-chat]
 context_window_fallbacks:
-    - llama-nvidia: [llama-strix]
-    - llama-strix: [dsv4f]
+    - qwen3.8-27b: [qwen3.8-flash-next]
+    - qwen3.8-flash-next: [dsv4f]
 ```
 
 Observed 7-day traffic (Prometheus, 2026-08-23; `litellm_total_tokens_metric_total`, cached input
@@ -486,10 +502,10 @@ included; all consumers combined):
 | --------------------------- | -------------------: |
 | gpt-5.6-luna                |               329.0M |
 | MiniMax-M3                  |               313.6M |
-| llama-nvidia                |               219.8M |
+| qwen3.8-27b                |               219.8M |
 | deepseek-v4-flash (`dsv4f`) |               203.7M |
 | glm-5.3                     |                74.5M |
-| llama-reviewer              |                45.0M |
+| gemma-4-12b-it-qat              |                45.0M |
 | MiniMax-M3-chat                   |                22.8M |
 | MiniMax-M2.7                |                13.7M |
 | k3                          |                 7.4M |
@@ -542,20 +558,20 @@ turn, and start a fresh session after a context incident. A single turn can exce
 because the two failure modes are asymmetric:
 
 - **Cap above the backend** and requests queue *inside* llama.cpp, invisible to the router.
-  `llama-nvidia` sat at 2 against a single slot; the queueing surfaced as a 53 s average
-  time-to-first-token on the `llama-nvidia` alias while the model itself was fine (fixed 2026-08).
-- **Cap below the backend** and provisioned VRAM goes unused. `llama-reviewer` served 3
+  `qwen3.8-27b` sat at 2 against a single slot; the queueing surfaced as a 53 s average
+  time-to-first-token on the `qwen3.8-27b` alias while the model itself was fine (fixed 2026-08).
+- **Cap below the backend** and provisioned VRAM goes unused. `gemma-4-12b-it-qat` served 3
   slots while LiteLLM dispatched into 2 — a third of the model unreachable (fixed 2026-08).
 
 Current: Strix 2, reviewer 2, nvidia 1. The Strix box is memory-bandwidth bound, so
 aggregate tok/s improves with concurrent streams spread **across** resident models rather
 than piled onto one — the useful range is roughly 6-8 streams for the whole box, not per
-model. The Mac LM Studio member was removed; `llama-strix` is now the single cluster server.
+model. The Mac LM Studio member was removed; `qwen3.8-flash-next` is now the single cluster server.
 
 Foreman's demand cannot currently be bounded per-Agent
 ([LLMKube#1497](https://github.com/defilantech/LLMKube/issues/1497)), so the only levers on
-its share of `llama-strix` are the bridge's `MAX_IN_PROGRESS` and the `LANE_CODER_AGENTS`
-split ratio — both blunt. Measured `llama-strix` utilisation across *all* consumers
+its share of `qwen3.8-flash-next` are the bridge's `MAX_IN_PROGRESS` and the `LANE_CODER_AGENTS`
+split ratio — both blunt. Measured `qwen3.8-flash-next` utilisation across *all* consumers
 (Foreman, home-ops PR reviews, groomer, repo-wiki) is ~15 busy-hours/day against 96
 slot-hours, so headroom is real and the risk is bursts, not steady state.
 
@@ -569,13 +585,13 @@ Tiers (three effective tiers; REASONING is folded into COMPLEX):
 
 | Tier               | Target                              | Why                                          |
 | ------------------ | ----------------------------------- | -------------------------------------------- |
-| SIMPLE             | `llama-nvidia` (3090 Qwen3.8-27B)   | Trivia — local, free                         |
+| SIMPLE             | `qwen3.8-27b` (3090 Qwen3.8-27B)   | Trivia — local, free                         |
 | MEDIUM             | `MiniMax-M3`                        | Flat sub, no weekly quota to burn            |
 | COMPLEX            | `reasoning-pool`                    | Terra -> GLM-5.3-Flash -> MiniMax-M3         |
 | REASONING          | `reasoning-pool`                    | Folded — no classifier could separate it     |
 | default (miss)     | `MiniMax-M3`                        | `classifier_fallback: default_model`         |
 
-Classifier is `llama-strix` (`classifier_llm_config`, 20s timeout) — local and free to sit in
+Classifier is `qwen3.8-flash-next` (`classifier_llm_config`, 20s timeout) — local and free to sit in
 every request's path. It replaced the reviewer-alias classifier on 2026-08-22.
 
 `frontier-pool` is deliberately **not** a tier target: `auto` must not compete with interactive
@@ -592,7 +608,7 @@ against real backends.
 | ------------------------------------------ | ------------------ |
 | Rule-based scorer, boundaries `.45/.65/.85` | **5/20 (25%)**     |
 | Rule-based scorer, boundaries `.15/.35/.60` | 7/20 (35%)         |
-| LLM classifier (`llama-reviewer`), held out       | 17/20 (85%) 3-tier |
+| LLM classifier (`gemma-4-12b-it-qat`), held out       | 17/20 (85%) 3-tier |
 | LLM classifier, end-to-end on real pools    | **16/20 (80%)**    |
 
 The scorer cannot be fixed by tuning. Observed score means: SIMPLE −0.120, MEDIUM +0.115,
@@ -633,7 +649,7 @@ builds an encoder at startup (crashloop risk on the live gateway), so it's verif
 
 Still ahead:
 
-- Swap MEDIUM to `llama-nvidia` once Foreman's backlog drains — it's the better model and free, but was
+- Swap MEDIUM to `qwen3.8-27b` once Foreman's backlog drains — it's the better model and free, but was
   measured at 37–90s under contention, unusable for a tier that receives over-routed volume.
 - Re-measure against real opencode system prompts rather than bare user messages.
 - Auto Router v2 offers `keyword_tier_rules` (deterministic tier overrides, `cause=literal_keyword_match`)
@@ -714,9 +730,9 @@ OpenCode Go endpoint (2026-08-04):
   `custom_llm_provider="deepseek"` and never runs on an `openai/`-via-OpenCode rung.
 - The one surviving constraint is **forced** tool choice: `tool_choice: "required"` or a named
   function returns `400 "Thinking mode does not support this tool_choice"`. `tool_choice: "auto"` is
-  fine, and forced calls fall through to the `dsv4f` → `llama-nvidia` router fallback rather than failing.
-- Watch `litellm_deployment_successful_fallbacks_total{requested_model="dsv4f",fallback_model="llama-nvidia"}`.
+  fine, and forced calls fall through to the `dsv4f` → `qwen3.8-27b` router fallback rather than failing.
+- Watch `litellm_deployment_successful_fallbacks_total{requested_model="dsv4f",fallback_model="qwen3.8-27b"}`.
   If it climbs, a consumer is forcing a tool and `extra_body: {thinking: {type: disabled}}` should be
-  restored on that deployment. The likeliest source is the `llama-strix` → `dsv4f` context-window
+  restored on that deployment. The likeliest source is the `qwen3.8-flash-next` → `dsv4f` context-window
   fallback, which arrives carrying whatever `tool_choice` the original caller set.
 - `dsv4p` was retired with the Opencode Go plan on 2026-08-25; the note is kept for history.


### PR DESCRIPTION
The rename PR (#9891) was scoped to kubernetes/ manifests, so the docs kept the dead names. This updates `llm-strategy.md`, `coding-loop.md`, and `foreman.instructions.md`: renames all current-state aliases, rewrites the model inventory to current reality (Strix runs Qwen3.8-Flash-Next not Qwen3.6; reviewer is Gemma 4 12B-it QAT on the 9070XT not Nemotron; llama-vision removed; jina reranker on CPU; fp8 deleted), and fixes the changelog to preserve the historical rename while recording this one. The capability-ranking and v2-bench sections measured the pre-swap models — aliases are renamed but the scores are left under a staleness banner rather than fabricating new numbers; those need a re-run you'd drive. Minor follow-up: the llmkube README (already name-renamed by #9891) may still describe the old Strix model.