### PR TITLE
fix(memini): thinking distiller with headroom, salience-weighted recall

### DIFF
--- a/kubernetes/apps/base/llm/litellm/virtualkeys/memini.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/memini.yaml
@@ -12,6 +12,7 @@ spec:
   - local-pool-chat
   - qwen3.8-27b-chat
   - qwen3.8-flash-next-chat
+  - qwen3.8-flash-next
   - gemma-4-12b-it-qat-chat
   - memini-embed
   - rerank

--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -35,7 +35,10 @@ spec:
               MEMINI_SHORT_TERM_CAP: 300
               MEMINI_ASSESS_BATCH: "5"
               MEMINI_LLM_BASE_URL: http://litellm.llm:4000/v1
-              MEMINI_LLM_MODEL: local-pool-chat
+              MEMINI_LLM_MODEL: qwen3.8-flash-next
+              MEMINI_LLM_MAX_TOKENS: "24576"
+              MEMINI_DISTILL_TIMEOUT: 600s
+              MEMINI_ASSESSED_SALIENCE_WEIGHT: "0.6"
               MEMINI_REEMBED_ON_MODEL_CHANGE: true
               MEMINI_RERANK: http://litellm.llm:4000/v1
               MEMINI_RERANK_MODEL: rerank

--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -70,8 +70,7 @@ spec:
                 exec node dist/index.js gateway --bind lan
             env:
               OPENCLAW_LOG_LEVEL: debug
-              MEMINI_INJECT_RECALL_MIN_SCORE: "0.85"
-              MEMINI_CAPTURE_TURNS: "false"
+              MEMINI_INJECT_RECALL_MIN_SCORE: "0.75"
               COMFYUI_FAST: smurf-pc.internal:8188
               COMFYUI_CLUSTER: comfyui.llm:8188
               COMFYUI_SLOW: macbookpro.internal:8188


### PR DESCRIPTION
Root cause of the recall garbage, not a bandaid. memini distills every captured turn into a permanent semantic fact at write time (`MEMINI_DISTILL_ON_WRITE` was removed upstream, so this can't be turned off). The tiny 4B `memini-summary` masked it by extracting little; the 27B non-thinking `-chat` distiller that replaced it on 08-25 mints ~1 fact per capture and stamps 0.7 confidence on everything, so junk never decays below the 0.35 demotion threshold. Capture volume then rose with real usage (29→283 captures/week), yielding ~330 permanent facts/week, 92% never recalled more than twice. This switches the distiller to the thinking `qwen3.8-flash-next` so it actually exercises the prompt's "extract only DURABLE knowledge" and calibrates confidence, and gives it the headroom that silently killed the 08-25 thinking attempt (`MEMINI_LLM_MAX_TOKENS` — the 4096 default is consumed by reasoning and returns `errEmptyResponse`; `MEMINI_DISTILL_TIMEOUT` — 60s default). Weights assessed importance into recall salience (`MEMINI_ASSESSED_SALIENCE_WEIGHT`, was 0, so a 0.1-importance turn outranked real facts on similarity alone). Restores auto-capture and the 0.75 floor removed by the earlier bandaid.