### PR TITLE
fix(openclaw): remove retired lossless setting

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -473,7 +473,6 @@ data:
               summaryTimeoutMs: 1000000,
               sweepDeadlineMs: 300000,
               compactUntilUnderDeadlineMs: 600000,
-              transcriptGcEnabled: false,
               largeFileThresholdTokens: 6000,
               stubLargeToolPayloads: false,
             },


### PR DESCRIPTION
Lossless Claw 1.0 rejects `transcriptGcEnabled`; remove the retired setting so the manually managed PVC-local plugin can load after the next OpenClaw restart.