### PR TITLE
fix(openclaw): allow Sage DMs from owner only

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -369,7 +369,8 @@ data:
             },
             sage: {
               token: "$${SAGE_BOT_TOKEN}",
-              dmPolicy: "disabled",
+              dmPolicy: "allowlist",
+              allowFrom: ["$${DISCORD_ADMIN_USER_ID}"],
               guilds: {
                 "western-subaru-club": {
                   requireMention: true,


### PR DESCRIPTION
## What changed
- Change Sage's Discord DM policy from `disabled` to `allowlist`.
- Allow only `${DISCORD_ADMIN_USER_ID}` to DM Sage.
- Leave public guild-channel behavior unchanged; existing mention requirements and guild access rules remain intact.

## Verification
- `git diff --check`
- Confirmed the PR diff is limited to `kubernetes/apps/base/llm/openclaw/app/configmap.yaml`.
