### PR TITLE
feat(llm): load-balance embed + rerank via litellm groups, 1 per non-skirk node

### DIFF
--- a/kubernetes/apps/base/llm/embed/embed-1.yaml
+++ b/kubernetes/apps/base/llm/embed/embed-1.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: embed-1
+  labels:
+    krr/ignore: "true"
+spec:
+  modelRef: embed
+  runtime: llamacpp
+  image: ghcr.io/ggml-org/llama.cpp:server@sha256:cbcdcb52d484e08e23bfc0135afa5beadd2d540513bbb7c65b233231fa033ff4
+  rolloutPolicy:
+    waitForIdle: true
+    idleTimeoutSeconds: 86400
+  replicas: 1
+  priority: normal
+  podLabels:
+    cpu-inference: "true"
+    embed-pool: "true"
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              embed-pool: "true"
+          topologyKey: kubernetes.io/hostname
+  contextSize: 32768
+  parallelSlots: 32
+  flashAttention: true
+  batchSize: 2048
+  uBatchSize: 2048
+  env:
+    - name: GOMP_CPU_AFFINITY
+      value: "0-11"
+    - name: KMP_AFFINITY
+      value: "granularity=fine,proc_list=[0-11],explicit"
+  resources:
+    cpu: "2"
+    memory: 8Gi
+  mode: embedding
+  extraArgs:
+    - --alias
+    - embed
+    - --cont-batching
+    - --cache-ram
+    - "0"
+    - --kv-unified
+    - --threads
+    - "6"
+    - --threads-batch
+    - "12"
+    - --load-mode
+    - mmap
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 360
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 6
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 6

--- a/kubernetes/apps/base/llm/embed/embed-2.yaml
+++ b/kubernetes/apps/base/llm/embed/embed-2.yaml
@@ -1,19 +1,8 @@
 ---
 apiVersion: inference.llmkube.dev/v1alpha1
-kind: Model
-metadata:
-  name: embed
-spec:
-  source: https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf
-  format: gguf
-  quantization: Q8_0
-  hardware:
-    accelerator: cpu
----
-apiVersion: inference.llmkube.dev/v1alpha1
 kind: InferenceService
 metadata:
-  name: embed
+  name: embed-2
   labels:
     krr/ignore: "true"
 spec:
@@ -23,17 +12,18 @@ spec:
   rolloutPolicy:
     waitForIdle: true
     idleTimeoutSeconds: 86400
-  replicas: 3
+  replicas: 1
   priority: normal
   podLabels:
     cpu-inference: "true"
-  topologySpreadConstraints:
-    - maxSkew: 1
-      topologyKey: kubernetes.io/hostname
-      whenUnsatisfiable: ScheduleAnyway
-      labelSelector:
-        matchLabels:
-          app: embed
+    embed-pool: "true"
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              embed-pool: "true"
+          topologyKey: kubernetes.io/hostname
   contextSize: 32768
   parallelSlots: 32
   flashAttention: true

--- a/kubernetes/apps/base/llm/embed/embed-3.yaml
+++ b/kubernetes/apps/base/llm/embed/embed-3.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: embed-3
+  labels:
+    krr/ignore: "true"
+spec:
+  modelRef: embed
+  runtime: llamacpp
+  image: ghcr.io/ggml-org/llama.cpp:server@sha256:cbcdcb52d484e08e23bfc0135afa5beadd2d540513bbb7c65b233231fa033ff4
+  rolloutPolicy:
+    waitForIdle: true
+    idleTimeoutSeconds: 86400
+  replicas: 1
+  priority: normal
+  podLabels:
+    cpu-inference: "true"
+    embed-pool: "true"
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              embed-pool: "true"
+          topologyKey: kubernetes.io/hostname
+  contextSize: 32768
+  parallelSlots: 32
+  flashAttention: true
+  batchSize: 2048
+  uBatchSize: 2048
+  env:
+    - name: GOMP_CPU_AFFINITY
+      value: "0-11"
+    - name: KMP_AFFINITY
+      value: "granularity=fine,proc_list=[0-11],explicit"
+  resources:
+    cpu: "2"
+    memory: 8Gi
+  mode: embedding
+  extraArgs:
+    - --alias
+    - embed
+    - --cont-batching
+    - --cache-ram
+    - "0"
+    - --kv-unified
+    - --threads
+    - "6"
+    - --threads-batch
+    - "12"
+    - --load-mode
+    - mmap
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 360
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 6
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 6

--- a/kubernetes/apps/base/llm/embed/kustomization.yaml
+++ b/kubernetes/apps/base/llm/embed/kustomization.yaml
@@ -3,4 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./embed.yaml
+  - ./model.yaml
+  - ./embed-1.yaml
+  - ./embed-2.yaml
+  - ./embed-3.yaml

--- a/kubernetes/apps/base/llm/embed/model.yaml
+++ b/kubernetes/apps/base/llm/embed/model.yaml
@@ -2,9 +2,9 @@
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
 metadata:
-  name: memini-rerank
+  name: embed
 spec:
-  source: https://huggingface.co/gpustack/bge-reranker-v2-m3-GGUF/resolve/main/bge-reranker-v2-m3-Q8_0.gguf
+  source: https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qwen3-Embedding-0.6B-Q8_0.gguf
   format: gguf
   quantization: Q8_0
   hardware:

--- a/kubernetes/apps/base/llm/litellm/models/embed-pool-1.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/embed-pool-1.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: embed-pool-1
+spec:
+  modelName: embed
+  proxyRef: litellm
+  params:
+    model: openai/embed
+    apiBase: http://embed-1.llm:8080/v1
+    apiKey: sk-llmkube-noauth
+  info:
+    maxInputTokens: 32768

--- a/kubernetes/apps/base/llm/litellm/models/embed-pool-2.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/embed-pool-2.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: embed-pool-2
+spec:
+  modelName: embed
+  proxyRef: litellm
+  params:
+    model: openai/embed
+    apiBase: http://embed-2.llm:8080/v1
+    apiKey: sk-llmkube-noauth
+  info:
+    maxInputTokens: 32768

--- a/kubernetes/apps/base/llm/litellm/models/embed-pool-3.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/embed-pool-3.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: embed-pool-3
+spec:
+  modelName: embed
+  proxyRef: litellm
+  params:
+    model: openai/embed
+    apiBase: http://embed-3.llm:8080/v1
+    apiKey: sk-llmkube-noauth
+  info:
+    maxInputTokens: 32768

--- a/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/kustomization.yaml
@@ -41,4 +41,9 @@ resources:
   - ./reasoning-pool-2.yaml
   - ./reasoning-pool-3.yaml
   - ./reasoning-pool-4.yaml
-  - ./rerank.yaml
+  - ./rerank-1.yaml
+  - ./rerank-2.yaml
+  - ./rerank-3.yaml
+  - ./embed-pool-1.yaml
+  - ./embed-pool-2.yaml
+  - ./embed-pool-3.yaml

--- a/kubernetes/apps/base/llm/litellm/models/rerank-1.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/rerank-1.yaml
@@ -2,13 +2,13 @@
 apiVersion: litellm.home-operations.com/v1alpha1
 kind: LiteLLMModel
 metadata:
-  name: rerank
+  name: rerank-1
 spec:
   modelName: rerank
   proxyRef: litellm
   params:
     model: infinity/memini-rerank
-    apiBase: http://memini-rerank.llm:8080
+    apiBase: http://memini-rerank-1.llm:8080
     apiKey: memini-rerank
   info:
     mode: rerank

--- a/kubernetes/apps/base/llm/litellm/models/rerank-2.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/rerank-2.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: rerank-2
+spec:
+  modelName: rerank
+  proxyRef: litellm
+  params:
+    model: infinity/memini-rerank
+    apiBase: http://memini-rerank-2.llm:8080
+    apiKey: memini-rerank
+  info:
+    mode: rerank
+    extra:
+      input_cost_per_token: 1.0e-08
+      output_cost_per_token: 0.0

--- a/kubernetes/apps/base/llm/litellm/models/rerank-3.yaml
+++ b/kubernetes/apps/base/llm/litellm/models/rerank-3.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: rerank-3
+spec:
+  modelName: rerank
+  proxyRef: litellm
+  params:
+    model: infinity/memini-rerank
+    apiBase: http://memini-rerank-3.llm:8080
+    apiKey: memini-rerank
+  info:
+    mode: rerank
+    extra:
+      input_cost_per_token: 1.0e-08
+      output_cost_per_token: 0.0

--- a/kubernetes/apps/base/llm/memini/kustomization.yaml
+++ b/kubernetes/apps/base/llm/memini/kustomization.yaml
@@ -7,5 +7,8 @@ resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./memini-rerank.yaml
+  - ./memini-rerank-1.yaml
+  - ./memini-rerank-2.yaml
+  - ./memini-rerank-3.yaml
   - ./ocirepository.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/base/llm/memini/memini-rerank-1.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-rerank-1.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: memini-rerank-1
+  labels:
+    krr/ignore: "true"
+spec:
+  modelRef: memini-rerank
+  runtime: llamacpp
+  image: ghcr.io/ggml-org/llama.cpp:server@sha256:cbcdcb52d484e08e23bfc0135afa5beadd2d540513bbb7c65b233231fa033ff4
+  rolloutPolicy:
+    waitForIdle: true
+    idleTimeoutSeconds: 86400
+  replicas: 1
+  priority: normal
+  podLabels:
+    cpu-inference: "true"
+    rerank-pool: "true"
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              rerank-pool: "true"
+          topologyKey: kubernetes.io/hostname
+  contextSize: 8096
+  parallelSlots: 4
+  batchSize: 8192
+  uBatchSize: 8192
+  env:
+    - name: GOMP_CPU_AFFINITY
+      value: "0-11"
+    - name: KMP_AFFINITY
+      value: "granularity=fine,proc_list=[0-11],explicit"
+  resources:
+    cpu: "2"
+    memory: 8Gi
+  mode: rerank
+  extraArgs:
+    - --alias
+    - memini-rerank
+    - --cont-batching
+    - --kv-unified
+    - --threads
+    - "6"
+    - --threads-batch
+    - "12"
+    - --load-mode
+    - mmap
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 360
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 6
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 6

--- a/kubernetes/apps/base/llm/memini/memini-rerank-2.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-rerank-2.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: memini-rerank-2
+  labels:
+    krr/ignore: "true"
+spec:
+  modelRef: memini-rerank
+  runtime: llamacpp
+  image: ghcr.io/ggml-org/llama.cpp:server@sha256:cbcdcb52d484e08e23bfc0135afa5beadd2d540513bbb7c65b233231fa033ff4
+  rolloutPolicy:
+    waitForIdle: true
+    idleTimeoutSeconds: 86400
+  replicas: 1
+  priority: normal
+  podLabels:
+    cpu-inference: "true"
+    rerank-pool: "true"
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              rerank-pool: "true"
+          topologyKey: kubernetes.io/hostname
+  contextSize: 8096
+  parallelSlots: 4
+  batchSize: 8192
+  uBatchSize: 8192
+  env:
+    - name: GOMP_CPU_AFFINITY
+      value: "0-11"
+    - name: KMP_AFFINITY
+      value: "granularity=fine,proc_list=[0-11],explicit"
+  resources:
+    cpu: "2"
+    memory: 8Gi
+  mode: rerank
+  extraArgs:
+    - --alias
+    - memini-rerank
+    - --cont-batching
+    - --kv-unified
+    - --threads
+    - "6"
+    - --threads-batch
+    - "12"
+    - --load-mode
+    - mmap
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 360
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 6
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 6

--- a/kubernetes/apps/base/llm/memini/memini-rerank-3.yaml
+++ b/kubernetes/apps/base/llm/memini/memini-rerank-3.yaml
@@ -1,0 +1,74 @@
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+  name: memini-rerank-3
+  labels:
+    krr/ignore: "true"
+spec:
+  modelRef: memini-rerank
+  runtime: llamacpp
+  image: ghcr.io/ggml-org/llama.cpp:server@sha256:cbcdcb52d484e08e23bfc0135afa5beadd2d540513bbb7c65b233231fa033ff4
+  rolloutPolicy:
+    waitForIdle: true
+    idleTimeoutSeconds: 86400
+  replicas: 1
+  priority: normal
+  podLabels:
+    cpu-inference: "true"
+    rerank-pool: "true"
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              rerank-pool: "true"
+          topologyKey: kubernetes.io/hostname
+  contextSize: 8096
+  parallelSlots: 4
+  batchSize: 8192
+  uBatchSize: 8192
+  env:
+    - name: GOMP_CPU_AFFINITY
+      value: "0-11"
+    - name: KMP_AFFINITY
+      value: "granularity=fine,proc_list=[0-11],explicit"
+  resources:
+    cpu: "2"
+    memory: 8Gi
+  mode: rerank
+  extraArgs:
+    - --alias
+    - memini-rerank
+    - --cont-batching
+    - --kv-unified
+    - --threads
+    - "6"
+    - --threads-batch
+    - "12"
+    - --load-mode
+    - mmap
+  endpoint:
+    port: 8080
+    type: ClusterIP
+  probeOverrides:
+    startup:
+      httpGet:
+        path: /health
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 360
+    liveness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      failureThreshold: 6
+    readiness:
+      httpGet:
+        path: /health
+        port: 8080
+      initialDelaySeconds: 20
+      periodSeconds: 10
+      failureThreshold: 6


### PR DESCRIPTION
Splits the `embed` and `memini-rerank` 3-replica Deployments into **3 single-replica InferenceServices each** (`embed-1/2/3`, `memini-rerank-1/2/3`), registered as litellm **groups** (`modelName: embed` / `rerank`, global `simple-shuffle`). This is the only native way to actually balance a cache-less backend: litellm fans requests across distinct endpoints, whereas a single ClusterIP + HTTP keep-alive pinned one client (e.g. a memini re-embed) to one pod. Each service carries a pool label + `requiredDuringScheduling` podAntiAffinity on hostname, so they land **1-per-node across ayaka/eula/ganyu** (skirk is excluded automatically by its `llm-workload` NoSchedule taint). Consumer model names (`embed`, `rerank`) are unchanged, so memini/vmcp configs are untouched and **no re-embed** is triggered. Follows the existing pool-per-file convention. Note: LLMKube still auto-projects an unused per-service model (`embed-1/2/3`, `memini-rerank-1/2/3`) alongside each group — same harmless coexistence as `memini-rerank`/`rerank` today. Hold merge until memini finishes its current re-embed.