### PR TITLE
fix(gemma): authenticate to Unsloth Studio, restore DNS, auto-reload

### DIFF
--- a/kubernetes/apps/base/llm/gemma-wake/configmap.yaml
+++ b/kubernetes/apps/base/llm/gemma-wake/configmap.yaml
@@ -20,11 +20,11 @@ data:
     broadcast_ip = "10.69.1.255"
     wol_port = 9
     # Liveness uses the 10G SFP NIC, which carries LM Studio traffic.
-    health_check = "tcp://192.168.30.14:8889"
+    health_check = "tcp://smurf-pc.internal:8889"
 
     [[routes]]
     machine = "smurf-pc"
     hostname = "gemma-wake.llm"
     # Proxy traffic uses the 10G SFP NIC rather than the WoL NIC.
-    destination = "http://192.168.30.14:8889"
-    health_check = "tcp://192.168.30.14:8889"
+    destination = "http://smurf-pc.internal:8889"
+    health_check = "tcp://smurf-pc.internal:8889"

--- a/kubernetes/apps/base/llm/gemma-wake/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/gemma-wake/helmrelease.yaml
@@ -22,6 +22,8 @@ spec:
         runAsUser: 65532
     controllers:
       gemma-wake:
+        annotations:
+          reloader.stakater.com/auto: "true"
         strategy: Recreate
         containers:
           app:

--- a/kubernetes/apps/base/llm/litellm/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/litellm/externalsecret.yaml
@@ -21,6 +21,7 @@ spec:
         MINIMAX_API_KEY: "{{ .MINIMAX_API_KEY }}"
         NEURALWATT_API_KEY: "{{ .NEURALWATT_API_KEY }}"
         ZAI_API_KEY: "{{ .ZAI_API_KEY }}"
+        UNSLOTH_API_KEY: "{{ .UNSLOTH_API_KEY }}"
   dataFrom:
     - extract:
         key: Charm Hyper
@@ -34,6 +35,8 @@ spec:
         key: neuralwatt
     - extract:
         key: z.ai
+    - extract:
+        key: unsloth studio
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1

--- a/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
+++ b/kubernetes/apps/base/llm/litellm/litellmproxy.yaml
@@ -134,6 +134,7 @@ spec:
     - MINIMAX_API_KEY
     - NEURALWATT_API_KEY
     - ZAI_API_KEY
+    - UNSLOTH_API_KEY
     - REDIS_HOST
     - REDIS_PORT
   apiAccess:

--- a/kubernetes/apps/base/llm/litellm/models/gemma-4-12b-it-qat-chat.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/gemma-4-12b-it-qat-chat.yaml
@@ -9,7 +9,7 @@ spec:
   params:
     model: openai/unsloth/gemma-4-12B-it-qat-GGUF
     apiBase: http://gemma-wake.llm:8080/v1
-    apiKey: sk-noauth
+    apiKey: os.environ/UNSLOTH_API_KEY
     additional:
       timeout: 300
       num_retries: 3

--- a/kubernetes/apps/base/llm/litellm/models/gemma-4-12b-it-qat.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/gemma-4-12b-it-qat.yaml
@@ -9,7 +9,7 @@ spec:
   params:
     model: openai/unsloth/gemma-4-12B-it-qat-GGUF
     apiBase: http://gemma-wake.llm:8080/v1
-    apiKey: sk-noauth
+    apiKey: os.environ/UNSLOTH_API_KEY
     additional:
       timeout: 300
       num_retries: 1


### PR DESCRIPTION
Unsloth Studio needs a valid API key; with one it accepts hostname requests, so gemma-wake goes back to smurf-pc.internal:8889 (no hardcoded IP). Wires UNSLOTH_API_KEY from the new 'unsloth studio' 1Password item through the litellm ExternalSecret + env allowlist to both gemma apiKeys, and adds the reloader annotation so gemma-wake config changes roll automatically.