### PR TITLE
feat(llm): ModelPool for the 3090, qwen3.8-27b <-> muse-glimmer

### DIFF
--- a/kubernetes/apps/base/games/games-on-whales/README.md
+++ b/kubernetes/apps/base/games/games-on-whales/README.md
@@ -4,8 +4,11 @@ GPU game streaming on ganyu's RTX 3090, sharing the GPU with `qwen3.8-27b`.
 
 ## What works
 
-- **GPU time-slicing** — the 3090 advertises `nvidia.com/gpu: 2`
-  (`kube-system/nvidia-device-plugin`).
+- ~~GPU time-slicing~~ — REMOVED. The 3090 now advertises `nvidia.com/gpu: 1`
+  so the LLM `ModelPool` (`llm/nvidia`) can gate its members on the device. A
+  Wolf session needs two grants (the `wolf` pod plus the app pod), so sessions
+  will sit `Pending` until this is re-thought (one grant per session, or a
+  DRA-style shared claim).
 - **PriorityClass preemption** — `qwen3.8-27b` runs at `gpu-preemptible`
   (-100); launching a session preempts it to free the GPU, and it reloads when
   the session ends. Validated live: a Steam session evicted `qwen3.8-27b`.

--- a/kubernetes/apps/base/kube-system/nvidia-device-plugin/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/nvidia-device-plugin/helmrelease.yaml
@@ -12,6 +12,18 @@ spec:
   values:
     runtimeClassName: nvidia
     failOnInitError: false
+    # config:
+    #   default: timeslice
+    #   map:
+    #     timeslice: |-
+    #       version: v1
+    #       flags:
+    #         migStrategy: none
+    #       sharing:
+    #         timeSlicing:
+    #           resources:
+    #             - name: nvidia.com/gpu
+    #               replicas: 2
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/apps/base/kube-system/nvidia-device-plugin/helmrelease.yaml
+++ b/kubernetes/apps/base/kube-system/nvidia-device-plugin/helmrelease.yaml
@@ -12,18 +12,6 @@ spec:
   values:
     runtimeClassName: nvidia
     failOnInitError: false
-    config:
-      default: timeslice
-      map:
-        timeslice: |-
-          version: v1
-          flags:
-            migStrategy: none
-          sharing:
-            timeSlicing:
-              resources:
-                - name: nvidia.com/gpu
-                  replicas: 2
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/kubernetes/apps/base/llm/litellm/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
   - ./litellmproxy.yaml
   - ./virtualkeys
   - ./qwen3.8-27b.yaml
+  - ./muse-glimmer.yaml
+  - ./nvidia-pool.yaml
   - ./qwen3.8-flash-next.yaml
   # - ./qwen3.6-35b-a3b.yaml
   # - ./nemotron-3.5-lightning-30b-a3b.yaml

--- a/kubernetes/apps/base/llm/litellm/models/implementation-pool-3.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/implementation-pool-3.yaml
@@ -8,7 +8,7 @@ spec:
   proxyRef: litellm
   params:
     model: openai/qwen3.8-27b
-    apiBase: http://qwen3.8-27b.llm.svc.cluster.local:8080/v1
+    apiBase: http://nvidia-router-proxy.llm.svc.cluster.local:8080/v1
     apiKey: sk-llmkube-noauth
     additional:
       temperature: 1.0

--- a/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
@@ -33,6 +33,8 @@ resources:
   - ./minimax-m2.7.yaml
   - ./minimax-m3.yaml
   - ./minimax-m3-chat.yaml
+  - ./muse-glimmer.yaml
+  - ./qwen3.8-27b.yaml
   - ./qwen3.8-27b-chat.yaml
   - ./qwen3.8-flash-next-chat.yaml
   - ./reasoning-pool-1.yaml

--- a/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
@@ -34,6 +34,7 @@ resources:
   - ./minimax-m3.yaml
   - ./minimax-m3-chat.yaml
   - ./muse-glimmer.yaml
+  - ./muse-glimmer-chat.yaml
   - ./qwen3.8-27b.yaml
   - ./qwen3.8-27b-chat.yaml
   - ./qwen3.8-flash-next-chat.yaml

--- a/kubernetes/apps/base/llm/litellm/models/local-pool-1.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-1.yaml
@@ -8,7 +8,7 @@ spec:
   proxyRef: litellm
   params:
     model: openai/qwen3.8-27b
-    apiBase: http://qwen3-8-27b.llm.svc.cluster.local:8080/v1
+    apiBase: http://nvidia-router-proxy.llm.svc.cluster.local:8080/v1
     apiKey: sk-llmkube-noauth
     additional:
       temperature: 1.0

--- a/kubernetes/apps/base/llm/litellm/models/muse-glimmer-chat.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/muse-glimmer-chat.yaml
@@ -14,9 +14,9 @@ spec:
       temperature: 1.0
       top_p: 0.95
       top_k: 64
-      reasoning_effort: none
-      allowed_openai_params:
-        - reasoning_effort
+      extra_body:
+        chat_template_kwargs:
+          reasoning_strength: low
       max_parallel_requests: 2
   info:
     mode: chat

--- a/kubernetes/apps/base/llm/litellm/models/muse-glimmer-chat.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/muse-glimmer-chat.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: muse-glimmer-chat
+spec:
+  modelName: muse-glimmer-chat
+  proxyRef: litellm
+  params:
+    model: openai/muse-glimmer
+    apiBase: http://nvidia-router-proxy.llm.svc.cluster.local:8080/v1
+    apiKey: sk-llmkube-noauth
+    additional:
+      temperature: 1.0
+      top_p: 0.95
+      top_k: 64
+      reasoning_effort: none
+      allowed_openai_params:
+        - reasoning_effort
+      max_parallel_requests: 2
+  info:
+    mode: chat
+    maxInputTokens: 131072
+    maxOutputTokens: 20480
+    supportsFunctionCalling: true
+    supportsVision: true
+    extra:
+      input_cost_per_token: 6.2e-08
+      output_cost_per_token: 1.35e-06
+      cache_read_input_token_cost: 0.0

--- a/kubernetes/apps/base/llm/litellm/models/muse-glimmer.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/muse-glimmer.yaml
@@ -2,27 +2,22 @@
 apiVersion: litellm.home-operations.com/v1alpha1
 kind: LiteLLMModel
 metadata:
-  name: local-pool-chat-1
+  name: muse-glimmer
+  labels:
+    litellm.home-operations.com/managed-by: flux
 spec:
-  modelName: local-pool-chat
+  modelName: muse-glimmer
   proxyRef: litellm
   params:
-    model: openai/qwen3.8-27b
+    model: openai/muse-glimmer
     apiBase: http://nvidia-router-proxy.llm.svc.cluster.local:8080/v1
     apiKey: sk-llmkube-noauth
     additional:
-      temperature: 0.7
-      top_p: 0.8
-      presence_penalty: 1.5
-      reasoning_effort: none
-      order: 1
       max_parallel_requests: 2
-      allowed_openai_params:
-        - reasoning_effort
   info:
     mode: chat
     maxInputTokens: 131072
-    maxOutputTokens: 40960
+    maxOutputTokens: 20480
     supportsFunctionCalling: true
     supportsVision: true
     extra:

--- a/kubernetes/apps/base/llm/litellm/models/qwen3.8-27b-chat.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/qwen3.8-27b-chat.yaml
@@ -8,7 +8,7 @@ spec:
   proxyRef: litellm
   params:
     model: openai/qwen3.8-27b
-    apiBase: http://qwen3-8-27b.llm.svc.cluster.local:8080/v1
+    apiBase: http://nvidia-router-proxy.llm.svc.cluster.local:8080/v1
     apiKey: sk-llmkube-noauth
     additional:
       temperature: 0.7

--- a/kubernetes/apps/base/llm/litellm/models/qwen3.8-27b.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/qwen3.8-27b.yaml
@@ -2,23 +2,18 @@
 apiVersion: litellm.home-operations.com/v1alpha1
 kind: LiteLLMModel
 metadata:
-  name: local-pool-chat-1
+  name: qwen3.8-27b
+  labels:
+    litellm.home-operations.com/managed-by: flux
 spec:
-  modelName: local-pool-chat
+  modelName: qwen3.8-27b
   proxyRef: litellm
   params:
     model: openai/qwen3.8-27b
     apiBase: http://nvidia-router-proxy.llm.svc.cluster.local:8080/v1
     apiKey: sk-llmkube-noauth
     additional:
-      temperature: 0.7
-      top_p: 0.8
-      presence_penalty: 1.5
-      reasoning_effort: none
-      order: 1
       max_parallel_requests: 2
-      allowed_openai_params:
-        - reasoning_effort
   info:
     mode: chat
     maxInputTokens: 131072

--- a/kubernetes/apps/base/llm/litellm/muse-glimmer.yaml
+++ b/kubernetes/apps/base/llm/litellm/muse-glimmer.yaml
@@ -5,6 +5,8 @@ metadata:
   name: muse-glimmer
 spec:
   source: hf://meta-models/Muse-Glimmer-30B-GGUF
+  sourceSecretRef:
+    name: huggingface
   files:
     - Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf
     - dflash-Muse-Glimmer-30B-Q4_K_M.gguf

--- a/kubernetes/apps/base/llm/litellm/muse-glimmer.yaml
+++ b/kubernetes/apps/base/llm/litellm/muse-glimmer.yaml
@@ -2,15 +2,16 @@
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
 metadata:
-  name: qwen3.8-27b
+  name: muse-glimmer
 spec:
-  source: hf://unsloth/Qwen3.8-27B-GGUF
+  source: hf://meta-models/Muse-Glimmer-30B-GGUF
   files:
-    - Qwen3.8-27B-UD-Q4_K_XL.gguf
-    - mmproj-F16.gguf
-  mmproj: mmproj-F16.gguf
+    - Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf
+    - dflash-Muse-Glimmer-30B-Q4_K_M.gguf
+    - mmproj-Muse-Glimmer-30B-Q4_K_M.gguf
+  mmproj: mmproj-Muse-Glimmer-30B-Q4_K_M.gguf
   format: gguf
-  quantization: UD-Q4_K_XL
+  quantization: Q4_K_M
   hardware:
     accelerator: cuda
     gpu:
@@ -22,11 +23,11 @@ spec:
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
 metadata:
-  name: qwen3.8-27b
+  name: muse-glimmer
   labels:
     krr/ignore: "true"
 spec:
-  modelRef: qwen3.8-27b
+  modelRef: muse-glimmer
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:5ebb7a55e3d38e5fe185346fcd908033e69c035ad49b33df0066eb7cf4f7b06b
   rolloutPolicy:
@@ -39,29 +40,28 @@ spec:
   env:
     - name: NVIDIA_DRIVER_CAPABILITIES
       value: compute,utility
-  # contextSize: 140000
   contextSize: 131072
   flashAttention: true
   jinja: true
-  # parallelSlots: 1
   parallelSlots: 2
   batchSize: 4096
   uBatchSize: 1024
-  cacheTypeK: q8_0
-  cacheTypeV: q8_0
-  reasoningBudget: 32768
+  cacheTypeK: f16
+  cacheTypeV: f16
+  reasoningBudget: 16384
   reasoningBudgetMessage: "Stop reasoning and produce the implementation, tool call, or final answer."
   resources:
     gpu: 1
     cpu: "500m"
     memory: 48Gi
   speculativeDecoding:
-    type: draft-mtp
-    nDraftMax: 2
+    type: draft-dflash
+    draftModel: dflash-Muse-Glimmer-30B-Q4_K_M.gguf
+    nDraftMax: 15
     pMin: 0.75
   extraArgs:
     - --alias
-    - qwen3.8-27b
+    - muse-glimmer
     - --no-mmproj-offload
     - --image-min-tokens
     - "1024"
@@ -70,35 +70,23 @@ spec:
     - q8_0
     - --spec-draft-type-v
     - q8_0
-    - -sps
-    - "0.75"
     - --cache-prompt
     - --cache-ram
     - "40960"
     - --kv-unified
     - --temp
-    - "1"
+    - "1.0"
     - --top-p
     - "0.95"
     - --top-k
-    - "20"
-    - --min-p
-    - "0"
-    - --presence-penalty
-    - "0"
-    - --repeat-penalty
-    - "1"
+    - "64"
+    - --reasoning-preserve
     - --threads
     - "6"
     - --threads-batch
     - "12"
     - --load-mode
     - none
-    - --chat-template-kwargs
-    - '{"reasoning_effort":"medium"}'
-    - --reasoning-preserve
-    - --n-predict
-    - "40960"
   endpoint:
     port: 8080
     type: ClusterIP

--- a/kubernetes/apps/base/llm/litellm/nvidia-pool.yaml
+++ b/kubernetes/apps/base/llm/litellm/nvidia-pool.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: ModelPool
+metadata:
+  name: nvidia
+spec:
+  nodeSelector:
+    topology.kubernetes.io: egpu
+  gpu: 1
+  swapPolicy: sticky
+  swapBudget: 600s
+  default: qwen3.8-27b
+  members:
+    - inferenceServiceRef:
+        name: qwen3.8-27b
+    - inferenceServiceRef:
+        name: muse-glimmer
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: ModelRouter
+metadata:
+  name: nvidia
+spec:
+  defaultRouteStrategy: BackendNameMatch
+  defaultRoute: qwen38-27b
+  backends:
+    - name: qwen38-27b
+      displayName: qwen3.8-27b
+      inferenceServiceRef:
+        name: qwen3.8-27b
+      capabilities: ["tools", "vision"]
+    - name: muse-glimmer
+      inferenceServiceRef:
+        name: muse-glimmer
+      capabilities: ["tools", "vision"]
+  proxy:
+    replicas: 1
+    responseHeaderTimeout: 600s

--- a/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
+++ b/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
@@ -5,6 +5,8 @@ metadata:
   name: qwen3.8-27b
 spec:
   source: hf://unsloth/Qwen3.8-27B-GGUF
+  sourceSecretRef:
+    name: huggingface
   files:
     - Qwen3.8-27B-UD-Q4_K_XL.gguf
     - mmproj-F16.gguf

--- a/kubernetes/apps/base/llm/litellm/qwen3.8-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/qwen3.8-flash-next.yaml
@@ -111,7 +111,7 @@ spec:
     - --load-mode
     - mmap
     - --tensor-read-lazy
-    - on
+    - "on"
     - --chat-template-kwargs
     - '{"reasoning_effort":"medium"}'
     - --reasoning-preserve

--- a/kubernetes/apps/base/llm/litellm/qwen3.8-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/qwen3.8-flash-next.yaml
@@ -5,6 +5,8 @@ metadata:
   name: qwen3.8-flash-next
 spec:
   source: hf://unsloth/Qwen3.8-Flash-Next-GGUF
+  sourceSecretRef:
+    name: huggingface
   files:
     - UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00001-of-00003.gguf
     - UD-IQ4_XS/Qwen3.8-Flash-Next-UD-IQ4_XS-00002-of-00003.gguf

--- a/kubernetes/apps/base/llm/llmkube/README.md
+++ b/kubernetes/apps/base/llm/llmkube/README.md
@@ -115,8 +115,10 @@ cached file is kept forever. Changing the `source` URL forces a fresh download
 
 **Caveats**
 
-- **No HF token** in this path — works for public GGUFs (unsloth, mradermacher).
-  Gated/private repos must be pre-staged (Option B).
+- Set `spec.sourceSecretRef: {name: huggingface}` so the downloader sends the
+  `HF_TOKEN` from the `huggingface` Secret (litellm ExternalSecret) as a bearer
+  on huggingface.co requests: gated repos work and authenticated pulls skip the
+  anonymous rate limits. The token is never forwarded off huggingface.co.
 - **Single file only.** Multimodal models needing a separate `mmproj-*.gguf`
   can't be expressed as one `source` — pre-stage them (Option B).
 

--- a/kubernetes/apps/base/llm/llmkube/README.md
+++ b/kubernetes/apps/base/llm/llmkube/README.md
@@ -64,16 +64,29 @@ GPU access depends on the target:
   (`llmkube/resourceclaim.yaml`).
 - **NVIDIA** — no claim; request `gpu: { count: 1 }` on the hardware block.
 
-## The 3090: single always-on tenant
+## The 3090: a ModelPool
 
-The egpu / RTX 3090 runs one `InferenceService` permanently — `qwen3.8-27b`
-(Qwen3.6-27B, `replicas: 1`). It serves the `nvidia` coding model and acts as a
-LiteLLM fallback for `self-hosted`.
+The egpu / RTX 3090 is one exclusive slot shared by a `ModelPool`
+(`litellm/nvidia-pool.yaml`): `qwen3.8-27b` (default resident) and
+`muse-glimmer`. At most one member is `Ready`; the operator holds the other at
+`replicas: 0` / `Stopped` — that is the normal held state, not a failure. Do
+not set `replicas` on a pooled InferenceService in git; the pool controller and
+the router own that field.
 
-There's no burst-swap (the old `burst-watcher` + `qwen3.8-27b-gemma` were
-retired): the card holds one model, so spinning a second up meant tearing Qwen
-down — too slow, and it took `nvidia` offline for too long. The card stays warm
-for `nvidia` traffic throughout.
+Swaps are demand-driven through the `nvidia` `ModelRouter` (service
+`nvidia-router-proxy.llm:8080`, `BackendNameMatch` on the request's `model`).
+A request for the stopped member is held open while the incumbent drains
+(`/slots` idle check, fail-closed) and unloads, then the target cold-loads
+(`swapBudget: 600s`, then 503 + Retry-After). Sticky policy: the resident stays
+until the *other* model is asked for. LiteLLM therefore points every 3090-backed
+model at the router, never at a member's own Service, and both members have
+explicit `LiteLLMModel` CRs in `litellm/models/` because the litellm-operator's
+auto-projection drops a model when its InferenceService goes `Stopped`. Those CRs
+carry `litellm.home-operations.com/managed-by: flux` so the projection sees a
+model it does not own and leaves it alone.
+
+The device plugin no longer time-slices the card (`nvidia.com/gpu: 1`), so a
+displaced member cannot co-schedule onto a busy card.
 
 ### Option A — let the operator download it (preferred for new models)
 

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -178,7 +178,7 @@ data:
             tools: { allow: ["web_fetch", "web_search", "view_image", "chart_generate", "youtube_tldw", "reddit_thread", "facebook_listing", "sage_runtime_status", "sage_office_temperature", "sage_reference_remember", "memory_recall", "memory_list"] },
             thinkingDefault: "low",
             model: {
-              primary: "litellm/muse-glimmer",
+              primary: "litellm/muse-glimmer-chat",
               fallbacks: [
                 "litellm/qwen3.8-27b-chat",
                 "litellm/qwen3.8-flash-next-chat",

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -178,8 +178,9 @@ data:
             tools: { allow: ["web_fetch", "web_search", "view_image", "chart_generate", "youtube_tldw", "reddit_thread", "facebook_listing", "sage_runtime_status", "sage_office_temperature", "sage_reference_remember", "memory_recall", "memory_list"] },
             thinkingDefault: "low",
             model: {
-              primary: "litellm/qwen3.8-27b-chat",
+              primary: "litellm/muse-glimmer",
               fallbacks: [
+                "litellm/qwen3.8-27b-chat",
                 "litellm/qwen3.8-flash-next-chat",
               ],
             },

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -175,7 +175,7 @@ data:
             name: "Sage",
             workspace: "/home/node/.openclaw/workspace-sage",
             agentDir: "/home/node/.openclaw/agents/sage/agent",
-            tools: { allow: ["web_fetch", "web_search", "view_image", "chart_generate", "youtube_tldw", "reddit_thread", "facebook_listing", "sage_runtime_status", "sage_office_temperature", "sage_reference_remember", "memory_recall", "memory_list"] },
+            tools: { allow: ["message", "web_fetch", "web_search", "view_image", "chart_generate", "youtube_tldw", "reddit_thread", "facebook_listing", "sage_runtime_status", "sage_office_temperature", "sage_reference_remember", "memory_recall", "memory_list"] },
             thinkingDefault: "low",
             model: {
               primary: "litellm/muse-glimmer-chat",

--- a/kubernetes/apps/main/games/kustomization.yaml
+++ b/kubernetes/apps/main/games/kustomization.yaml
@@ -10,7 +10,7 @@ replacements:
 resources:
   # - ./core-keeper.yaml
   # - ./enshrouded.yaml
-  - ./games-on-whales.yaml
+  # - ./games-on-whales.yaml
   - ./minecraft.yaml
   - ./palworld.yaml
   - ./romm.yaml


### PR DESCRIPTION
Turns the 3090 into an LLMKube ModelPool so qwen3.8-27b and muse-glimmer swap on demand. The device plugin stops time-slicing (nvidia.com/gpu goes 2 to 1) so a displaced member cannot land on a busy card; a sticky ModelPool holds qwen3.8-27b as the default resident and a ModelRouter (nvidia-router-proxy.llm:8080, BackendNameMatch) holds a request for the stopped member while the incumbent drains and unloads, then cold-loads it (swapBudget 600s). LiteLLM's 3090-backed rungs move from the member Service to the router, both members get explicit LiteLLMModel CRs labelled managed-by flux so the litellm-operator projection does not delete or overwrite them when a member goes Stopped, and qwen3.8-27b drops its pinned replicas since the pool owns that field. muse-glimmer is restored from the September cleanup with the renamed GGUFs and the draft model expressed through speculativeDecoding; the pinned server-cuda image is b10884, past the b10353 it needs. Games-on-Whales sessions need two GPU grants and will sit Pending until re-thought; noted in its README.