### PR TITLE
fix(openclaw): disable memini auto-injection, keep auto-save

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -530,6 +530,8 @@ data:
               fallback_on_error: true,
               timeout_ms: 60000,
               recall_limit: 3,
+              inject_cooldown_ms: 0,
+              inject_cooldown_prompts: 0,
               min_capture_chars: 200,
               expose_tools: true,
             },

--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -70,8 +70,7 @@ spec:
                 exec node dist/index.js gateway --bind lan
             env:
               OPENCLAW_LOG_LEVEL: debug
-              MEMINI_INJECT_RECALL_MIN_SCORE: "0.85"
-              MEMINI_CAPTURE_TURNS: "false"
+              MEMINI_INJECT_RECALL_MIN_SCORE: "0.75"
               COMFYUI_FAST: smurf-pc.internal:8188
               COMFYUI_CLUSTER: comfyui.llm:8188
               COMFYUI_SLOW: macbookpro.internal:8188


### PR DESCRIPTION
Corrects the prior PR, which had it backwards. Auto-**save** is wanted — facts get captured without the agent having to ask. The **auto-injection** of recalled turns into the prompt between answers was the garbage. This re-enables capture (drops `MEMINI_CAPTURE_TURNS=false`) and disables auto-injection via `inject_cooldown_ms: 0` + `inject_cooldown_prompts: 0` (both-0 is the plugin's suppress-forever path). The manual `memory_recall` tool still works. Recall floor reverted to 0.75 (irrelevant while injection is off).