### PR TITLE
fix(litellm): make z.ai primary for glm-5.3-flash

### DIFF
--- a/kubernetes/apps/base/llm/litellm/models/glm-5.3-flash-1.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/glm-5.3-flash-1.yaml
@@ -11,7 +11,7 @@ spec:
     apiBase: https://api.z.ai/api/coding/paas/v4
     apiKey: os.environ/ZAI_API_KEY
     additional:
-      order: 3
+      order: 1
       allowed_openai_params:
       - reasoning_effort
   info:


### PR DESCRIPTION
z.ai is the paid plan and becomes order 1; Hyper Charm (free 100 credits/month) drops to order 2 as fallback. It had been serving all glm-5.3-flash traffic because no order 1 existed.