### PR TITLE
fix(llm): 3090 pool members get 64Gi so their 40 GiB prompt caches fit

### DIFF
--- a/kubernetes/apps/base/llm/litellm/muse-glimmer.yaml
+++ b/kubernetes/apps/base/llm/litellm/muse-glimmer.yaml
@@ -55,7 +55,7 @@ spec:
   resources:
     gpu: 1
     cpu: "500m"
-    memory: 48Gi
+    memory: 64Gi
   speculativeDecoding:
     type: draft-dflash
     draftModel: dflash-Muse-Glimmer-30B-Q4_K_M.gguf

--- a/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
+++ b/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
@@ -56,7 +56,7 @@ spec:
   resources:
     gpu: 1
     cpu: "500m"
-    memory: 48Gi
+    memory: 64Gi
   speculativeDecoding:
     type: draft-mtp
     nDraftMax: 2


### PR DESCRIPTION
Raises qwen3.8-27b and muse-glimmer to 64Gi (request and limit under llmkube 0.9.25). Both run --cache-ram 40960, so the working set climbs from about 4 GiB at load to the limit as the prompt cache fills; the 27B was OOMKilled at 48Gi twice tonight (peaks 44.3 and 48.0 GiB, roughly every three hours under Foreman's 50k-token contexts) and muse would hit the same wall once it stays resident long enough. The 48Gi ceiling was set when ganyu was at 97% requested; the embedders have since moved off that node, so requests there are 89 of 123 GiB, and since the pool keeps only one member resident the 64Gi is only ever held once. Keeps the full cache rather than shrinking it.