### PR TITLE
fix(litellm): repair local-pool-chat qwen DNS, demote gemma to last, drop response_format

### DIFF
--- a/kubernetes/apps/base/llm/litellm/models/local-pool-2.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-2.yaml
@@ -16,8 +16,11 @@ spec:
       temperature: 1.0
       top_p: 0.95
       top_k: 64
-      order: 2
+      order: 3
       max_parallel_requests: 4
+      drop_params: true
+      additional_drop_params:
+        - response_format
   info:
     mode: chat
     maxInputTokens: 262144

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-3.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-3.yaml
@@ -15,7 +15,7 @@ spec:
       top_p: 0.95
       top_k: 20
       min_p: 0
-      order: 3
+      order: 2
       max_parallel_requests: 1
   info:
     mode: chat

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-chat-1.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-chat-1.yaml
@@ -8,7 +8,7 @@ spec:
   proxyRef: litellm
   params:
     model: openai/qwen3.8-27b
-    apiBase: http://qwen3.8-27b.llm.svc.cluster.local:8080/v1
+    apiBase: http://qwen3-8-27b.llm.svc.cluster.local:8080/v1
     apiKey: sk-llmkube-noauth
     additional:
       temperature: 0.7

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-chat-2.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-chat-2.yaml
@@ -17,8 +17,11 @@ spec:
       top_p: 0.95
       top_k: 64
       reasoning_effort: none
-      order: 2
+      order: 3
       max_parallel_requests: 4
+      drop_params: true
+      additional_drop_params:
+        - response_format
       allowed_openai_params:
         - reasoning_effort
   info:

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-chat-3.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-chat-3.yaml
@@ -8,7 +8,7 @@ spec:
   proxyRef: litellm
   params:
     model: openai/qwen3.8-flash-next
-    apiBase: http://qwen3.8-flash-next.llm.svc.cluster.local:8080/v1
+    apiBase: http://qwen3-8-flash-next.llm.svc.cluster.local:8080/v1
     apiKey: sk-llmkube-noauth
     additional:
       temperature: 0.7
@@ -16,7 +16,7 @@ spec:
       presence_penalty: 1.5
       repetition_penalty: 1.0
       reasoning_effort: none
-      order: 3
+      order: 2
       max_parallel_requests: 1
       allowed_openai_params:
         - reasoning_effort


### PR DESCRIPTION
The GitHub Actions PR reviewer calls the `local-pool-chat` model group, and its requests were landing on **gemma (smurf-pc)** constantly — waking and hammering the gaming PC with 4 concurrent calls. Root-caused to three separate faults in the pool wiring:

### 1. DNS typo — the fire
`local-pool-chat-1` and `-3` pointed litellm at `http://qwen3**.**8-27b…` and `http://qwen3**.**8-flash-next…` (**dots**). The Services are `qwen3-8-27b` and `qwen3-8-flash-next` (**dashes**), so both primaries resolved to NXDOMAIN and every request failed with `InternalServerError: Connection error`, forcing failover all the way down to gemma. Verified from a litellm pod: `socket.gethostbyname("qwen3.8-27b.llm.svc.cluster.local")` → `Name or service not known`. The thinking `local-pool` was already dashed and correct — only the `-chat` members were wrong.

### 2. Order — gemma wasn't actually last
`order` failover *is* honored, but gemma was `order: 2`, ahead of `qwen3.8-flash-next` at `order: 3`. So when the 27b primary failed, gemma was preferred over the other qwen. Intent is "gemma only if **both** qwen are unavailable" → flash-next is now `order: 2`, gemma `order: 3` (last), in both pools.

### 3. `response_format` 400
When gemma *is* reached it 400s: LM Studio requires `response_format.type ∈ {json_schema, text}`, but the reviewer sends `json_object`. A 400 is non-retryable, so it halted the failover chain (litellm returned the 400 instead of trying the next member). Added `drop_params` + `additional_drop_params: [response_format]` on the gemma pool members so a last-resort gemma call degrades to a normal completion instead of a hard 400.

**Effect:** #1 puts `local-pool-chat` back on the qwen backends and gemma falls idle; #2 and #3 harden the failover path for when both qwen are genuinely down.

**Not touched (follow-up to consider):** the *standalone* `gemma-4-12b-it-qat` models (used by the foreman reviewer agents) would 400 the same way if they send `response_format` — left alone here since dropping it there could break their structured-output parsing, and there's no evidence they're failing.