### PR TITLE
feat(external-dns): move to the v1.22.0 GA annotation prefix

### DIFF
--- a/kubernetes/apps/base/games/core-keeper/helmrelease.yaml
+++ b/kubernetes/apps/base/games/core-keeper/helmrelease.yaml
@@ -65,9 +65,9 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: 10.69.10.37
-          external-dns.alpha.kubernetes.io/hostname: core-keeper.jory.dev
-          external-dns.alpha.kubernetes.io/target: towonel.jory.dev
-          external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+          external-dns.kubernetes.io/hostname: core-keeper.jory.dev
+          external-dns.kubernetes.io/target: towonel.jory.dev
+          external-dns.kubernetes.io/cloudflare-proxied: "false"
           towonel.io/game.public-port: "27015"
           towonel.io/game.udp: "true"
           towonel.io/tunnel: enable

--- a/kubernetes/apps/base/games/enshrouded/helmrelease.yaml
+++ b/kubernetes/apps/base/games/enshrouded/helmrelease.yaml
@@ -65,9 +65,9 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: 10.69.10.34
-          external-dns.alpha.kubernetes.io/hostname: enshrouded.jory.dev
-          external-dns.alpha.kubernetes.io/target: towonel.jory.dev
-          external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+          external-dns.kubernetes.io/hostname: enshrouded.jory.dev
+          external-dns.kubernetes.io/target: towonel.jory.dev
+          external-dns.kubernetes.io/cloudflare-proxied: "false"
           towonel.io/gameport.public-port: "27015"
           towonel.io/gameport.udp: "true"
           towonel.io/queryport.public-port: "15637"

--- a/kubernetes/apps/base/games/minecraft/mc-router/helmrelease.yaml
+++ b/kubernetes/apps/base/games/minecraft/mc-router/helmrelease.yaml
@@ -20,11 +20,11 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: 10.69.10.40
-          external-dns.alpha.kubernetes.io/hostname: mc.jory.dev,
+          external-dns.kubernetes.io/hostname: mc.jory.dev,
             takocraft.jory.dev, create.jory.dev, vibecraft.jory.dev,
             jellycraft.jory.dev, cobbleverse.jory.dev
-          external-dns.alpha.kubernetes.io/target: towonel.jory.dev
-          external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+          external-dns.kubernetes.io/target: towonel.jory.dev
+          external-dns.kubernetes.io/cloudflare-proxied: "false"
           towonel.io/minecraft.public-port: "25565"
           towonel.io/minecraft.tcp: "true"
           towonel.io/tunnel: enable

--- a/kubernetes/apps/base/games/palworld/helmrelease.yaml
+++ b/kubernetes/apps/base/games/palworld/helmrelease.yaml
@@ -104,9 +104,9 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: 10.69.10.39
-          external-dns.alpha.kubernetes.io/hostname: palworld.jory.dev
-          external-dns.alpha.kubernetes.io/target: towonel.jory.dev
-          external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+          external-dns.kubernetes.io/hostname: palworld.jory.dev
+          external-dns.kubernetes.io/target: towonel.jory.dev
+          external-dns.kubernetes.io/cloudflare-proxied: "false"
           towonel.io/game.public-port: "8211"
           towonel.io/game.udp: "true"
           towonel.io/tunnel: enable

--- a/kubernetes/apps/base/games/valheim/helmrelease.yaml
+++ b/kubernetes/apps/base/games/valheim/helmrelease.yaml
@@ -69,9 +69,9 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: 10.69.10.42
-          external-dns.alpha.kubernetes.io/hostname: valheim.jory.dev
-          external-dns.alpha.kubernetes.io/target: towonel.jory.dev
-          external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+          external-dns.kubernetes.io/hostname: valheim.jory.dev
+          external-dns.kubernetes.io/target: towonel.jory.dev
+          external-dns.kubernetes.io/cloudflare-proxied: "false"
           towonel.io/auth.public-port: "2457"
           towonel.io/auth.udp: "true"
           towonel.io/gameplay.public-port: "2456"

--- a/kubernetes/apps/base/games/vrising/helmrelease.yaml
+++ b/kubernetes/apps/base/games/vrising/helmrelease.yaml
@@ -67,9 +67,9 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: 10.69.10.33
-          external-dns.alpha.kubernetes.io/hostname: vrising.jory.dev
-          external-dns.alpha.kubernetes.io/target: towonel.jory.dev
-          external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+          external-dns.kubernetes.io/hostname: vrising.jory.dev
+          external-dns.kubernetes.io/target: towonel.jory.dev
+          external-dns.kubernetes.io/cloudflare-proxied: "false"
           towonel.io/game.public-port: "9876"
           towonel.io/game.udp: "true"
           towonel.io/query.public-port: "9877"

--- a/kubernetes/apps/base/home-automation/mosquitto/helmrelease.yaml
+++ b/kubernetes/apps/base/home-automation/mosquitto/helmrelease.yaml
@@ -68,7 +68,7 @@ spec:
       app:
         type: LoadBalancer
         annotations:
-          external-dns.alpha.kubernetes.io/hostname: mqtt.jory.dev
+          external-dns.kubernetes.io/hostname: mqtt.jory.dev
           gatus.home-operations.com/endpoint: |-
             group: services
           lbipam.cilium.io/ips: 10.69.10.134

--- a/kubernetes/apps/base/network/cloudflare-dns/helmrelease.yaml
+++ b/kubernetes/apps/base/network/cloudflare-dns/helmrelease.yaml
@@ -35,7 +35,6 @@ spec:
     podAnnotations:
       secret.reloader.stakater.com/reload: *secret
     policy: sync
-    annotationPrefix: external-dns.alpha.kubernetes.io/
     provider:
       name: cloudflare
     serviceMonitor:

--- a/kubernetes/apps/base/network/envoy-gateway/config/envoy.yaml
+++ b/kubernetes/apps/base/network/envoy-gateway/config/envoy.yaml
@@ -55,7 +55,7 @@ kind: Gateway
 metadata:
   name: envoy-external
   annotations:
-    external-dns.alpha.kubernetes.io/target: &hostname ${EXTERNAL_DOMAIN}.jory.dev
+    external-dns.kubernetes.io/target: &hostname ${EXTERNAL_DOMAIN}.jory.dev
     gatus.home-operations.com/endpoint: |
       client:
         dns-resolver: tcp://1.1.1.1:53
@@ -68,7 +68,7 @@ spec:
   gatewayClassName: envoy
   infrastructure:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: *hostname
+      external-dns.kubernetes.io/hostname: *hostname
       lbipam.cilium.io/ips: ${SVC_GATEWAY_EXTERNAL}
   listeners:
     - name: http
@@ -94,7 +94,7 @@ kind: Gateway
 metadata:
   name: envoy-internal
   annotations:
-    external-dns.alpha.kubernetes.io/target: &hostname ${INTERNAL_DOMAIN}.jory.dev
+    external-dns.kubernetes.io/target: &hostname ${INTERNAL_DOMAIN}.jory.dev
     gatus.home-operations.com/endpoint: |
       group: ${CLUSTER}-internal
       guarded: true
@@ -105,7 +105,7 @@ spec:
   gatewayClassName: envoy
   infrastructure:
     annotations:
-      external-dns.alpha.kubernetes.io/hostname: *hostname
+      external-dns.kubernetes.io/hostname: *hostname
       lbipam.cilium.io/ips: ${SVC_GATEWAY_INTERNAL}
   listeners:
     - name: http
@@ -173,7 +173,7 @@ kind: HTTPRoute
 metadata:
   name: https-redirect
   annotations:
-    external-dns.alpha.kubernetes.io/controller: none
+    external-dns.kubernetes.io/controller: none
 spec:
   parentRefs:
     - name: envoy-external

--- a/kubernetes/apps/base/network/towonel-operator/config/dnsendpoint.yaml
+++ b/kubernetes/apps/base/network/towonel-operator/config/dnsendpoint.yaml
@@ -12,13 +12,13 @@ spec:
       recordType: A
       targets: ["148.113.195.107"]
       providerSpecific:
-        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+        - name: external-dns.kubernetes.io/cloudflare-proxied
           value: "false"
     - dnsName: columbina-gatus.jory.dev
       recordType: A
       targets: ["148.113.195.107"]
       providerSpecific:
-        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+        - name: external-dns.kubernetes.io/cloudflare-proxied
           value: "false"
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/externaldns.k8s.io/dnsendpoint_v1alpha1.json
@@ -32,5 +32,5 @@ spec:
       recordType: CNAME
       targets: ["towonel.jory.dev"]
       providerSpecific:
-        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+        - name: external-dns.kubernetes.io/cloudflare-proxied
           value: "false"

--- a/kubernetes/apps/base/network/unifi-dns/helmrelease.yaml
+++ b/kubernetes/apps/base/network/unifi-dns/helmrelease.yaml
@@ -17,7 +17,6 @@ spec:
     podAnnotations:
       secret.reloader.stakater.com/reload: *app
     policy: sync
-    annotationPrefix: external-dns.alpha.kubernetes.io/
     provider:
       name: webhook
       webhook:

--- a/kubernetes/apps/base/observability/exporters/hoymiles-exporter/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/hoymiles-exporter/helmrelease.yaml
@@ -42,4 +42,4 @@ spec:
             protocol: TCP
             port: 9099
         annotations:
-          external-dns.alpha.kubernetes.io/hostname: exporters.jory.dev
+          external-dns.kubernetes.io/hostname: exporters.jory.dev

--- a/kubernetes/apps/base/observability/exporters/nut-exporter/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/exporters/nut-exporter/helmrelease.yaml
@@ -45,4 +45,4 @@ spec:
             protocol: TCP
             port: 9199
         annotations:
-          external-dns.alpha.kubernetes.io/hostname: exporters.jory.dev
+          external-dns.kubernetes.io/hostname: exporters.jory.dev

--- a/kubernetes/apps/base/observability/network-ups-tools/helmrelease.yaml
+++ b/kubernetes/apps/base/observability/network-ups-tools/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
       app:
         type: LoadBalancer
         annotations:
-          external-dns.alpha.kubernetes.io/hostname: ${HOSTNAME}.jory.dev
+          external-dns.kubernetes.io/hostname: ${HOSTNAME}.jory.dev
           lbipam.cilium.io/ips: ${NUT_SERVICE_IP}
         externalTrafficPolicy: Cluster
         ports:

--- a/kubernetes/apps/base/self-hosted/forgejo/helmrelease.yaml
+++ b/kubernetes/apps/base/self-hosted/forgejo/helmrelease.yaml
@@ -65,7 +65,7 @@ spec:
       ssh:
         type: LoadBalancer
         annotations:
-          external-dns.alpha.kubernetes.io/hostname: forgejo-ssh.jory.dev
+          external-dns.kubernetes.io/hostname: forgejo-ssh.jory.dev
           lbipam.cilium.io/ips: 10.69.10.46
         externalTrafficPolicy: Local
         port: 22

--- a/kubernetes/apps/base/workadventure/workadventure/dnsendpoint.yaml
+++ b/kubernetes/apps/base/workadventure/workadventure/dnsendpoint.yaml
@@ -10,5 +10,5 @@ spec:
       recordType: CNAME
       targets: ["towonel.jory.dev"]
       providerSpecific:
-        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+        - name: external-dns.kubernetes.io/cloudflare-proxied
           value: "false"

--- a/kubernetes/apps/main/kube-system/cilium/networking.yaml
+++ b/kubernetes/apps/main/kube-system/cilium/networking.yaml
@@ -62,7 +62,7 @@ kind: Service
 metadata:
   name: kube-api
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: k8s.main.jory.dev
+    external-dns.kubernetes.io/hostname: k8s.main.jory.dev
     io.cilium/lb-ipam-ips: 10.69.10.2
 spec:
   type: LoadBalancer

--- a/kubernetes/apps/test/kube-system/cilium/networking.yaml
+++ b/kubernetes/apps/test/kube-system/cilium/networking.yaml
@@ -27,7 +27,7 @@ kind: Service
 metadata:
   name: kube-api
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: k8s.test.jory.dev
+    external-dns.kubernetes.io/hostname: k8s.test.jory.dev
     io.cilium/lb-ipam-ips: 10.69.10.202
 spec:
   type: LoadBalancer

--- a/kubernetes/apps/utility/kube-system/cilium/networking.yaml
+++ b/kubernetes/apps/utility/kube-system/cilium/networking.yaml
@@ -62,7 +62,7 @@ kind: Service
 metadata:
   name: kube-api
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: k8s.utility.jory.dev
+    external-dns.kubernetes.io/hostname: k8s.utility.jory.dev
     io.cilium/lb-ipam-ips: 10.69.10.102
 spec:
   type: LoadBalancer


### PR DESCRIPTION
Completes the external-dns 1.22.0 migration by moving to its default annotation prefix instead of pinning the old one (#10003). Every external-dns.alpha.kubernetes.io/ key becomes external-dns.kubernetes.io/ (16 hostname, 8 target, 1 controller, and the 10 cloudflare-proxied providerSpecific names on DNSEndpoints, which the Cloudflare provider derives from the same prefix in 1.22.0), and annotationPrefix is removed from both unifi-dns and cloudflare-dns. Nothing alpha-prefixed remains in the repo. The annotated resources and the two controllers reconcile under different Kustomizations, so on merge there is a short window where whichever side applies first sees the other's old state; with policy sync that can drop and re-create the Service-sourced records within a reconcile or two. That window is accepted here in exchange for a single PR.