### PR TITLE
fix(litellm): generate litellm-selfhosted dashboard configmap

### DIFF
--- a/kubernetes/apps/base/llm/litellm/dashboard/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/dashboard/kustomization.yaml
@@ -9,6 +9,9 @@ configMapGenerator:
   - name: litellm-economics
     files:
       - litellm-economics.json
+  - name: litellm-selfhosted
+    files:
+      - litellm-selfhosted.json
   - name: llm-nvidia-node
     files:
       - llm-nvidia-node.json


### PR DESCRIPTION
The self-hosted economics dashboard shipped its JSON and GrafanaDashboard CR but the `configMapGenerator` entry was dropped, so the `litellm-selfhosted` configmap was never created — the CR sat in `InvalidSpec` (configmaps not found) and the dashboard never rendered. Adds the missing generator entry.