### PR TITLE
fix(openclaw): raise memini recall injection floor to 0.85

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -70,7 +70,7 @@ spec:
                 exec node dist/index.js gateway --bind lan
             env:
               OPENCLAW_LOG_LEVEL: debug
-              MEMINI_INJECT_RECALL_MIN_SCORE: "0.75"
+              MEMINI_INJECT_RECALL_MIN_SCORE: "0.85"
               MEMINI_INJECT_LABELS: "tier,age"
               COMFYUI_FAST: smurf-pc.internal:8188
               COMFYUI_CLUSTER: comfyui.llm:8188


### PR DESCRIPTION
Raise the memini recall injection floor from 0.75 to 0.85; the earlier calibration sweep measured 0.85 as the threshold that drops noise without losing relevant recalls. Injection only; capture and manual recall unaffected.