### PR TITLE
fix(mosquitto): persist to the volume that is actually mounted

### DIFF
--- a/kubernetes/apps/base/home-automation/mosquitto/helmrelease.yaml
+++ b/kubernetes/apps/base/home-automation/mosquitto/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
             listener 1883
             per_listener_settings false
             persistence true
-            persistence_location /data
+            persistence_location /config/
     controllers:
       mosquitto:
         type: statefulset


### PR DESCRIPTION
`persistence_location` pointed at `/data`, but the only writable mount is the `config` volumeClaimTemplate at `/config` — so every autosave has been failing once a minute with `unable to open /data/mosquitto.db.new for writing: No such file or directory`, and the broker kept its entire retained set in memory only. That was invisible until celestia rebooted: mosquitto came back empty and took every retained `homeassistant/.../config` discovery topic with it, so Home Assistant lost the zigbee2mqtt devices even though zigbee2mqtt was healthy and still publishing state — discovery configs are only republished when z2m starts or sees `homeassistant/status` go online. This points `persistence_location` at `/config/` so the database lands on the PVC. Note the configMap change trips the reloader annotation and restarts mosquitto, which clears retained topics one last time, so restart zigbee2mqtt after it settles.