### PR TITLE
feat(talos): route the Thunderbolt mesh around a failed segment

### DIFF
--- a/talos/main/controlplane/ayaka.yaml
+++ b/talos/main/controlplane/ayaka.yaml
@@ -27,6 +27,9 @@ addresses:
 routes:
   - destination: 169.254.255.22/32
     metric: 2048
+  - destination: 169.254.255.23/32
+    gateway: 169.254.255.22
+    metric: 4096
 ---
 ## Ganyu
 apiVersion: v1alpha1
@@ -45,3 +48,6 @@ addresses:
 routes:
   - destination: 169.254.255.23/32
     metric: 2048
+  - destination: 169.254.255.22/32
+    gateway: 169.254.255.23
+    metric: 4096

--- a/talos/main/controlplane/eula.yaml
+++ b/talos/main/controlplane/eula.yaml
@@ -27,6 +27,9 @@ addresses:
 routes:
   - destination: 169.254.255.21/32
     metric: 2048
+  - destination: 169.254.255.23/32
+    gateway: 169.254.255.21
+    metric: 4096
 ---
 ## Ganyu
 apiVersion: v1alpha1
@@ -45,3 +48,6 @@ addresses:
 routes:
   - destination: 169.254.255.23/32
     metric: 2048
+  - destination: 169.254.255.21/32
+    gateway: 169.254.255.23
+    metric: 4096

--- a/talos/main/controlplane/ganyu.yaml
+++ b/talos/main/controlplane/ganyu.yaml
@@ -32,6 +32,9 @@ addresses:
 routes:
   - destination: 169.254.255.21/32
     metric: 2048
+  - destination: 169.254.255.22/32
+    gateway: 169.254.255.21
+    metric: 4096
 ---
 ## Eula
 apiVersion: v1alpha1
@@ -50,3 +53,6 @@ addresses:
 routes:
   - destination: 169.254.255.22/32
     metric: 2048
+  - destination: 169.254.255.21/32
+    gateway: 169.254.255.22
+    metric: 4096


### PR DESCRIPTION
Each node carried one route per peer pinned to the direct link, so losing a single segment cut those two nodes off from each other even though both were up and both still reached the third — physical redundancy the routing table could not use, and since the mesh is Ceph's `cluster_network`, a dead segment meant OSD flapping. This adds a backup route on each link to the far node via the directly attached peer at metric 4096 against the direct route's 2048, so Linux prefers the direct path while it has carrier and falls back to one hop through the third node on NO-CARRIER; `ip_forward` is already 1 on all three and the gateway is on-link via the existing /32, so nothing else changes. Six routes, symmetric, and all three merged configs pass `talosctl validate --mode metal`. Caveat: this only rescues a clean link-down — a wedged controller that still reports carrier keeps the direct route installed and blackholes, which needs BFD (available natively in 1.14 via `BGPInstanceConfig`) if that turns out to be the common failure.