### PR TITLE
refactor(opencode): realign coordinator roster and trim MCP

### DIFF
--- a/kubernetes/apps/base/llm/opencode/configmap.yaml
+++ b/kubernetes/apps/base/llm/opencode/configmap.yaml
@@ -38,34 +38,34 @@ data:
       "enabled_providers": ["litellm-anthropic", "litellm", "opencode"],
       "agent": {
         "coordinator": {
-          "description": "Reasoning coordinator — plans, then delegates to role subagents (explorer/fixer/implementer/agentic-local/oracle/reviewer)",
+          "description": "Reasoning coordinator — plans, then delegates to role subagents (explorer/coder-local/implementer/agentic-local/oracle/reviewer/local-reviewer)",
           "mode": "primary",
           "model": "litellm/reasoning-pool",
-          "prompt": "You are a coordinator. Do the high-level reasoning and synthesis yourself; delegate the legwork to role subagents via the task tool.\n\nCONTRACTS: hand each sub a self-contained brief — objective, the decisions already settled (inline the exact values), the files it owns, what's out of scope, and the observable check that proves success. A sub should never have to infer scope or re-derive a decision you already made. Ask for a compact handoff back — findings, file paths, the change that matters — not a full transcript.\n\nROLES:\n- `explorer` (MiniMax M3 — 1M ctx, flat-rate plan): default recon, read-only scouting, 'where/how is X'. It is the one lane with real concurrency (3-4 at once), so fan out here.\n- `fixer` (qwen3.8-27b — local, free, 131k, text-only): small scoped edits and mechanical changes. several vLLM slots on the 3090, so fan out concurrent scoped edits (contended by an automated pipeline, but no longer serialising).\n- `agentic-local` (qwen3.8-flash-next, Qwen3.8-Flash-Next 180B-A6B UD-IQ4_XS — local, free, 262k, vision): the long-context and agentic lane. Reach for it when the job will not fit `fixer`'s 131k window, or for long-horizon multi-step work. Slower and weaker at pure code (~300 t/s prefill at depth, ~26 t/s decode). ONE slot, so run it singly.\n- `oracle` (glm-5.3-flash): hard debugging, root-cause, architecture. Rate-capped but roomy (~3x the GLM-5.3 quota, shared with other consumers) — still not the default lane.\n- `implementer` (implementation-pool — Luna at effort high -> MiniMax-M2.7 -> qwen3.8-27b, 131k): carrying out a plan already settled — multi-file edits, mechanical refactors, long implementation runs. Cloud-led, so unlike `fixer` and `agentic-local` it runs CONCURRENTLY: fan out here for implementation the way you fan out `explorer` for recon. Text only; route images to `agentic-local` (Flash-Next, vision).\n- `reviewer` (gemma-4-12b-it-qat — Gemma-4-12B on the 9070XT, part-time/non-Qwen, 4 slots; MiniMax-M3 fallback when the box is off): independent second opinion and prose.\n\nCOUNCIL (high-stakes review): collect independent verdicts from different model families — MiniMax (`explorer`), Qwen on Strix (`agentic-local`), Qwen on the 3090 (`fixer`), GLM (`oracle`), Gemma (`reviewer`) — then reconcile. Never let one model grade its own work.\n\nQUALITY PASS (before you report done): after a substantive change, dispatch a fresh `reviewer` subagent for a critical full pass over the diff — remaining bugs, edge cases, error handling, and small QoL wins. Hand it the changed files and the goal, not your reasoning; a near-zero-context reviewer is more critical and catches what you talked yourself past. Act on what it flags, then re-verify. Skip only for trivial or read-only work."
+          "prompt": "You are a coordinator. Do the high-level reasoning and synthesis yourself; delegate the legwork to role subagents via the task tool.\n\nCONTRACTS: hand each sub a self-contained brief — objective, the decisions already settled (inline the exact values), the files it owns, what's out of scope, and the observable check that proves success. A sub should never have to infer scope or re-derive a decision you already made. Ask for a compact handoff back — findings, file paths, the change that matters — not a full transcript.\n\nROLES:\n- `explorer` (MiniMax M2.7 — 262k ctx, flat-rate plan): default recon, read-only scouting, 'where/how is X'. It is the one lane with real concurrency (3-4 at once), so fan out here.\n- `coder-local` (qwen3.8-27b — local, free, 131k, text-only): small scoped edits and mechanical changes. several vLLM slots on the 3090, so fan out concurrent scoped edits (contended by an automated pipeline, but no longer serialising).\n- `agentic-local` (qwen3.8-flash-next, Qwen3.8-Flash-Next 180B-A6B UD-IQ4_XS — local, free, 262k, vision): the long-context and agentic lane. Reach for it when the job will not fit `coder-local`'s 131k window, or for long-horizon multi-step work. Slower and weaker at pure code (~300 t/s prefill at depth, ~26 t/s decode). ONE slot, so run it singly.\n- `oracle` (glm-5.3-flash): hard debugging, root-cause, architecture. Rate-capped but roomy (~3x the GLM-5.3 quota, shared with other consumers) — still not the default lane.\n- `implementer` (implementation-pool — Luna at effort high -> MiniMax-M2.7 -> qwen3.8-27b, 131k): carrying out a plan already settled — multi-file edits, mechanical refactors, long implementation runs. Cloud-led, so unlike `coder-local` and `agentic-local` it runs CONCURRENTLY: fan out here for implementation the way you fan out `explorer` for recon. Text only; route images to `agentic-local` (Flash-Next, vision).\n- `reviewer` (MiniMax-M3 — 1M ctx, flat-rate, cloud, concurrent): independent second opinion and prose. A different family from the Qwen coders and stronger than the local Gemma; this is the default review lane.\n- `local-reviewer` (gemma-4-12b-it-qat — Gemma-4-12B on the 9070XT, non-Qwen, 4 slots, woken on demand): optional free local second opinion from a third family. Only a 12B, so weaker than `reviewer` — reach for it for a cheap different-family gut-check or to offload prose, not as the primary review.\n\nCOUNCIL (high-stakes review): collect independent verdicts from different model families — MiniMax (`explorer`/`reviewer`), Qwen on Strix (`agentic-local`), Qwen on the 3090 (`coder-local`), GLM (`oracle`), Gemma (`local-reviewer`) — then reconcile. Never let one model grade its own work.\n\nQUALITY PASS (before you report done): after a substantive change, dispatch a fresh `reviewer` subagent for a critical full pass over the diff — remaining bugs, edge cases, error handling, and small QoL wins. Hand it the changed files and the goal, not your reasoning; a near-zero-context reviewer is more critical and catches what you talked yourself past. Act on what it flags, then re-verify. Skip only for trivial or read-only work."
         },
-        "local": {
-          "description": "Local-only coordinator - Flash-Next (qwen3.8-flash-next, 262k) plans, delegates edits to the 27B fixer (qwen3.8-27b) and recon to local-explorer (Gemma on the 9070XT). No rate caps; cloud only if the 9070XT cannot be woken.",
+        "coordinator-local": {
+          "description": "Local-only coordinator - Flash-Next (qwen3.8-flash-next, 262k) plans, delegates edits to coder-local (qwen3.8-27b) and recon/review to explorer-local (Gemma on the 9070XT). No rate caps; cloud only if the 9070XT cannot be woken.",
           "mode": "primary",
           "model": "litellm/qwen3.8-flash-next",
-          "prompt": "You are a LOCAL-ONLY coordinator on Flash-Next (Qwen3.8-Flash-Next, 262k). Do the planning and synthesis yourself and delegate the legwork.\n\nLANES:\n- `fixer` (qwen3.8-27b, Qwen3.8-27B on vLLM, 3090, 131k, low-latency, text-only): scoped implementation and edits; several slots so fan out freely. Images are not supported here — the coordinator (Flash-Next) has vision, or delegate to `local-explorer` (Gemma).\n- `local-explorer` (gemma-4-12b-it-qat, Gemma-4-12B on the 9070XT, 4 slots, non-Qwen): read-only recon and independent second opinions. It is the only lane here that runs concurrently, so fan out for scouting. The box is woken on demand, so the first call after an idle period takes about a minute; if it cannot be woken the request is served by MiniMax in the cloud, which is acceptable.\n\nUse `local-explorer` rather than grading your own work: it is the one non-Qwen family available locally. Do NOT use `explorer`, `oracle` or `implementer` - cloud lanes. Do NOT use `agentic-local` - it is this same single-slot server, so delegating there only queues behind you.\n\nQUALITY PASS (before you report done): after a substantive change, dispatch a fresh `local-explorer` subagent for a critical full pass over the diff — remaining bugs, edge cases, error handling, and small QoL wins. Hand it the changed files and the goal, not your reasoning; a near-zero-context reviewer is more critical and catches what you talked yourself past. Act on what it flags, then re-verify. Skip only for trivial or read-only work."
+          "prompt": "You are a LOCAL-ONLY coordinator on Flash-Next (Qwen3.8-Flash-Next, 262k). Do the planning and synthesis yourself and delegate the legwork.\n\nLANES:\n- `coder-local` (qwen3.8-27b, Qwen3.8-27B on vLLM, 3090, 131k, low-latency, text-only): scoped implementation and edits; several slots so fan out freely. Images are not supported here — you (Flash-Next) have vision, or delegate to `explorer-local` (Gemma).\n- `explorer-local` (gemma-4-12b-it-qat, Gemma-4-12B on the 9070XT, 4 slots, non-Qwen): read-only recon and independent second opinions. It is the only lane here that runs concurrently, so fan out for scouting. The box is woken on demand, so the first call after an idle period takes about a minute; if it cannot be woken the request is served by MiniMax in the cloud, which is acceptable.\n\nUse `explorer-local` rather than grading your own work: it is the one non-Qwen family available locally. Do NOT use `explorer`, `oracle` or `implementer` - cloud lanes. Do NOT use `agentic-local` - it is this same single-slot server, so delegating there only queues behind you.\n\nQUALITY PASS (before you report done): after a substantive change, dispatch a fresh `explorer-local` subagent for a critical full pass over the diff — remaining bugs, edge cases, error handling, and small QoL wins. Hand it the changed files and the goal, not your reasoning; an independent, near-zero-context, different-family reviewer catches what you talked yourself past, which matters more here than raw model size. Act on what it flags, then re-verify. Skip only for trivial or read-only work."
         },
         "explorer": {
-          "description": "Default recon — codebase scouting, search, 'where/how is X', read-only. MiniMax M3 (1M ctx, flat-rate). The one lane with real concurrency: fan out 3-4 at a time.",
+          "description": "Default recon — codebase scouting, search, 'where/how is X', read-only. MiniMax M2.7 (262k ctx, flat-rate). The one lane with real concurrency: fan out 3-4 at a time.",
           "mode": "subagent",
-          "model": "litellm-anthropic/MiniMax-M3"
+          "model": "litellm-anthropic/MiniMax-M2.7"
         },
-        "fixer": {
-          "description": "Primary coding lane — Qwen3.8-27B dense UD-Q4_K_XL on the 3090 (131k, vision-capable). The fastest and strongest coder available (vLLM, DFlash2 speculation), several slots so it can serve concurrent fan-out. Text-only — route anything involving images to `agentic-local` (Flash-Next has vision).",
+        "coder-local": {
+          "description": "Primary coding lane — Qwen3.8-27B dense UD-Q4_K_XL on the 3090 (131k, text-only). The fastest and strongest coder available (vLLM, DFlash2 speculation), several slots so it can serve concurrent fan-out. Text-only — route anything involving images to `agentic-local` (Flash-Next has vision).",
           "mode": "subagent",
           "model": "litellm/qwen3.8-27b"
         },
         "agentic-local": {
-          "description": "Long-context and agentic lane — Qwen3.8-Flash-Next UD-IQ4_XS, a 180B-A6B MoE on Strix (262k, vision). Use it when the work will not fit fixer's 131k window, or for long-horizon multi-step tasks where its agentic strength pays. Slower and weaker at pure code: ~300 t/s prefill at depth, ~26 t/s decode. ONE slot, so it serialises.",
+          "description": "Long-context and agentic lane — Qwen3.8-Flash-Next UD-IQ4_XS, a 180B-A6B MoE on Strix (262k, vision). Use it when the work will not fit coder-local's 131k window, or for long-horizon multi-step tasks where its agentic strength pays. Slower and weaker at pure code: ~300 t/s prefill at depth, ~26 t/s decode. ONE slot, so it serialises.",
           "mode": "subagent",
           "model": "litellm/qwen3.8-flash-next"
         },
         "implementer": {
-          "description": "Implementation lane — implementation-pool (Luna at effort high, then MiniMax-M2.7, then qwen3.8-27b, 131k). Carrying out a plan already settled: multi-file edits, mechanical refactors, long implementation runs. Cloud-led, so unlike fixer and agentic-local it runs CONCURRENTLY — fan out. Text only: route anything involving images to fixer.",
+          "description": "Implementation lane — implementation-pool (Luna at effort high, then MiniMax-M2.7, then qwen3.8-27b, 131k). Carrying out a plan already settled: multi-file edits, mechanical refactors, long implementation runs. Cloud-led, so unlike coder-local and agentic-local it runs CONCURRENTLY — fan out. Text only: route anything involving images to agentic-local.",
           "mode": "subagent",
           "model": "litellm/implementation-pool"
         },
@@ -74,35 +74,20 @@ data:
           "mode": "subagent",
           "model": "litellm/glm-5.3-flash"
         },
-        "local-explorer": {
+        "explorer-local": {
           "description": "Local recon and second opinion — Gemma-4-12B-it-QAT on the 9070XT (smurf-pc, woken on demand, non-Qwen, 4 slots, vision). The only locally concurrent lane: fan out for scouting. Falls back to MiniMax-M3 if the box cannot be woken.",
           "mode": "subagent",
           "model": "litellm/gemma-4-12b-it-qat"
         },
         "reviewer": {
-          "description": "Independent review — Gemma-4-12B-it-QAT on the 9070XT (smurf-pc, part-time, non-Qwen, ~55 tok/s, 4 slots, vision). Falls back to MiniMax-M3 when the box is off. Distinct family from the Qwen coders.",
+          "description": "Independent review — MiniMax-M3 (1M ctx, flat-rate, cloud, concurrent). A different family from the Qwen coders and stronger than the local Gemma; the default second-opinion and prose lane.",
+          "mode": "subagent",
+          "model": "litellm-anthropic/MiniMax-M3"
+        },
+        "local-reviewer": {
+          "description": "Optional local second opinion — Gemma-4-12B-it-QAT on the 9070XT (smurf-pc, woken on demand, non-Qwen, 4 slots, vision). Only a 12B, so weaker than the MiniMax-M3 `reviewer`; reach for it for a cheap different-family gut-check or to offload prose, not as the primary review.",
           "mode": "subagent",
           "model": "litellm/gemma-4-12b-it-qat"
-        },
-        "lean": {
-          "description": "Minimal MCP context — toolhive router only (reaches other MCPs via call_tool)",
-          "mode": "primary",
-          "tools": {
-            "github*": false,
-            "kubectl*": false,
-            "konflate*": false,
-            "dispatch*": false,
-            "context7*": false
-          }
-        },
-        "gitops": {
-          "description": "Cluster ops — kubectl/konflate direct on macOS; via toolhive router off-Mac",
-          "mode": "primary",
-          "tools": {
-            "github*": false,
-            "dispatch*": false,
-            "context7*": false
-          }
         }
       },
       "provider": {


### PR DESCRIPTION
Realign the in-cluster opencode coordinator roster to match the dotfiles/pi taxonomy: rename `fixer`->`coder-local`, `local`->`coordinator-local`, `local-explorer`->`explorer-local`; move `explorer` to MiniMax-M2.7 and `reviewer` to MiniMax-M3; add a `local-reviewer` (Gemma-4-12B) as an optional different-family second opinion; and drop the `lean`/`gitops` profiles now that only context7/toolhive/dispatch are wired (dispatch reached via the toolhive gateway). Also corrects the 27B to text-only in the role prose.