### PR TITLE
fix(searxng): wire Brave API secret

### DIFF
--- a/kubernetes/apps/base/llm/searxng/configmap.yaml
+++ b/kubernetes/apps/base/llm/searxng/configmap.yaml
@@ -95,10 +95,12 @@ data:
       # it here and providing api_key routes Brave queries through the official API.
       # The key is injected at apply time: Flux postBuild.substituteFrom reads the
       # searxng Brave key from the searxng ExternalSecret (1Password-backed).
+      - name: brave
+        disabled: true
       - name: braveapi
         disabled: false
         inactive: false
-        api_key: $${BRAVE_API_KEY}
+        api_key: ${BRAVE_API_KEY}
 
   limiter.toml: |
     [real_ip]

--- a/kubernetes/apps/main/llm/searxng.yaml
+++ b/kubernetes/apps/main/llm/searxng.yaml
@@ -16,6 +16,11 @@ spec:
   postBuild:
     substitute:
       APP: *app
+    substituteFrom:
+      # The ExternalSecret is created by this Kustomization; allow it to bootstrap.
+      - kind: Secret
+        name: searxng
+        optional: true
   wait: false
   prune: true
   sourceRef:


### PR DESCRIPTION
The live SearXNG pod was receiving the literal `${BRAVE_API_KEY}`, so the Brave API fallback returned `SUBSCRIPTION_TOKEN_INVALID`. Restore Flux Secret substitution, use the actual substitution expression, and disable the rate-limited HTML Brave engine.

No secret values are present in the diff.

Validation: `flate test all --path ./kubernetes/clusters/main`; the SearXNG checks pass. The full run has 420 passes plus 16 unrelated OCI credential failures and 1 dependent block.