### PR TITLE
feat(openclaw): memini plugin 0.7.24 — per-agent opt-out, capture skip, context isolation

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -533,6 +533,13 @@ data:
               min_capture_chars: 24,
               recall_position: "append",
               expose_tools: true,
+              agents: {
+                sage: { capture: false, recall: false },
+              },
+              capture_skip_patterns: [
+                "type: image generation task",
+                "[System] Your previous turn was interrupted",
+              ],
             },
           },
         },

--- a/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
                 # only fetches when the pinned version differs from what's on the
                 # persistent volume, so normal restarts stay offline.
                 # ClawHub's latest published Memini artifact. Git tags can lead it.
-                MEMINI_PLUGIN_VERSION=0.7.22
+                MEMINI_PLUGIN_VERSION=0.7.24
                 if [ "$(cat "$HOME/.openclaw/extensions/memini/.clawver" 2>/dev/null)" != "$MEMINI_PLUGIN_VERSION" ]; then
                   if node dist/index.js plugins install "clawhub:@eleboucher/memini@$MEMINI_PLUGIN_VERSION" --force --accept-capabilities --acknowledge-install-policy-warning; then
                     printf '%s' "$MEMINI_PLUGIN_VERSION" > "$HOME/.openclaw/extensions/memini/.clawver"


### PR DESCRIPTION
DRAFT — hold until ClawHub publishes @eleboucher/memini@0.7.24 (has 0.7.23 at prep; the new config keys crashloop the 0.7.22 allowlist). Bumps the OpenClaw plugin, opts Sage out of capture+recall, and adds capture_skip_patterns for the image-gen-task and gateway-restart turn markers. 0.7.24 also natively isolates recalled context from the user prompt and enforces relevance gates.