### PR TITLE
fix(embed): align memini + toolhive embedders to one spec

### DIFF
--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
               MEMINI_EMBED_MODEL: memini-embed # Qwen3-Embedding-0.6B, 1024-dim, 32k ctx
               MEMINI_EMBED_DIMS: "1024"
               MEMINI_EMBED_QUERY_PREFIX: "Instruct: Given a user message, retrieve relevant past memories\nQuery: "
-              MEMINI_EMBED_MAX_CONCURRENCY: 2
+              MEMINI_EMBED_MAX_CONCURRENCY: 32
               MEMINI_RECALL_EMBED_TIMEOUT: 15s
               MEMINI_WRITE_DEDUP_SCORE: "0.80"
               MEMINI_WRITE_DEDUP_ACTION: coalesce

--- a/kubernetes/apps/base/llm/memini/memini-embed.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-embed.yaml
@@ -36,6 +36,7 @@ spec:
           cpu-inference: "true"
   contextSize: 32768
   parallelSlots: 32
+  flashAttention: true
   batchSize: 2048
   uBatchSize: 2048
   env:
@@ -45,12 +46,14 @@ spec:
       value: "granularity=fine,proc_list=[0-11],explicit"
   resources:
     cpu: "2"
-    memory: 8Gi
+    memory: 6Gi
   mode: embedding
   extraArgs:
     - --alias
     - memini-embed
     - --cont-batching
+    - --cache-ram
+    - "0"
     - --kv-unified
     - --threads
     - "6"

--- a/kubernetes/apps/base/llm/memini/memini-embed.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-embed.yaml
@@ -35,9 +35,9 @@ spec:
         matchLabels:
           cpu-inference: "true"
   contextSize: 32768
-  parallelSlots: 2
-  batchSize: 16384
-  uBatchSize: 16384
+  parallelSlots: 32
+  batchSize: 2048
+  uBatchSize: 2048
   env:
     - name: GOMP_CPU_AFFINITY
       value: "0-11"
@@ -51,6 +51,7 @@ spec:
     - --alias
     - memini-embed
     - --cont-batching
+    - --kv-unified
     - --threads
     - "6"
     - --threads-batch

--- a/kubernetes/apps/base/llm/toolhive/config/toolhive-embed.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/toolhive-embed.yaml
@@ -37,8 +37,8 @@ spec:
   contextSize: 32768
   parallelSlots: 32
   flashAttention: true
-  batchSize: 1024
-  uBatchSize: 1024
+  batchSize: 2048
+  uBatchSize: 2048
   env:
     - name: GOMP_CPU_AFFINITY
       value: "0-11"
@@ -52,6 +52,8 @@ spec:
     - --alias
     - toolhive-embed
     - --cont-batching
+    - --cache-ram
+    - "0"
     - --kv-unified
     - --threads
     - "6"


### PR DESCRIPTION
Aligns the two CPU embedders (same model, both 32 slots + --kv-unified now) to a byte-identical InferenceService modulo name: batch/ubatch 2048 (covers memini's 1269-token max input; toolhive was 1024), flashAttention, --cache-ram 0 (embedders get ~0% prompt-cache hit; it had been dropped from both), cpu 2 / 6Gi, and MEMINI_EMBED_MAX_CONCURRENCY 2->32 so memini uses the slots. Sets up collapsing both into one shared 3-replica embedder like rerank.