### PR TITLE
fix(external-dns): back to 1.22.0 with the alpha annotation prefix pinned

### DIFF
--- a/kubernetes/apps/base/network/cloudflare-dns/helmrelease.yaml
+++ b/kubernetes/apps/base/network/cloudflare-dns/helmrelease.yaml
@@ -35,6 +35,7 @@ spec:
     podAnnotations:
       secret.reloader.stakater.com/reload: *secret
     policy: sync
+    annotationPrefix: external-dns.alpha.kubernetes.io/
     provider:
       name: cloudflare
     serviceMonitor:

--- a/kubernetes/apps/base/network/cloudflare-dns/ocirepository.yaml
+++ b/kubernetes/apps/base/network/cloudflare-dns/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.21.1
+    tag: 1.22.0
   url: oci://ocharted.jory.dev/kubernetes-sigs.github.io/external-dns/external-dns

--- a/kubernetes/apps/base/network/unifi-dns/helmrelease.yaml
+++ b/kubernetes/apps/base/network/unifi-dns/helmrelease.yaml
@@ -17,6 +17,7 @@ spec:
     podAnnotations:
       secret.reloader.stakater.com/reload: *app
     policy: sync
+    annotationPrefix: external-dns.alpha.kubernetes.io/
     provider:
       name: webhook
       webhook:

--- a/kubernetes/apps/base/network/unifi-dns/ocirepository.yaml
+++ b/kubernetes/apps/base/network/unifi-dns/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.21.1
+    tag: 1.22.0
   url: oci://ocharted.jory.dev/kubernetes-sigs.github.io/external-dns/external-dns


### PR DESCRIPTION
Re-applies the external-dns chart 1.21.1 to 1.22.0 bump that #10002 reverted, and pins annotationPrefix to external-dns.alpha.kubernetes.io/ on both unifi-dns and cloudflare-dns. v0.22.0 changed the default annotation prefix to external-dns.kubernetes.io/ with no fallback, so at 12:27Z today the service source saw no annotated Services and policy sync deleted every Service-sourced record on main, utility and test (k8s.*, the envoy gateway hostnames, mc/palworld/forgejo-ssh/exporters); HTTPRoute records take hostnames from spec and survived. With the prefix pinned, 0.22.0 reads the annotations the repo already carries, so this is safe in any Flux apply order and no other resource changes. Moving to the GA prefix is a later, unhurried three-step (add duplicate GA annotations, drop the pin, remove alpha) that must stay split across PRs because the annotated resources and the controllers reconcile under different Kustomizations.