### PR TITLE
feat(llm): flash-next q8_0 KV + 16k ubatch

### DIFF
--- a/kubernetes/apps/base/llm/litellm/qwen3.8-flash-next.yaml
+++ b/kubernetes/apps/base/llm/litellm/qwen3.8-flash-next.yaml
@@ -44,7 +44,7 @@ spec:
   modelCache:
     claimName: llmkube-skirk-cache
   runtime: llamacpp
-  image: ghcr.io/joryirving/llama-qwen4exp:f5daaa3c-rocm@sha256:2d87d92ede4160c65e152c07b6ee8fd24f2d04c4d8bde6e0db4657541b346ee3
+  image: ghcr.io/joryirving/llama-qwen4exp:f5daaa3c-rocm-faq@sha256:d0595332fa58dbf9060f3496ecbbe9abd93cef5f4cb216ad04df31a52cb753e9
   rolloutPolicy:
     waitForIdle: true
     idleTimeoutSeconds: 86400
@@ -66,10 +66,10 @@ spec:
     type: draft-mtp
     draftModel: mtp-Qwen3.8-Flash-Next-shared-Q8_0.gguf
     nDraftMax: 2
-  cacheTypeK: f16
-  cacheTypeV: f16
-  batchSize: 8192
-  uBatchSize: 8192
+  cacheTypeK: q8_0
+  cacheTypeV: q8_0
+  batchSize: 16384
+  uBatchSize: 16384
   env:
     - name: HSA_OVERRIDE_GFX_VERSION
       value: "11.5.1"


### PR DESCRIPTION
Swaps flash-next to the FA_ALL_QUANTS=ON ROCm image so flash attention has a q8_0 KV kernel, drops KV f16->q8_0 (halves KV; 131k ~6.3GB vs ~12.6GB), and raises ubatch 8192->16384 to kill the prefill cliff (small ubatch halved prefill between chunks; the reference build holds it at 16384). The q8_0 saving pays for the larger prefill buffer. Projected at-rest with comfyui up is ~120-123GB of 124 — tight, so it may OOM under a comfyui burst; will verify on roll and iterate ubatch/context down if it doesn't hold.