### PR TITLE
fix(openclaw): route main heartbeat delivery to Discord DM

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -133,6 +133,13 @@ data:
                 "litellm/dsv4f",
               ]
             },
+            heartbeat: {
+              // Explicit delivery route — the owner-DM resolution path fails
+              // closed for unproven targets under dmPolicy "pairing", leaving
+              // heartbeats skipped with "no-route" since the 2026.9 conversion.
+              target: "discord",
+              to: "$${DISCORD_ADMIN_USER_ID}",
+            },
           },
           matcha: {
             name: "Matcha",


### PR DESCRIPTION
Heartbeats for `main` skip with `no-route` since the 2026.9 conversion — owner-DM resolution fails closed under `dmPolicy: "pairing"`, so Miso's heartbeat contract never runs.

Fix: explicit delivery route on `main` only — `heartbeat.target: "discord"`, `to: "$${DISCORD_ADMIN_USER_ID}"` (env var already provided by the `openclaw` ExternalSecret; nothing new in public git).

Validated: JSONC parses, flate clean (only the 16 known ocharted failures). Post-merge: `openclaw status` heartbeat row should resolve and the next hourly run shouldn't be `skipped`.