### PR TITLE
fix(llm): embedders get 8Gi; memini-embed was thrashing at its 6Gi limit

### DIFF
--- a/kubernetes/apps/base/llm/memini/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/memini/helmrelease.yaml
@@ -28,6 +28,7 @@ spec:
               MEMINI_EMBED_QUERY_PREFIX: "Instruct: Given a user message, retrieve relevant past memories\nQuery: "
               MEMINI_EMBED_MAX_CONCURRENCY: 32
               MEMINI_RECALL_EMBED_TIMEOUT: 15s
+              MEMINI_WRITE_EMBED_TIMEOUT: 30s
               MEMINI_WRITE_DEDUP_SCORE: "0.80"
               MEMINI_WRITE_DEDUP_ACTION: coalesce
               MEMINI_DEDUP_TIERS: episodic,semantic,procedural

--- a/kubernetes/apps/base/llm/memini/memini-embed.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-embed.yaml
@@ -46,7 +46,7 @@ spec:
       value: "granularity=fine,proc_list=[0-11],explicit"
   resources:
     cpu: "2"
-    memory: 6Gi
+    memory: 8Gi
   mode: embedding
   extraArgs:
     - --alias

--- a/kubernetes/apps/base/llm/toolhive/config/toolhive-embed.yaml
+++ b/kubernetes/apps/base/llm/toolhive/config/toolhive-embed.yaml
@@ -46,7 +46,7 @@ spec:
       value: "granularity=fine,proc_list=[0-11],explicit"
   resources:
     cpu: "2"
-    memory: 6Gi
+    memory: 8Gi
   mode: embedding
   extraArgs:
     - --alias


### PR DESCRIPTION
Raises memini-embed and toolhive-embed to 8Gi (request and limit under llmkube 0.9.25) and sets MEMINI_WRITE_EMBED_TIMEOUT to 30s. After #9973 memini-embed's working set pinned at exactly 6.0 GiB with the container taking 1,300 to 2,000 major page faults a second as the cgroup evicted the mmapped model: throughput fell from about 300 tokens/s to 11 over the evening, every embed took 4 to 5 seconds, and memini's 5s write-embed deadline turned that into MeminiEmbedErrors plus a share of ganyu's NodeMemoryMajorPagesFaults. The 32-slot unified KV alone is 3.5 GiB on this model; 8Gi leaves room for it plus the mmapped weights and compute buffers. toolhive-embed stays identical modulo name so both keep tracking the same spec.