### PR TITLE
feat(openclaw): let Miso forget memories

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -118,7 +118,7 @@ data:
             workspace: "/home/node/.openclaw/workspace",
             agentDir: "/home/node/.openclaw/agents/main/agent",
             thinkingDefault: "adaptive",
-            tools: { alsoAllow: ["memory_recall", "memory_list", "memory_remember"] },
+            tools: { alsoAllow: ["memory_recall", "memory_list", "memory_remember", "memory_forget", "memory_briefing"] },
             identity: {
               name: "Miso",
               avatar: "avatars/miso_avatar.png",


### PR DESCRIPTION
Allows the memini `memory_forget` and `memory_briefing` tools on the main agent so she can delete wrong, stale, or poisoned recalls herself.