### PR TITLE
fix(llm): raise qwen3.8-27b vLLM memory to 64Gi for first-boot requant

### DIFF
--- a/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
+++ b/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
@@ -53,7 +53,7 @@ spec:
   resources:
     gpu: 1
     cpu: "2"
-    memory: 24Gi
+    memory: 64Gi
   extraVolumes:
     - name: models
       persistentVolumeClaim:


### PR DESCRIPTION
The syv image requantizes the model on first boot (int4 lm_head/MTP/drafter), loading it in host RAM and spiking past the 24Gi limit, so the pod is OOMKilled (exit 137) mid-requant and loops. Raise to 64Gi, matching the previous llama.cpp reservation; ganyu has the headroom. Applied in-cluster already to unblock the current rollout.