### PR TITLE
feat(llm): route chat/agentic to glimmer, keep 27B for code

### DIFF
--- a/kubernetes/apps/base/llm/litellm/models/local-pool-chat-1.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/local-pool-chat-1.yaml
@@ -7,22 +7,19 @@ spec:
   modelName: local-pool-chat
   proxyRef: litellm
   params:
-    model: openai/qwen3.8-27b
+    model: openai/muse-glimmer
     apiBase: http://nvidia-router-proxy.llm.svc.cluster.local:8080/v1
     apiKey: sk-llmkube-noauth
     additional:
-      temperature: 0.7
-      top_p: 0.8
-      presence_penalty: 1.5
-      reasoning_effort: none
+      temperature: 1.0
+      top_p: 0.95
+      top_k: 64
       order: 1
       max_parallel_requests: 2
-      allowed_openai_params:
-        - reasoning_effort
   info:
     mode: chat
     maxInputTokens: 131072
-    maxOutputTokens: 40960
+    maxOutputTokens: 20480
     supportsFunctionCalling: true
     supportsVision: true
     extra:

--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -131,7 +131,7 @@ data:
               fallbacks: [
                 "litellm/kimi-k3",
                 "minimax/MiniMax-M3",
-                "litellm/qwen3.8-27b",
+                "litellm/muse-glimmer",
                 "litellm/qwen3.8-flash-next",
                 "litellm/dsv4f",
               ]
@@ -153,7 +153,7 @@ data:
             model: {
               primary: "minimax/MiniMax-M3",
               fallbacks: [
-                "litellm/qwen3.8-27b",
+                "litellm/muse-glimmer",
                 "litellm/qwen3.8-flash-next",
               ]
             },
@@ -172,7 +172,7 @@ data:
               primary: "litellm/reasoning-pool",
               fallbacks: [
                 "litellm/dsv4f",
-                "litellm/qwen3.8-27b",
+                "litellm/muse-glimmer",
                 "litellm/qwen3.8-flash-next",
               ]
             },


### PR DESCRIPTION
Now that the 27B is vLLM (tuned for edit/reproduction, slow for interactive chat at 131k), point chat/agentic at glimmer and keep the 27B for the code lanes.

- **Chat agents:** Miso/Matcha/Saffron swap their local `qwen3.8-27b` fallback to `muse-glimmer`. Sage was already on glimmer. The code lanes (foreman coder, opencode `fixer`/`implementer`) stay on 27B, unchanged.
- **local-pool-chat:** rung-1 moves from `qwen3.8-27b` to `muse-glimmer`, so its consumers (sillytavern etc.) lead with glimmer; flash-next and gemma remain the lower rungs.

Caveat: `muse-glimmer` is thinking-only (the `-chat` twin was removed because reasoning cannot be disabled), so `local-pool-chat` now emits reasoning where it previously ran the 27B non-thinking. `local-pool` (thinking) and the tool/code consumers (dispatch, pr-review, repo-wiki) are untouched.