### PR TITLE
feat(observability): LLM routing dashboard (consumer -> model)

### DIFF
--- a/kubernetes/apps/base/llm/litellm/dashboard/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/dashboard/kustomization.yaml
@@ -12,6 +12,9 @@ configMapGenerator:
   - name: litellm-selfhosted
     files:
       - litellm-selfhosted.json
+  - name: litellm-routing
+    files:
+      - litellm-routing.json
   - name: llm-nvidia-node
     files:
       - llm-nvidia-node.json

--- a/kubernetes/apps/base/llm/litellm/dashboard/litellm-routing.json
+++ b/kubernetes/apps/base/llm/litellm/dashboard/litellm-routing.json
@@ -1,0 +1,59 @@
+{
+  "id": null,
+  "uid": "llm-routing",
+  "title": "LLM Routing (Consumer -> Model)",
+  "tags": ["llm", "litellm", "routing"],
+  "schemaVersion": 39,
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": { "from": "now-24h", "to": "now" },
+  "templating": {
+    "list": [
+      { "name": "datasource", "type": "datasource", "query": "prometheus", "current": {}, "hide": 0, "label": "Datasource" }
+    ]
+  },
+  "panels": [
+    {
+      "type": "table",
+      "title": "Consumer -> Model (requests over range)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 12, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (api_key_alias, requested_model) (increase(litellm_requests_metric_total[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true }, "renameByName": { "api_key_alias": "Consumer", "requested_model": "Model", "Value": "Requests" } } },
+        { "id": "sortBy", "options": { "fields": "", "sort": [ { "field": "Requests", "desc": true } ] } }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "align": "auto", "filterable": true }, "decimals": 0 }, "overrides": [] },
+      "options": { "showHeader": true, "footer": { "show": false } }
+    },
+    {
+      "type": "table",
+      "title": "Live (req/min, last 5m)",
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "gridPos": { "h": 12, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (api_key_alias, requested_model) (rate(litellm_requests_metric_total[5m])) * 60 > 0",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true }, "renameByName": { "api_key_alias": "Consumer", "requested_model": "Model", "Value": "req/min" } } },
+        { "id": "sortBy", "options": { "fields": "", "sort": [ { "field": "req/min", "desc": true } ] } }
+      ],
+      "fieldConfig": { "defaults": { "custom": { "align": "auto", "filterable": true }, "decimals": 1 }, "overrides": [] },
+      "options": { "showHeader": true, "footer": { "show": false } }
+    }
+  ]
+}

--- a/kubernetes/apps/base/llm/litellm/grafanadashboard.yaml
+++ b/kubernetes/apps/base/llm/litellm/grafanadashboard.yaml
@@ -100,3 +100,21 @@ spec:
   configMapRef:
     name: litellm-selfhosted
     key: litellm-selfhosted.json
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: litellm-routing
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  configMapRef:
+    name: litellm-routing
+    key: litellm-routing.json
+


### PR DESCRIPTION
A Grafana dashboard that answers "what consumes what model" at a glance, the litellm UI is poor for it. Two tables from `litellm_requests_metric_total` (labeled by `api_key_alias` × `requested_model`): a consumer→model request count over the range, and a live `req/min` (last 5m) table for "who is hitting glimmer right now". Wired as a `GrafanaDashboard` CR + configmap like the other litellm dashboards.