### PR TITLE
fix(llm): persist qwen3.8-27b vLLM compile/JIT cache

### DIFF
--- a/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
+++ b/kubernetes/apps/base/llm/litellm/qwen3.8-27b.yaml
@@ -66,6 +66,9 @@ spec:
     - name: models
       mountPath: /app/models
       subPath: vllm-27b
+    - name: models
+      mountPath: /cache
+      subPath: vllm-27b-cache
     - name: shm
       mountPath: /dev/shm
   endpoint:


### PR DESCRIPTION
Mount `/cache` (the syv image HOME: torch.compile, Triton, FlashInfer JIT, HF hub caches) from the shared `llmkube-model-cache` PVC under a `vllm-27b-cache` subPath, so pod restarts skip the torch.compile and FlashInfer fp8-KV JIT that dominated the first-boot time. No new PVC. On merge, one more rollout recompiles into the now-persistent cache; subsequent restarts are fast.