### PR TITLE
feat(memini): faster debris demotion and lifecycle alerts

### DIFF
--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -45,6 +45,7 @@ spec:
               MEMINI_RERANK_MAX_CONCURRENCY: 2
               MEMINI_RERANK_TIMEOUT: 45s
               MEMINI_PROMOTE_MIN_ACCESS: "10"
+              MEMINI_DEMOTE_AFTER: 72h
               MEMINI_RERANK_POOL: "5"
               MEMINI_RERANK_MAX_DOC_CHARS: "1024"
               MEMINI_TIMEOUT_MS: "55000"

--- a/kubernetes/apps/base/llm/memini/prometheusrule.yaml
+++ b/kubernetes/apps/base/llm/memini/prometheusrule.yaml
@@ -36,3 +36,46 @@ spec:
               not keeping up with recall volume
           labels:
             severity: warning
+        - alert: MeminiFactMintingHigh
+          expr: |-
+            sum(increase(memini_store_upserts_total{op="insert",tier="semantic"}[1d])) > 30
+          for: 2h
+          annotations:
+            summary: >-
+              Memini minted {{ $value | printf "%.0f" }} durable facts in 24h — the distiller is
+              over-extracting (healthy baseline is 6-13/day)
+          labels:
+            severity: warning
+        - alert: MeminiLifecycleStalled
+          expr: |-
+            sum(increase(memini_store_upserts_total{op="insert",tier=~"semantic|procedural"}[7d])) > 100
+            and
+            sum(increase(memini_demoted_total[7d]) + increase(memini_dedup_tombstoned_total[7d])) < 5
+          for: 6h
+          annotations:
+            summary: >-
+              Memini is accumulating durable facts with almost no demotion or dedup — debris is
+              piling up in recall
+          labels:
+            severity: warning
+        - alert: MeminiDistillStalled
+          expr: |-
+            sum(increase(memini_store_upserts_total{op="insert",tier="episodic"}[6h])) > 10
+            and
+            sum(increase(memini_store_upserts_total{op="insert",tier="semantic"}[6h])) == 0
+          for: 1h
+          annotations:
+            summary: >-
+              Memini is capturing turns but distilling no facts — the distill LLM is likely
+              returning empty or unparseable output
+          labels:
+            severity: warning
+        - alert: MeminiConsolidateErrors
+          expr: |-
+            sum(increase(memini_consolidate_results_total{result="error"}[1h])) > 3
+          for: 30m
+          annotations:
+            summary: >-
+              Memini consolidation LLM calls are failing ({{ $value | printf "%.0f" }} errors/h)
+          labels:
+            severity: warning

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -530,7 +530,7 @@ data:
               fallback_on_error: true,
               timeout_ms: 60000,
               recall_limit: 3,
-              min_capture_chars: 200,
+              min_capture_chars: 24,
               expose_tools: true,
             },
           },


### PR DESCRIPTION
Prevents a repeat of the fact-factory backlog. Shortens `MEMINI_DEMOTE_AFTER` 168h→72h so never-recalled, low-confidence durable facts leave recall in three days instead of seven (this only works now that the thinking distiller calibrates confidence — the old uniform 0.7 never crossed the 0.35 demotion threshold). Adds four alerts on the modes that let ~330 junk facts/week accumulate unnoticed for weeks: semantic minting rate above 30/day, durable inserts with near-zero demotion/dedup over a week, episodic captures arriving with zero facts distilled (the silent empty-response/timeout failure), and consolidation LLM errors.