### PR TITLE
fix(openclaw): stop memini turn-capture garbage injection

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -70,7 +70,8 @@ spec:
                 exec node dist/index.js gateway --bind lan
             env:
               OPENCLAW_LOG_LEVEL: debug
-              MEMINI_INJECT_RECALL_MIN_SCORE: "0.75"
+              MEMINI_INJECT_RECALL_MIN_SCORE: "0.85"
+              MEMINI_CAPTURE_TURNS: "false"
               COMFYUI_FAST: smurf-pc.internal:8188
               COMFYUI_CLUSTER: comfyui.llm:8188
               COMFYUI_SLOW: macbookpro.internal:8188


### PR DESCRIPTION
Raw `format: turn` captures (importance ~0.1) were being recalled and injected as noise for every agent (Sage acutely, Miso/Saffron too). Disables auto turn-capture (`MEMINI_CAPTURE_TURNS=false` — deliberate `memory_remember` and already-promoted semantic memory are unaffected) and raises the recall floor 0.75→0.85, where an earlier self-query sweep measured zero injected noise. Reversible via env.