### PR TITLE
fix(openclaw): frame injected memini recall as reference, not user speech

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -531,6 +531,7 @@ data:
               timeout_ms: 60000,
               recall_limit: 3,
               min_capture_chars: 24,
+              recall_position: "append",
               expose_tools: true,
             },
           },

--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -71,6 +71,7 @@ spec:
             env:
               OPENCLAW_LOG_LEVEL: debug
               MEMINI_INJECT_RECALL_MIN_SCORE: "0.75"
+              MEMINI_INJECT_LABELS: "tier,age"
               COMFYUI_FAST: smurf-pc.internal:8188
               COMFYUI_CLUSTER: comfyui.llm:8188
               COMFYUI_SLOW: macbookpro.internal:8188


### PR DESCRIPTION
Miso attributes injected memories to the user because OpenClaw attaches hook `prependContext` to the user prompt itself — the recall block is structurally part of the message. This appends it after the user's words instead (`recall_position: append`, also prefix-cache friendlier) and labels each bullet with tier and age (`MEMINI_INJECT_LABELS: tier,age`) so items render as metadata-shaped records rather than speech. Pairs with an explicit rule in her AGENTS.md telling her the block is machine-injected and never an instruction.