### PR TITLE
feat(ai-marketplace): add telegram secrets

### DIFF
--- a/kubernetes/apps/base/llm/ai-marketplace-monitor/externalsecret.yaml
+++ b/kubernetes/apps/base/llm/ai-marketplace-monitor/externalsecret.yaml
@@ -16,6 +16,10 @@ spec:
       data:
         FACEBOOK_PASSWORD: "{{ .password }}"
         FACEBOOK_USERNAME: "{{ .username }}"
+        TELEGRAM_CHAT_ID: "{{ .TELEGRAM_CHAT_ID }}"
+        TELEGRAM_TOKEN: "{{ .TELEGRAM_TOKEN }}"
   dataFrom:
     - extract:
         key: Facebook
+    - extract:
+        key: FB Market Scraper


### PR DESCRIPTION
Add Telegram credentials from the separate `FB Market Scraper` 1Password item to the monitor Secret.

The existing Facebook `dataFrom` mapping is preserved; this relies on the Telegram item having no generic `password` field, as intended. The UI-owned config can consume `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID` without storing the token in TOML.