### PR TITLE
feat(llm): swap qwen3.8-27b from llama.cpp to syv-ai tuned vLLM

### DIFF
--- a/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
+++ b/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
@@ -1,25 +1,31 @@
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vllm-model-cache
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 60Gi
+---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
 metadata:
   name: qwen3.8-27b
 spec:
-  source: hf://unsloth/Qwen3.8-27B-GGUF
+  source: "dbirks/Qwen3.8-27B-W4A16-AutoRound"
   sourceSecretRef:
     name: huggingface
-  files:
-    - Qwen3.8-27B-UD-Q4_K_XL.gguf
-    - mmproj-F16.gguf
-  mmproj: mmproj-F16.gguf
-  format: gguf
-  quantization: UD-Q4_K_XL
+  format: safetensors
+  quantization: compressed-tensors
   hardware:
     accelerator: cuda
     gpu:
       enabled: true
       vendor: nvidia
       count: 1
-      layers: 99
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
@@ -27,10 +33,13 @@ metadata:
   name: qwen3.8-27b
   labels:
     krr/ignore: "true"
+  annotations:
+    inference.llmkube.dev/idle-endpoint: /health
 spec:
   modelRef: qwen3.8-27b
-  runtime: llamacpp
-  image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:82de60bb2ba6e66d750f4b7db8752bc3071a2ed3999700d0b21c8b5c709b5513
+  runtime: generic
+  image: ghcr.io/syv-ai/qwen38-27b-rtx3090@sha256:8382b69916f413a8580f3117b6dc353bba6fb3ace94810c91c945ba7bdee8096
+  skipModelInit: true
   rolloutPolicy:
     waitForIdle: false #https://github.com/defilantech/LLMKube/pull/1794
     idleTimeoutSeconds: 86400
@@ -39,89 +48,55 @@ spec:
   nodeSelector:
     topology.kubernetes.io: egpu
   env:
+    - name: SPEC
+      value: dflash2
+    - name: PREFIX_CACHE
+      value: "1"
+    - name: CTX
+      value: long
     - name: NVIDIA_DRIVER_CAPABILITIES
       value: compute,utility
-  # contextSize: 140000
-  contextSize: 131072
-  flashAttention: true
-  jinja: true
-  # parallelSlots: 1
-  parallelSlots: 2
-  batchSize: 4096
-  uBatchSize: 1024
-  cacheTypeK: q8_0
-  cacheTypeV: q8_0
-  reasoningBudget: 32768
-  reasoningBudgetMessage: "Stop reasoning and produce the implementation, tool call, or final answer."
+    - name: HF_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: huggingface
+          key: HF_TOKEN
   resources:
     gpu: 1
-    cpu: "500m"
-    memory: 64Gi
-  speculativeDecoding:
-    type: draft-mtp
-    nDraftMax: 2
-    pMin: 0.75
-  extraArgs:
-    - --alias
-    - qwen3.8-27b
-    - --no-mmproj-offload
-    - --image-min-tokens
-    - "1024"
-    - --cont-batching
-    - --spec-draft-type-k
-    - q8_0
-    - --spec-draft-type-v
-    - q8_0
-    - -sps
-    - "0.75"
-    - --cache-prompt
-    - --cache-ram
-    - "40960"
-    - --kv-unified
-    - --temp
-    - "1"
-    - --top-p
-    - "0.95"
-    - --top-k
-    - "20"
-    - --min-p
-    - "0"
-    - --presence-penalty
-    - "0"
-    - --repeat-penalty
-    - "1"
-    - --threads
-    - "6"
-    - --threads-batch
-    - "12"
-    - --load-mode
-    - none
-    - --chat-template-kwargs
-    - '{"reasoning_effort":"medium"}'
-    - --reasoning-preserve
-    - --n-predict
-    - "40960"
+    cpu: "2"
+    memory: 24Gi
+  extraVolumes:
+    - name: models
+      persistentVolumeClaim:
+        claimName: vllm-model-cache
+    - name: shm
+      emptyDir:
+        medium: Memory
+        sizeLimit: 8Gi
+  extraVolumeMounts:
+    - name: models
+      mountPath: /app/models
+    - name: shm
+      mountPath: /dev/shm
   endpoint:
-    port: 8080
+    port: 18020
     type: ClusterIP
   probeOverrides:
     startup:
-      httpGet:
-        path: /health
-        port: 8080
+      tcpSocket:
+        port: 18020
       periodSeconds: 10
       failureThreshold: 360
     liveness:
-      httpGet:
-        path: /health
-        port: 8080
-      initialDelaySeconds: 30
+      tcpSocket:
+        port: 18020
+      initialDelaySeconds: 60
       periodSeconds: 30
       failureThreshold: 6
     readiness:
       httpGet:
         path: /health
-        port: 8080
-      initialDelaySeconds: 20
+        port: 18020
+      initialDelaySeconds: 30
       periodSeconds: 10
       failureThreshold: 6

--- a/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
+++ b/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
@@ -1,15 +1,4 @@
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: vllm-model-cache
-spec:
-  accessModes: ["ReadWriteOnce"]
-  storageClassName: ceph-block
-  resources:
-    requests:
-      storage: 60Gi
----
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
 metadata:
@@ -68,7 +57,7 @@ spec:
   extraVolumes:
     - name: models
       persistentVolumeClaim:
-        claimName: vllm-model-cache
+        claimName: llmkube-model-cache
     - name: shm
       emptyDir:
         medium: Memory
@@ -76,6 +65,7 @@ spec:
   extraVolumeMounts:
     - name: models
       mountPath: /app/models
+      subPath: vllm-27b
     - name: shm
       mountPath: /dev/shm
   endpoint:


### PR DESCRIPTION
Swaps the `qwen3.8-27b` InferenceService from llama.cpp (unsloth UD-Q4_K_XL GGUF) to the syv-ai `qwen38-27b-rtx3090` image, a vLLM 0.28.0 build tuned for a single RTX 3090 with DFlash2 speculative decoding. The isvc name stays `qwen3.8-27b`, so the ModelPool membership, the ModelRouter backend (resolves by `inferenceServiceRef`), and the litellm model all carry over unchanged. Only the port moves (8080 to vLLM's 18020), which the router derives automatically.

## Why

Benchmarked both runtimes on foreman-shaped prompts, isolated on the 3090, both with their speculative decoders on. Decode tok/s:

| workload | llama.cpp | syv-vLLM | speedup |
|---|---|---|---|
| edit a Go method, reproduce it | 112 | 1122 | 10x |
| answer quoting exact lines | 110 | 814 | 7.4x |
| edit a YAML, reproduce it | 105 | 554 | 5.3x |
| summarize a code file | 148 | 369 | 2.5x |
| chat / reasoning | 46 | 132 | 2.9x |
| write new code from spec | 210 | 136 | 0.6x |
| take a tool action | 193 | 141 | 0.7x |

Anything that reproduces context (apply a diff, quote a file, edit and re-emit) runs 5-10x faster; llama.cpp only wins on short novel codegen where its own dflash drafts structured code well. That reproduction/edit shape is the bulk of foreman's work.

## How

- `runtime: generic` with the prebuilt image pinned by digest. The image self-manages its model (downloads `dbirks/Qwen3.8-27B-W4A16-AutoRound` and requantizes) into the shared `llmkube-model-cache` (200Gi RWX CephFS, under a `vllm-27b` subPath) that every LLMKube model already uses, so no new PVC; the first rollout is a one-time ~20GB pull.
- `SPEC=dflash2` + `PREFIX_CACHE=1` + `CTX=long` (~138k, to cover the prior 131k). If VRAM is tight, drop `CTX` for the 64k default.
- TCP startup probe with a long `failureThreshold` for the first-boot download/requant.

## Review points / known tradeoffs

- **Idle drain is coarser than llama.cpp.** The generic runtime's idle probe is a plain 2xx check (`/health`), not vLLM-metric-aware, so the pool treats vLLM as always-idle. A muse/Sage request can therefore preempt a busy foreman-27B mid-generation, where llama.cpp's `/slots` probe waited for in-flight to finish. Foreman retries, but this is a real regression until LLMKube has a metric-gated idle probe for generic (or the reclaim/IfIdle work reduces swap frequency). This is the main thing to weigh.
- **Fork dependency.** The image is a community single-maintainer repo, pinned by digest and Renovate-trackable; a bump should be gated on a re-bench.
- **Vision unverified.** The litellm model still advertises `supportsVision: true`; the syv build is text/coding-focused, so image requests may fail. Flip to false if we confirm no vision.
- **First swap is slow.** vLLM cold-load plus any download is minutes, versus llama.cpp's ~30s.

