### PR TITLE
fix(ai-marketplace): bind web ui locally

### DIFF
--- a/kubernetes/apps/base/llm/ai-marketplace-monitor/helmrelease.yaml
+++ b/kubernetes/apps/base/llm/ai-marketplace-monitor/helmrelease.yaml
@@ -23,6 +23,7 @@ spec:
               repository: ghcr.io/bopeng/ai-marketplace-monitor
               tag: 0.10.2@sha256:0f5c180cca0317475a7fd3b199054abb64b98845b3a29c74fb1dcdf2a1257835
             env:
+              AIMM_WEBUI_HOST: 127.0.0.1
               TZ: America/Edmonton
               LITELLM_API_KEY:
                 valueFrom:
@@ -39,16 +40,28 @@ spec:
                 spec:
                   initialDelaySeconds: 60
                   periodSeconds: 30
-                  tcpSocket:
-                    port: 8467
+                  exec:
+                    command:
+                      - /usr/bin/curl
+                      - --fail
+                      - --silent
+                      - --output
+                      - /dev/null
+                      - http://127.0.0.1:8467/
               readiness:
                 enabled: true
                 custom: true
                 spec:
                   initialDelaySeconds: 30
                   periodSeconds: 15
-                  tcpSocket:
-                    port: 8467
+                  exec:
+                    command:
+                      - /usr/bin/curl
+                      - --fail
+                      - --silent
+                      - --output
+                      - /dev/null
+                      - http://127.0.0.1:8467/
             resources:
               requests:
                 cpu: 100m
@@ -64,6 +77,7 @@ spec:
               - path: /root/.ai-marketplace-monitor
     route:
       app:
+        enabled: false
         hostnames: ["scraper.jory.dev"]
         parentRefs:
           - name: envoy-internal


### PR DESCRIPTION
The monitor refuses to start its WebUI on 0.0.0.0 without credentials in the PVC config. Bind it to loopback instead, use loopback HTTP probes, and disable the external HTTPRoute; access is via port-forward when needed.

Validation: the ai-marketplace-monitor Kustomization and HelmRelease pass flate. The full main-cluster run is otherwise blocked by unrelated missing credentials for several ocharted OCI sources (418 passed, 16 failed, 1 blocked).