### PR TITLE
feat(alert-triage): chat model, Prometheus and VictoriaLogs evidence, Grafana links

### DIFF
--- a/kubernetes/apps/base/llm/litellm/virtualkeys/alert-triage.yaml
+++ b/kubernetes/apps/base/llm/litellm/virtualkeys/alert-triage.yaml
@@ -10,6 +10,7 @@ spec:
   secretKey: api-key
   models:
   - qwen3.8-flash-next
+  - qwen3.8-flash-next-chat
   - qwen3.8-27b
   - dsv4f
   - reasoning-pool

--- a/kubernetes/apps/base/observability/alert-triage/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/alert-triage/helmrelease.yaml
@@ -37,8 +37,13 @@ spec:
             env:
               CLUSTER: ${CLUSTER}
               LITELLM_URL: ${LITELLM_URL:=http://litellm.llm:4000/v1}
-              MODEL: qwen3.8-flash-next
+              MODEL: qwen3.8-flash-next-chat
               HISTORY_PATH: /data/history.jsonl
+              METRICS_URL: http://kube-prometheus-stack-prometheus.observability.svc.cluster.local:9090
+              LOGS_URL: ${LOGS_URL:=}
+              LOGS_FLAVOR: ${LOGS_FLAVOR:=}
+              GRAFANA_URL: ${GRAFANA_URL:=}
+              GRAFANA_METRICS_DS: ${GRAFANA_METRICS_DS:=}
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}"

--- a/kubernetes/apps/main/observability/alert-triage.yaml
+++ b/kubernetes/apps/main/observability/alert-triage.yaml
@@ -7,6 +7,12 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/base/observability/alert-triage
+  postBuild:
+    substitute:
+      LOGS_URL: http://victoria-logs-server.observability.svc.cluster.local:9428
+      LOGS_FLAVOR: victorialogs
+      GRAFANA_URL: https://grafana.jory.dev
+      GRAFANA_METRICS_DS: df062450-90bc-4bee-a5e7-08371b2919b8
   wait: false
   prune: true
   sourceRef:


### PR DESCRIPTION
Turns on the enrichment alert-triage 0.2.0 already ships but home-ops never configured, and moves narration off the thinking model. MODEL becomes qwen3.8-flash-next-chat (added to the Alert Triage key): the task is a JSON classification plus a few sentences, thinking added nothing visible and its 70s median / 285s p95 blew the 120s NARRATE_TIMEOUT so 13 of the last 53 digests shipped with no narrative. METRICS_URL points at the in-cluster Prometheus on both clusters so each group's own rule expression and the pods' restart, memory and throttle series enter the evidence block; on main, LOGS_URL/LOGS_FLAVOR add VictoriaLogs pod logs and GRAFANA_URL plus the prometheus-main datasource UID put an Explore link on the embed. The logs datasource link is left unset because the service hardcodes a Loki datasource type in that URL and a VictoriaLogs UID would render a broken link. Utility inherits the Prometheus enrichment only; its substitutions default to empty, which the service treats as disabled.