### PR TITLE
fix(llm): pool members must not gate scale-from-zero on an idle check

### DIFF
--- a/kubernetes/apps/base/llm/litellm/muse-glimmer.yaml
+++ b/kubernetes/apps/base/llm/litellm/muse-glimmer.yaml
@@ -33,8 +33,7 @@ spec:
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:82de60bb2ba6e66d750f4b7db8752bc3071a2ed3999700d0b21c8b5c709b5513
   rolloutPolicy:
-    waitForIdle: true
-    idleTimeoutSeconds: 86400
+    waitForIdle: false
   priorityClassName: gpu-preemptible
   runtimeClassName: nvidia
   nodeSelector:

--- a/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
+++ b/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
@@ -32,8 +32,7 @@ spec:
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:82de60bb2ba6e66d750f4b7db8752bc3071a2ed3999700d0b21c8b5c709b5513
   rolloutPolicy:
-    waitForIdle: true
-    idleTimeoutSeconds: 86400
+    waitForIdle: false
   priorityClassName: gpu-preemptible
   runtimeClassName: nvidia
   nodeSelector:


### PR DESCRIPTION
Sets rolloutPolicy.waitForIdle: false on qwen3.8-27b and muse-glimmer. The ModelPool controller already drains the incumbent through /slots before scaling the next member up, so the per-InferenceService rollout drain is redundant for pooled members and it deadlocks at scale-from-zero: the controller probes the member being started, finds no endpoints because replicas was 0, fails closed as PodsBusy and defers the rollout for idleTimeoutSeconds (24h). After ganyu rebooted this morning that left qwen3.8-27b Stopped, muse-glimmer stuck at Creating with RolloutDeferred=True, and nothing resident on the 3090 while the router held requests. Unpooled services keep their drain policy.