### PR TITLE
fix(gemma): point gemma-wake at Unsloth Studio on smurf-pc

### DIFF
--- a/kubernetes/apps/base/llm/gemma-wake/configmap.yaml
+++ b/kubernetes/apps/base/llm/gemma-wake/configmap.yaml
@@ -20,11 +20,11 @@ data:
     broadcast_ip = "10.69.1.255"
     wol_port = 9
     # Liveness uses the 10G SFP NIC, which carries LM Studio traffic.
-    health_check = "tcp://smurf-pc.internal:1234"
+    health_check = "tcp://192.168.30.14:8889"
 
     [[routes]]
     machine = "smurf-pc"
     hostname = "gemma-wake.llm"
     # Proxy traffic uses the 10G SFP NIC rather than the WoL NIC.
-    destination = "http://smurf-pc.internal:1234"
-    health_check = "tcp://smurf-pc.internal:1234"
+    destination = "http://192.168.30.14:8889"
+    health_check = "tcp://192.168.30.14:8889"

--- a/kubernetes/apps/base/llm/litellm/models/gemma-4-12b-it-qat-chat.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/gemma-4-12b-it-qat-chat.yaml
@@ -7,7 +7,7 @@ spec:
   modelName: gemma-4-12b-it-qat-chat
   proxyRef: litellm
   params:
-    model: openai/gemma-4-12b-it-qat
+    model: openai/unsloth/gemma-4-12B-it-qat-GGUF
     apiBase: http://gemma-wake.llm:8080/v1
     apiKey: sk-noauth
     additional:

--- a/kubernetes/apps/base/llm/litellm/models/gemma-4-12b-it-qat.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/gemma-4-12b-it-qat.yaml
@@ -7,7 +7,7 @@ spec:
   modelName: gemma-4-12b-it-qat
   proxyRef: litellm
   params:
-    model: openai/gemma-4-12b-it-qat
+    model: openai/unsloth/gemma-4-12B-it-qat-GGUF
     apiBase: http://gemma-wake.llm:8080/v1
     apiKey: sk-noauth
     additional:


### PR DESCRIPTION
Unsloth Studio replaces LM Studio on smurf-pc: it serves on :8889 and rejects hostname Host headers, so gemma-wake targets the raw IP 192.168.30.14, and the served model id becomes unsloth/gemma-4-12B-it-qat-GGUF. WOL unchanged.