### PR TITLE
config(openclaw): default subagents to Muse Glimmer

### DIFF
--- a/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/base/llm/openclaw/app/configmap.yaml
@@ -99,7 +99,7 @@ data:
           maxConcurrent: 4,
           subagents: {
             model: {
-              primary: "minimax/MiniMax-M3",
+              primary: "litellm/muse-glimmer",
             },
             archiveAfterMinutes: 120,
             maxConcurrent: 3,


### PR DESCRIPTION
## What changed
- Set the global OpenClaw subagent primary model to `litellm/muse-glimmer`.

## Rationale
- Muse Glimmer produced the best general-purpose result in the same read-only subagent audit used to compare it with Qwen 27B and Flash-Next.
- Keep Qwen 27B as an explicit coding override; no agent-specific primary models or fallback order changed.

## Verification
- `git diff --check`
- Confirmed the diff changes only the global `subagents.model.primary` setting.
