### PR TITLE
feat(dispatch): declare TypeScript source extensions for the reviewer scope-overlap vouch

### DIFF
--- a/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/dispatch/foreman-dispatch-bridge/helmrelease.yaml
@@ -59,7 +59,7 @@ spec:
               FOREMAN_NAMESPACE: llm
               MAX_IN_PROGRESS: "14"
               VERDICT_SELF_GO: "code-fix,docs,packaging,config,ci-policy"
-              GATEPROFILE_MAP: '{"misospace/pr-reviewer-action":{"testLayout":{"testRoot":"tests","sourceRoot":"pr_reviewer"}},"misospace/windowstead":{"testLayout":{"testRoot":"tests","sourceRoot":"scripts"},"sourceExtensions":[".gd"]},"misospace/pinchflat":{"testLayout":{"testRoot":"test","sourceRoot":"lib"},"sourceExtensions":[".ex",".exs",".heex"]},"misospace/foreman-dispatch-bridge":{"testLayout":{"testRoot":"tests","sourceRoot":"bridge"}},"misospace/miso-chat":{"testLayout":{"testRoot":"tests","sourceRoot":"lib"}},"*":{"sourceExtensions":[".go",".hcl"]}}'
+              GATEPROFILE_MAP: '{"misospace/dispatch":{"sourceExtensions":[".ts",".tsx"]},"misospace/pr-reviewer-action":{"testLayout":{"testRoot":"tests","sourceRoot":"pr_reviewer"}},"misospace/windowstead":{"testLayout":{"testRoot":"tests","sourceRoot":"scripts"},"sourceExtensions":[".gd"]},"misospace/pinchflat":{"testLayout":{"testRoot":"test","sourceRoot":"lib"},"sourceExtensions":[".ex",".exs",".heex"]},"misospace/foreman-dispatch-bridge":{"testLayout":{"testRoot":"tests","sourceRoot":"bridge"}},"misospace/miso-chat":{"testLayout":{"testRoot":"tests","sourceRoot":"lib"}},"*":{"sourceExtensions":[".go",".hcl"]}}'
               REVISION_CODER_AGENTS: '{"*":"coder-revision"}'
               PR_FIX_ENABLED: "true"
               PR_FIX_MAX_ATTEMPTS: "4"


### PR DESCRIPTION
Adds `misospace/dispatch` to `GATEPROFILE_MAP` with `sourceExtensions: [".ts",".tsx"]`.

Not a gate — gates are off. The map is retained only to feed the reviewer's scope-overlap rail (`sourceExtensions`) and the coder self-gate (`testLayout`). Dispatch is the one TypeScript repo that was never declared, so it inherited the `*` default `[".go",".hcl"]` and the scope rail could not recognize `.ts` paths in dispatch issues.

Consequence, seen on dispatch#970: the reviewer approved a valid fix, but the scope-overlap vouch found zero named-file matches (the only ref it could extract from the issue body was `AGENTS.md`, via the base `.md` extension), so a failed issueAsk keyword check demoted GO → NO-GO and the bridge parked it `needs-human`. With `.ts` declared, the vouch matches the files the issue names and the GO stands.

No `testLayout`: dispatch tests are colocated `*.test.ts` beside their source, so there is no `testRoot`/`sourceRoot` split — the `sourceExtensions`-only shape mirrors the `*` entry.